### PR TITLE
Making utility class EasyTrain non-final. Requires suppressing "Final…

### DIFF
--- a/api/src/main/java/ai/djl/training/EasyTrain.java
+++ b/api/src/main/java/ai/djl/training/EasyTrain.java
@@ -27,7 +27,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 
 /** Helper for easy training of a whole model, a trainining batch, or a validation batch. */
-public final class EasyTrain {
+@SuppressWarnings("FinalClass")
+public class EasyTrain {
 
     private EasyTrain() {}
 


### PR DESCRIPTION
…Class" style check. See issue #937.

## Description ##

This change was discussed in issue #937

I am working on data with labels but do not use those labels for learning and inference - unsupervised learning with auto-encoders. I do need the labels later for validation though, so creating a `DataSet` that sets the labels to be the same as the data and loosing the label information, won't solve my problem. To get this working, I changed `EasyTrain.java` of version 0.9.0, to set the labelmember equal to the data member. However, `EasyTrain` has been updated, and will in the future most probably be updated again. It is much easier for users to simply extend the class and change the required behavior. In my case just change the `trainSplit` and `validateSplit` methods.

Will this change the current api? How?
This change is a backward compatible. Removing the final qualifier won't change the API, so most users won't even be aware of the change.

Who will benefit from this enhancement?
Interesting edge cases to note here: sometimes we need to adapt training to use different type of labeling (in my case unsupervised learning).  Anyone that has to adapt the `EasyTrain` class to do something similar to the already existing class.
