### PR TITLE
Add integration test for truncated-normal op

### DIFF
--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayCreationOpTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayCreationOpTest.java
@@ -414,6 +414,16 @@ public class NDArrayCreationOpTest {
     }
 
     @Test
+    public void testTruncatedNormal() {
+        try (NDManager manager = NDManager.newBaseManager()) {
+            NDArray normal = manager.truncatedNormal(new Shape(1000, 1000));
+            Assertions.assertAlmostEquals(normal.mean().getFloat(), 0f, 2e-2f, 2e-2f);
+            Assert.assertTrue(normal.gte(-2).all().getBoolean());
+            Assert.assertTrue(normal.lte(2).all().getBoolean());
+        }
+    }
+
+    @Test
     public void testFixedSeed() {
         try (NDManager manager = NDManager.newBaseManager()) {
             if ("TensorFlow".equals(Engine.getInstance().getEngineName())) {


### PR DESCRIPTION
## Description ##

Add the integration test for the truncated-normal operation. This test verifies the sample mean is within a certain range from the theoretical mean. It also checks the truncation, testing if all the sample points are within 2 standard deviations from the mean.