### PR TITLE
Update NDArray.java

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/NDArray.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArray.java
@@ -1740,7 +1740,7 @@ public interface NDArray extends NDResource {
     NDArray minimum(Number n);
 
     /**
-     * Returns the maximum of this {@code NDArray} and the other {@code NDArray} element-wise.
+     * Returns the minimum of this {@code NDArray} and the other {@code NDArray} element-wise.
      *
      * <p>The shapes of this {@code NDArray} and the other {@code NDArray} must be broadcastable.
      *
@@ -1762,7 +1762,7 @@ public interface NDArray extends NDResource {
      * </pre>
      *
      * @param other the {@code NDArray} to be compared
-     * @return the maximum of this {@code NDArray} and the other {@code NDArray} element-wise
+     * @return the minimum of this {@code NDArray} and the other {@code NDArray} element-wise
      */
     NDArray minimum(NDArray other);
 


### PR DESCRIPTION
Fix documentation of minimum of two NDArrays to read minimum, not maximum.

#1112 
