### PR TITLE
[SP] avoid uploading cached shared library

### DIFF
--- a/extensions/sentencepiece/build.gradle
+++ b/extensions/sentencepiece/build.gradle
@@ -44,13 +44,6 @@ processResources {
         }
         def propFile = file("${classDir}/sentencepiece.properties")
         propFile.text = "version=${versionName}\n"
-
-        // for ci to upload to S3
-        def ciDir = "${project.projectDir}/jnilib/${djl_version}"
-        copy {
-            from jniDir
-            into ciDir
-        }
     }
 }
 
@@ -74,6 +67,13 @@ task compileJNI {
                 || System.properties['os.name'].toLowerCase(Locale.ROOT).contains("linux")) {
             exec {
                 commandLine 'bash', 'build.sh'
+            }
+            def jniDir = "${project.buildDir}/jnilib"
+            // for ci to upload to S3
+            def ciDir = "${project.projectDir}/jnilib/${djl_version}"
+            copy {
+                from jniDir
+                into ciDir
             }
         } else {
             throw new IllegalStateException("Unknown Architecture " + System.properties['os.name'])


### PR DESCRIPTION
## Description ##

Currently, we will download from the S3 and use that to upload. It is not performing correctly and just make the shared library not updating.