### PR TITLE
Fix NPE bug in block.toString() function

### DIFF
--- a/api/src/main/java/ai/djl/nn/AbstractBlock.java
+++ b/api/src/main/java/ai/djl/nn/AbstractBlock.java
@@ -115,7 +115,7 @@ public abstract class AbstractBlock implements Block {
             boolean training,
             PairList<String, Object> params) {
         NDManager paramsManager = parameterStore.getManager();
-        if (!isInitialized()) {
+        if (training && !isInitialized()) {
             initialize(paramsManager, DataType.FLOAT32, inputs.getShapes());
         }
         return forwardInternal(parameterStore, inputs, training, params);
@@ -330,6 +330,9 @@ public abstract class AbstractBlock implements Block {
     /** {@inheritDoc} */
     @Override
     public boolean isInitialized() {
+        if (inputShapes == null) {
+            return false;
+        }
         for (Parameter param : getParameters().values()) {
             if (!param.isInitialized()) {
                 return false;


### PR DESCRIPTION
Change-Id: I2aa8bc6c8d36d01cc00c02778907b040d782330c

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
