### PR TITLE
[fasttext] allow specify label preifx

### DIFF
--- a/extensions/fasttext/src/main/java/ai/djl/fasttext/FtModel.java
+++ b/extensions/fasttext/src/main/java/ai/djl/fasttext/FtModel.java
@@ -84,6 +84,11 @@ public class FtModel implements Model {
         }
         fta.loadModel(modelFilePath);
 
+        if (options != null) {
+            for (Map.Entry<String, ?> entry : options.entrySet()) {
+                properties.put(entry.getKey(), entry.getValue().toString());
+            }
+        }
         properties.put("model-type", fta.getModelType());
     }
 
@@ -126,7 +131,8 @@ public class FtModel implements Model {
      * @return classifications of the input text
      */
     public Classifications classify(String text, int topK) {
-        return fta.predictProba(text, topK);
+        String labelPrefix = properties.getOrDefault("label-prefix", "__label__");
+        return fta.predictProba(text, topK, labelPrefix);
     }
 
     /**

--- a/extensions/fasttext/src/main/java/ai/djl/fasttext/jni/FtWrapper.java
+++ b/extensions/fasttext/src/main/java/ai/djl/fasttext/jni/FtWrapper.java
@@ -58,7 +58,7 @@ public final class FtWrapper extends NativeResource<Long> {
         return FastTextLibrary.LIB.getModelType(getHandle());
     }
 
-    public Classifications predictProba(String text, int topK) {
+    public Classifications predictProba(String text, int topK, String labelPrefix) {
         String[] labels = new String[topK];
         float[] probs = new float[topK];
 
@@ -67,7 +67,11 @@ public final class FtWrapper extends NativeResource<Long> {
         List<String> classes = new ArrayList<>(size);
         List<Double> probabilities = new ArrayList<>(size);
         for (int i = 0; i < size; ++i) {
-            classes.add(labels[i]); // NOPMD
+            String label = labels[i];
+            if (label.startsWith(labelPrefix)) {
+                label = label.substring(labelPrefix.length());
+            }
+            classes.add(label);
             probabilities.add((double) probs[i]);
         }
         return new Classifications(classes, probabilities);

--- a/extensions/fasttext/src/main/java/ai/djl/fasttext/zoo/nlp/textclassification/TextClassificationModelLoader.java
+++ b/extensions/fasttext/src/main/java/ai/djl/fasttext/zoo/nlp/textclassification/TextClassificationModelLoader.java
@@ -65,7 +65,7 @@ public class TextClassificationModelLoader extends BaseModelLoader {
         }
         Model model = new FtModel(modelName);
         Path modelPath = mrl.getRepository().getResourceDirectory(artifact);
-        model.load(modelPath);
+        model.load(modelPath, modelName, criteria.getOptions());
         return new ZooModel<>(model, null);
     }
 }

--- a/extensions/fasttext/src/test/java/ai/djl/fasttext/CookingStackExchangeTest.java
+++ b/extensions/fasttext/src/test/java/ai/djl/fasttext/CookingStackExchangeTest.java
@@ -73,12 +73,13 @@ public class CookingStackExchangeTest {
                 Criteria.builder()
                         .setTypes(String.class, Classifications.class)
                         .optArtifactId("ai.djl.fasttext:cooking_stackexchange")
+                        .optOption("label-prefix", "__label")
                         .build();
         try (ZooModel<String, Classifications> model = criteria.loadModel()) {
             String input = "Which baking dish is best to bake a banana bread ?";
             FtModel ftModel = (FtModel) model.getWrappedModel();
             Classifications result = ftModel.classify(input, 8);
-            Assert.assertEquals(result.item(0).getClassName(), "__label__bread");
+            Assert.assertEquals(result.item(0).getClassName(), "__bread");
         }
     }
 
@@ -131,7 +132,7 @@ public class CookingStackExchangeTest {
             Classifications result = model.classify(text, 5);
 
             logger.info("{}", result);
-            Assert.assertEquals(result.item(0).getClassName(), "__label__Company");
+            Assert.assertEquals(result.item(0).getClassName(), "Company");
         }
     }
 }


### PR DESCRIPTION
1. This reverts commit 887bc6f136706efbaeb1cad783e710ec16293078.
2. This reverts commit 3198f656b228322eb38e03ed1d80d92cc0c14d2b.
3. Add options to set label prefix

Change-Id: I022352a8ecd4156ce08a92543db934710fa2a865

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
