### PR TITLE
Fix gradlew in case JAVA_HOME is not set

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -120,7 +120,7 @@ if [ ! -r "${WRAPPER_JAR_PATH}" ]; then
         if [ -e "$javaClass" ]; then
             if [ ! -e "$APP_HOME/gradle/wrapper/GradleWrapperDownloader.class" ]; then
                 # Compiling the Java class
-                ("$JAVA_HOME/bin/javac" "$javaClass")
+                ("${JAVACMD}c" "$javaClass")
             fi
             if [ -e "$APP_HOME/gradle/wrapper/GradleWrapperDownloader.class" ]; then
                 ("$JAVACMD" -cp gradle/wrapper GradleWrapperDownloader "$APP_HOME")


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
