### PR TITLE
Fix NDArrayAdapter.getSparseFormat()

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
@@ -35,7 +35,7 @@ public interface NDArrayAdapter extends NDArray {
     /** {@inheritDoc} */
     @Override
     default SparseFormat getSparseFormat() {
-        throw new UnsupportedOperationException(UNSUPPORTED_MSG);
+        return SparseFormat.DENSE;
     }
 
     /** {@inheritDoc} */

--- a/tflite/tflite-engine/src/main/java/ai/djl/tflite/engine/TfLiteNDArray.java
+++ b/tflite/tflite-engine/src/main/java/ai/djl/tflite/engine/TfLiteNDArray.java
@@ -18,7 +18,6 @@ import ai.djl.ndarray.NDArrayAdapter;
 import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
-import ai.djl.ndarray.types.SparseFormat;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.UUID;
@@ -93,12 +92,6 @@ public class TfLiteNDArray implements NDArrayAdapter {
     @Override
     public Shape getShape() {
         return shape;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public SparseFormat getSparseFormat() {
-        return SparseFormat.DENSE;
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Change-Id: I2bc4bc7ad97abe32e7fa065b42be7e1f4f886952

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
