### PR TITLE
[PyTorch] Set and override shape API for NDArray

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/NDArray.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArray.java
@@ -442,6 +442,64 @@ public interface NDArray extends NDResource {
     }
 
     /**
+     * Sets this {@code NDArray} value from {@link Buffer} and overrides {@link Shape}.
+     *
+     * @param data the input buffered data
+     * @param shape the shape of input data
+     */
+    void set(Buffer data, Shape shape);
+
+    /**
+     * Sets this {@code NDArray} value from an array of floats and overrides {@link Shape}.
+     *
+     * @param data the array of floats to set
+     * @param shape the shape of input data
+     */
+    default void set(float[] data, Shape shape) {
+        set(FloatBuffer.wrap(data), shape);
+    }
+
+    /**
+     * Sets this {@code NDArray} value from an array of ints and overrides {@link Shape}.
+     *
+     * @param data the array of integers to set
+     * @param shape the shape of input data
+     */
+    default void set(int[] data, Shape shape) {
+        set(IntBuffer.wrap(data), shape);
+    }
+
+    /**
+     * Sets this {@code NDArray} value from an array of doubles and overrides {@link Shape}.
+     *
+     * @param data the array of doubles to set
+     * @param shape the shape of input data
+     */
+    default void set(double[] data, Shape shape) {
+        set(DoubleBuffer.wrap(data), shape);
+    }
+
+    /**
+     * Sets this {@code NDArray} value from an array of longs and overrides {@link Shape}.
+     *
+     * @param data the array of longs to set
+     * @param shape the shape of input data
+     */
+    default void set(long[] data, Shape shape) {
+        set(LongBuffer.wrap(data), shape);
+    }
+
+    /**
+     * Sets this {@code NDArray} value from an array of bytes and overrides {@link Shape}.
+     *
+     * @param data the array of bytes to set
+     * @param shape the shape of input data
+     */
+    default void set(byte[] data, Shape shape) {
+        set(ByteBuffer.wrap(data), shape);
+    }
+
+    /**
      * Sets the specified index in this {@code NDArray} with the given values.
      *
      * @param index the locations to update

--- a/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
@@ -149,6 +149,12 @@ public interface NDArrayAdapter extends NDArray {
 
     /** {@inheritDoc} */
     @Override
+    default void set(Buffer data, Shape shape) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MSG);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     default void copyTo(NDArray array) {
         throw new UnsupportedOperationException(UNSUPPORTED_MSG);
     }

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayOtherOpTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayOtherOpTest.java
@@ -279,12 +279,32 @@ public class NDArrayOtherOpTest {
             expected = manager.create(data, new Shape(2, 1, 1, 2));
             Assert.assertEquals(array, expected);
 
+            // test buffer larger than NDArray
+            array = manager.create(new float[] {0, 1, 2});
+            data = new float[] {9, 8, 7, 6, 5};
+            array.set(FloatBuffer.wrap(data));
+            expected = manager.create(new float[] {9, 8, 7});
+            Assert.assertEquals(array, expected);
+
+            // test buffer smaller than NDArray
             Assert.assertThrows(
                     IllegalArgumentException.class,
                     () -> {
-                        NDArray ndArray = manager.create(1f);
-                        ndArray.set(FloatBuffer.wrap(new float[] {-1, 1}));
+                        NDArray ndArray = manager.create(new float[] {0, 1, 2});
+                        ndArray.set(FloatBuffer.wrap(new float[] {-1}));
                     });
+        }
+    }
+
+    @Test
+    public void testSetWithShape() {
+        try (NDManager manager = NDManager.newBaseManager()) {
+            // test set and override shape
+            NDArray array = manager.create(new float[] {0, 1}, new Shape(1, 2));
+            float[] data = {9, 8, 7, 6, 5, 4};
+            array.set(FloatBuffer.wrap(data), new Shape(2, 2));
+            NDArray expected = manager.create(new float[] {9, 8, 7, 6}, new Shape(2, 2));
+            Assert.assertEquals(array, expected);
         }
     }
 

--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -216,10 +216,21 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public void set(Buffer data) {
+        set(data, getShape());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void set(Buffer data, Shape shape) {
         int size = data.remaining();
-        if (size != size()) {
+        if (size < shape.size()) {
             throw new IllegalArgumentException(
-                    "size mismatch! the NDArray has size " + size() + " but set with size " + size);
+                    "array size "
+                            + size
+                            + " is less than NDArray size: "
+                            + shape.size()
+                            + " "
+                            + shape);
         }
         // TODO how do we handle the exception happened in the middle
         dataRef = null;
@@ -229,7 +240,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
             if (!Device.Type.GPU.equals(getDevice().getDeviceType())) {
                 dataRef = (ByteBuffer) data;
             }
-            JniUtils.set(this, (ByteBuffer) data);
+            JniUtils.set(this, (ByteBuffer) data, shape);
             return;
         }
         // int8, uint8, boolean use ByteBuffer, so need to explicitly input DataType
@@ -264,7 +275,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
         if (!Device.Type.GPU.equals(getDevice().getDeviceType())) {
             dataRef = buf;
         }
-        JniUtils.set(this, buf);
+        JniUtils.set(this, buf, shape);
     }
 
     /** {@inheritDoc} */

--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
@@ -367,9 +367,9 @@ public final class JniUtils {
                 ndArray.getHandle(), value.getHandle(), minIndices, maxIndices, stepIndices);
     }
 
-    public static void set(PtNDArray self, ByteBuffer data) {
+    public static void set(PtNDArray self, ByteBuffer data, Shape shape) {
         // Note the ByteBuffer here is directByteBuffer
-        PyTorchLibrary.LIB.torchSet(self.getHandle(), data);
+        PyTorchLibrary.LIB.torchSet(self.getHandle(), data, shape.getShape());
     }
 
     public static PtNDArray pick(PtNDArray ndArray, PtNDArray index, long dim) {

--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
@@ -190,7 +190,7 @@ final class PyTorchLibrary {
             long[] maxIndices,
             long[] stepIndices);
 
-    native void torchSet(long handle, ByteBuffer data);
+    native void torchSet(long handle, ByteBuffer data, long[] shape);
 
     native long torchSlice(long handle, long dim, long start, long end, long step);
 

--- a/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
+++ b/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
@@ -189,6 +189,12 @@ public class TfNDArray extends NativeResource<TFE_TensorHandle> implements NDArr
 
     /** {@inheritDoc} */
     @Override
+    public void set(Buffer data, Shape shape) {
+        throw new UnsupportedOperationException("Tensor cannot be modified after creation");
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void attach(NDManager manager) {
         detach();
         this.manager = (TfNDManager) manager;


### PR DESCRIPTION
Introducing a new `NDArray::set` API that overrides the shape and relaxing the size check to allow the use of larger buffers.

The use case is a high-throughput inference service that needs to support variable batch sizes. This change will reduce the number of memory allocations by allowing the reuse of the buffer and `NDArray` between inference calls.

Limitation:
* The new set API is only implemented for PyTorch
