### PR TITLE
[WIP] Put the output of the model into existing NDArrays when provided

### DIFF
--- a/api/src/main/java/ai/djl/modality/nlp/Encoder.java
+++ b/api/src/main/java/ai/djl/modality/nlp/Encoder.java
@@ -57,6 +57,7 @@ public abstract class Encoder extends AbstractBlock {
     public NDList forward(
             ParameterStore parameterStore,
             NDList inputs,
+            NDList output,
             boolean training,
             PairList<String, Object> params) {
         return block.forward(parameterStore, inputs, training, params);

--- a/api/src/main/java/ai/djl/modality/nlp/EncoderDecoder.java
+++ b/api/src/main/java/ai/djl/modality/nlp/EncoderDecoder.java
@@ -72,6 +72,7 @@ public class EncoderDecoder extends AbstractBlock {
     public NDList forward(
             ParameterStore parameterStore,
             NDList inputs,
+            NDList output,
             boolean training,
             PairList<String, Object> params) {
         if (training) {

--- a/api/src/main/java/ai/djl/modality/nlp/embedding/TrainableTextEmbedding.java
+++ b/api/src/main/java/ai/djl/modality/nlp/embedding/TrainableTextEmbedding.java
@@ -73,6 +73,7 @@ public class TrainableTextEmbedding extends AbstractBlock implements TextEmbeddi
     public NDList forward(
             ParameterStore parameterStore,
             NDList inputs,
+            NDList output,
             boolean training,
             PairList<String, Object> params) {
         return trainableWordEmbedding.forward(parameterStore, inputs, training, params);

--- a/api/src/main/java/ai/djl/nn/Block.java
+++ b/api/src/main/java/ai/djl/nn/Block.java
@@ -114,7 +114,33 @@ public interface Block {
      * @return the output of the forward pass
      */
     default NDList forward(ParameterStore parameterStore, NDList inputs, boolean training) {
-        return forward(parameterStore, inputs, training, null);
+        return forward(parameterStore, inputs, null, training, null);
+    }
+
+    /**
+     * Applies the operating function of the block once. This method should be called only on blocks
+     * that are initialized.
+     *
+     * @param parameterStore the parameter store
+     * @param inputs the input NDList
+     * @param training true for a training forward pass
+     * @return the output of the forward pass
+     */
+    default NDList forward(ParameterStore parameterStore, NDList inputs, NDList output, boolean training) {
+        return forward(parameterStore, inputs, output, training, null);
+    }
+
+    /**
+     * Applies the operating function of the block once. This method should be called only on blocks
+     * that are initialized.
+     *
+     * @param parameterStore the parameter store
+     * @param inputs the input NDList
+     * @param training true for a training forward pass
+     * @return the output of the forward pass
+     */
+    default NDList forward(ParameterStore parameterStore, NDList inputs, boolean training, PairList<String, Object> params) {
+        return forward(parameterStore, inputs, null, training, params);
     }
 
     /**
@@ -130,6 +156,7 @@ public interface Block {
     NDList forward(
             ParameterStore parameterStore,
             NDList inputs,
+            NDList output,
             boolean training,
             PairList<String, Object> params);
 

--- a/api/src/main/java/ai/djl/nn/LambdaBlock.java
+++ b/api/src/main/java/ai/djl/nn/LambdaBlock.java
@@ -63,6 +63,7 @@ public class LambdaBlock extends AbstractBlock {
     public NDList forward(
             ParameterStore parameterStore,
             NDList inputs,
+            NDList output,
             boolean training,
             PairList<String, Object> params) {
         return lambda.apply(inputs);

--- a/api/src/main/java/ai/djl/nn/ParallelBlock.java
+++ b/api/src/main/java/ai/djl/nn/ParallelBlock.java
@@ -116,6 +116,7 @@ public class ParallelBlock extends AbstractBlock {
     public NDList forward(
             ParameterStore parameterStore,
             NDList inputs,
+            NDList output,
             boolean training,
             PairList<String, Object> params) {
         return function.apply(

--- a/api/src/main/java/ai/djl/nn/SequentialBlock.java
+++ b/api/src/main/java/ai/djl/nn/SequentialBlock.java
@@ -126,6 +126,7 @@ public class SequentialBlock extends AbstractBlock {
     public NDList forward(
             ParameterStore parameterStore,
             NDList inputs,
+            NDList output,
             boolean training,
             PairList<String, Object> params) {
         NDList current = inputs;

--- a/api/src/main/java/ai/djl/nn/convolutional/Convolution.java
+++ b/api/src/main/java/ai/djl/nn/convolutional/Convolution.java
@@ -135,6 +135,7 @@ public abstract class Convolution extends AbstractBlock {
     public NDList forward(
             ParameterStore parameterStore,
             NDList inputs,
+            NDList output,
             boolean training,
             PairList<String, Object> params) {
         NDArray input = inputs.singletonOrThrow();

--- a/api/src/main/java/ai/djl/nn/convolutional/Deconvolution.java
+++ b/api/src/main/java/ai/djl/nn/convolutional/Deconvolution.java
@@ -114,6 +114,7 @@ public abstract class Deconvolution extends AbstractBlock {
     public NDList forward(
             ParameterStore parameterStore,
             NDList inputs,
+            NDList output,
             boolean training,
             PairList<String, Object> params) {
         NDArray input = inputs.singletonOrThrow();

--- a/api/src/main/java/ai/djl/nn/core/ConstantEmbedding.java
+++ b/api/src/main/java/ai/djl/nn/core/ConstantEmbedding.java
@@ -45,6 +45,7 @@ public class ConstantEmbedding extends AbstractBlock implements AbstractIndexedE
     public NDList forward(
             ParameterStore parameterStore,
             NDList inputs,
+            NDList output,
             boolean training,
             PairList<String, Object> params) {
         NDManager manager = inputs.get(0).getManager();

--- a/api/src/main/java/ai/djl/nn/core/Embedding.java
+++ b/api/src/main/java/ai/djl/nn/core/Embedding.java
@@ -126,6 +126,7 @@ public abstract class Embedding<T> extends AbstractBlock implements AbstractInde
     public NDList forward(
             ParameterStore parameterStore,
             NDList inputs,
+            NDList output,
             boolean training,
             PairList<String, Object> params) {
         NDList opInputs = opInputs(parameterStore, inputs, training);

--- a/api/src/main/java/ai/djl/nn/core/Linear.java
+++ b/api/src/main/java/ai/djl/nn/core/Linear.java
@@ -75,6 +75,7 @@ public class Linear extends AbstractBlock {
     public NDList forward(
             ParameterStore parameterStore,
             NDList inputs,
+            NDList output,
             boolean training,
             PairList<String, Object> params) {
         NDArray input = inputs.singletonOrThrow();

--- a/api/src/main/java/ai/djl/nn/core/Prelu.java
+++ b/api/src/main/java/ai/djl/nn/core/Prelu.java
@@ -52,6 +52,7 @@ public class Prelu extends AbstractBlock {
     public NDList forward(
             ParameterStore parameterStore,
             NDList inputs,
+            NDList output,
             boolean training,
             PairList<String, Object> params) {
         NDArray input = inputs.singletonOrThrow();

--- a/api/src/main/java/ai/djl/nn/norm/BatchNorm.java
+++ b/api/src/main/java/ai/djl/nn/norm/BatchNorm.java
@@ -110,6 +110,7 @@ public class BatchNorm extends AbstractBlock {
     public NDList forward(
             ParameterStore parameterStore,
             NDList inputs,
+            NDList output,
             boolean training,
             PairList<String, Object> params) {
         NDArray input = inputs.singletonOrThrow();

--- a/api/src/main/java/ai/djl/nn/norm/Dropout.java
+++ b/api/src/main/java/ai/djl/nn/norm/Dropout.java
@@ -66,6 +66,7 @@ public class Dropout extends AbstractBlock {
     public NDList forward(
             ParameterStore parameterStore,
             NDList inputs,
+            NDList output,
             boolean training,
             PairList<String, Object> params) {
         return dropout(inputs.singletonOrThrow(), rate, training);

--- a/api/src/main/java/ai/djl/nn/recurrent/RecurrentBlock.java
+++ b/api/src/main/java/ai/djl/nn/recurrent/RecurrentBlock.java
@@ -124,6 +124,7 @@ public abstract class RecurrentBlock extends AbstractBlock {
     public NDList forward(
             ParameterStore parameterStore,
             NDList inputs,
+            NDList o,
             boolean training,
             PairList<String, Object> params) {
         inputs = opInputs(parameterStore, inputs, training);

--- a/api/src/main/java/ai/djl/nn/transformer/ScaledDotProductAttentionBlock.java
+++ b/api/src/main/java/ai/djl/nn/transformer/ScaledDotProductAttentionBlock.java
@@ -196,6 +196,7 @@ public final class ScaledDotProductAttentionBlock extends AbstractBlock {
     public NDList forward(
             ParameterStore parameterStore,
             NDList inputs,
+            NDList output,
             boolean training,
             PairList<String, Object> params) {
         // E=embedding size

--- a/model-zoo/src/main/java/ai/djl/basicmodelzoo/cv/object_detection/ssd/SingleShotDetection.java
+++ b/model-zoo/src/main/java/ai/djl/basicmodelzoo/cv/object_detection/ssd/SingleShotDetection.java
@@ -69,6 +69,7 @@ public final class SingleShotDetection extends AbstractBlock {
     public NDList forward(
             ParameterStore parameterStore,
             NDList inputs,
+            NDList output,
             boolean training,
             PairList<String, Object> params) {
         NDList networkOutput = inputs;

--- a/model-zoo/src/main/java/ai/djl/basicmodelzoo/nlp/SimpleTextDecoder.java
+++ b/model-zoo/src/main/java/ai/djl/basicmodelzoo/nlp/SimpleTextDecoder.java
@@ -86,6 +86,7 @@ public class SimpleTextDecoder extends Decoder {
     public NDList forward(
             ParameterStore parameterStore,
             NDList inputs,
+            NDList o,
             boolean training,
             PairList<String, Object> params) {
         if (training) {

--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtSymbolBlock.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtSymbolBlock.java
@@ -87,6 +87,7 @@ public class PtSymbolBlock extends NativeResource<Long> implements SymbolBlock {
     public NDList forward(
             ParameterStore parameterStore,
             NDList inputs,
+            NDList output,
             boolean training,
             PairList<String, Object> params) {
         // TODO refactor the forward to not take ParameterStore
@@ -106,7 +107,7 @@ public class PtSymbolBlock extends NativeResource<Long> implements SymbolBlock {
                     for (NDArray array : inputs) {
                         inputDescriptions.add(array.getName(), array.getShape());
                     }
-                    NDList outputs = IValueUtils.forward(this, inputs, training);
+                    NDList outputs = IValueUtils.forward(this, inputs, output, training);
                     for (NDArray array : outputs) {
                         outputDescriptions.add(array.getName(), array.getShape());
                     }
@@ -115,7 +116,7 @@ public class PtSymbolBlock extends NativeResource<Long> implements SymbolBlock {
                 }
             }
         }
-        return IValueUtils.forward(this, inputs, training);
+        return IValueUtils.forward(this, inputs, output, training);
     }
 
     /** {@inheritDoc} */

--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
@@ -434,6 +434,8 @@ final class PyTorchLibrary {
 
     native long iValueToTensor(long iValueHandle);
 
+    native void iValueToTensorCopy(long iValueHandle, long tensorHandle);
+
     native long[] iValueToTensorList(long iValueHandle);
 
     native long[] iValueToList(long iValueHandle);


### PR DESCRIPTION
Introducing an optional output `NDList` parameter on the `Predictor::predict` interface. When the output parameter is provided the underlying engine will copy the inference result into the corresponding `NDArray` instead of creating new objects.

This functionality is useful for high throughput systems as it reduces the number of memory allocations and reduces the load on the garbage collector.

TODO:
* The engine specific implementation is only provided for PyTorch:
  * On the Java side, the copy is only implemented for the NDArray type.
  * The PyTorch lib side was refactored since and not included in the PR.