### PR TITLE
Refactor alternative engine API

### DIFF
--- a/api/src/main/java/ai/djl/engine/Engine.java
+++ b/api/src/main/java/ai/djl/engine/Engine.java
@@ -88,6 +88,13 @@ public abstract class Engine {
     }
 
     /**
+     * Returns the alternative {@code engine} if available.
+     *
+     * @return the alternative {@code engine}
+     */
+    public abstract Engine getAlternativeEngine();
+
+    /**
      * Returns the name of the Engine.
      *
      * @return the name of the engine

--- a/api/src/main/java/ai/djl/ndarray/NDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/NDManager.java
@@ -162,6 +162,14 @@ public interface NDManager extends AutoCloseable {
     ByteBuffer allocateDirect(int capacity);
 
     /**
+     * Converts an external engine's {@link NDArray} to current engine.
+     *
+     * @param array the input {@code NDArray}
+     * @return a new if the input {@code NDArray} is from external engine
+     */
+    NDArray adopt(NDArray array);
+
+    /**
      * Creates an uninitialized instance of {@link DataType#FLOAT32} {@link NDArray} with specified
      * {@link Shape}.
      *

--- a/api/src/main/java/ai/djl/ndarray/types/DataType.java
+++ b/api/src/main/java/ai/djl/ndarray/types/DataType.java
@@ -19,6 +19,7 @@ import java.nio.DoubleBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.LongBuffer;
+import java.nio.ShortBuffer;
 
 /** An enum representing the underlying {@link NDArray}'s data type. */
 public enum DataType {
@@ -96,6 +97,8 @@ public enum DataType {
     public static DataType fromBuffer(Buffer data) {
         if (data instanceof FloatBuffer) {
             return DataType.FLOAT32;
+        } else if (data instanceof ShortBuffer) {
+            return DataType.FLOAT16;
         } else if (data instanceof DoubleBuffer) {
             return DataType.FLOAT64;
         } else if (data instanceof IntBuffer) {
@@ -149,6 +152,8 @@ public enum DataType {
      */
     public Buffer asDataType(ByteBuffer data) {
         switch (this) {
+            case FLOAT16:
+                return data.asShortBuffer();
             case FLOAT32:
                 return data.asFloatBuffer();
             case FLOAT64:
@@ -159,7 +164,6 @@ public enum DataType {
                 return data.asLongBuffer();
             case UINT8:
             case INT8:
-            case FLOAT16:
             case UNKNOWN:
             default:
                 return data;

--- a/api/src/main/java/ai/djl/util/Float16Utils.java
+++ b/api/src/main/java/ai/djl/util/Float16Utils.java
@@ -20,6 +20,8 @@ import java.nio.ShortBuffer;
 @SuppressWarnings("PMD.AvoidUsingShortType")
 public final class Float16Utils {
 
+    public static final short ONE = floatToHalf(1);
+
     private Float16Utils() {}
 
     /**

--- a/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrModel.java
+++ b/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrModel.java
@@ -13,7 +13,6 @@
 package ai.djl.dlr.engine;
 
 import ai.djl.BaseModel;
-import ai.djl.Device;
 import ai.djl.Model;
 import ai.djl.inference.Predictor;
 import ai.djl.ndarray.NDManager;
@@ -33,22 +32,18 @@ import java.util.Map;
  */
 public class DlrModel extends BaseModel {
 
-    private Device predictorDevice;
-
     /**
      * Constructs a new Model on a given device.
      *
      * @param name the model name
      * @param manager the {@link NDManager} to holds the NDArray
-     * @param device the {@link Device} to create DlrModel on
      */
-    DlrModel(String name, NDManager manager, Device device) {
+    DlrModel(String name, NDManager manager) {
         super(name);
         this.manager = manager;
         this.manager.setName("dlrModel");
         // DLR only support float32
         dataType = DataType.FLOAT32;
-        this.predictorDevice = device;
     }
 
     /** {@inheritDoc} */
@@ -67,7 +62,7 @@ public class DlrModel extends BaseModel {
     /** {@inheritDoc} */
     @Override
     public <I, O> Predictor<I, O> newPredictor(Translator<I, O> translator) {
-        return new DlrPredictor<>(this, modelDir.toString(), predictorDevice, translator);
+        return new DlrPredictor<>(this, modelDir.toString(), manager.getDevice(), translator);
     }
 
     private void checkModelFiles(String prefix) throws IOException {

--- a/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrNDArray.java
+++ b/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrNDArray.java
@@ -12,7 +12,6 @@
  */
 package ai.djl.dlr.engine;
 
-import ai.djl.Device;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDArrayAdapter;
 import ai.djl.ndarray.NDManager;
@@ -22,90 +21,23 @@ import java.nio.ByteBuffer;
 import java.util.UUID;
 
 /** {@code DlrNDArray} is the DLR implementation of {@link NDArray}. */
-public class DlrNDArray implements NDArrayAdapter {
+public class DlrNDArray extends NDArrayAdapter {
 
-    private DlrNDManager manager;
     private ByteBuffer data;
-    private Shape shape;
-    private String name;
-    private boolean isClosed;
-    private String uid;
 
     /**
      * Constructs an DLR NDArray from a {@link DlrNDManager} (internal. Use {@link NDManager}
      * instead).
      *
      * @param manager the manager to attach the new array to
+     * @param alternativeManager the alternative manager to execute unsupported operation
      * @param data the underlying data
      * @param shape the shape of {@code DlrNDArray}
      */
-    DlrNDArray(DlrNDManager manager, ByteBuffer data, Shape shape) {
-        this.manager = manager;
+    DlrNDArray(DlrNDManager manager, NDManager alternativeManager, ByteBuffer data, Shape shape) {
+        super(manager, alternativeManager, shape, DataType.FLOAT32, UUID.randomUUID().toString());
         this.data = data;
-        this.shape = shape;
-        uid = UUID.randomUUID().toString();
         manager.attachInternal(uid, this);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public NDManager getManager() {
-        return manager;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public String getName() {
-        return name;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public String getUid() {
-        return uid;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public DataType getDataType() {
-        // DLR only supports float32
-        return DataType.FLOAT32;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Device getDevice() {
-        // TODO: support GPU
-        return Device.cpu();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Shape getShape() {
-        return shape;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void attach(NDManager manager) {
-        detach();
-        this.manager = (DlrNDManager) manager;
-        manager.attachInternal(getUid(), this);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void tempAttach(NDManager manager) {
-        detach();
-        NDManager original = this.manager;
-        this.manager = (DlrNDManager) manager;
-        manager.tempAttachInternal(original, getUid(), this);
     }
 
     /** {@inheritDoc} */
@@ -120,20 +52,5 @@ public class DlrNDArray implements NDArrayAdapter {
     public ByteBuffer toByteBuffer() {
         data.rewind();
         return data;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public String toString() {
-        if (isClosed) {
-            return "This array is already closed";
-        }
-        return toDebugString();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void close() {
-        isClosed = true;
     }
 }

--- a/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrSymbolBlock.java
+++ b/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrSymbolBlock.java
@@ -15,7 +15,6 @@ package ai.djl.dlr.engine;
 
 import ai.djl.dlr.jni.JniUtils;
 import ai.djl.ndarray.NDList;
-import ai.djl.ndarray.NDManager;
 import ai.djl.nn.AbstractSymbolBlock;
 import ai.djl.nn.SymbolBlock;
 import ai.djl.training.ParameterStore;
@@ -52,7 +51,6 @@ public class DlrSymbolBlock extends AbstractSymbolBlock implements AutoCloseable
             boolean training,
             PairList<String, Object> params) {
         long modelHandle = handle.get();
-        NDManager manager = inputs.head().getManager();
         // TODO maybe verify the number of inputs
         // currently we assume the order of the input NDList is the same
         // as the model input
@@ -60,7 +58,7 @@ public class DlrSymbolBlock extends AbstractSymbolBlock implements AutoCloseable
             JniUtils.setDlrInput(modelHandle, inputs.get(i), i);
         }
         JniUtils.runDlrModel(modelHandle);
-        return JniUtils.getDlrOutputs(modelHandle, manager);
+        return JniUtils.getDlrOutputs(modelHandle, inputs.head().getManager());
     }
 
     /** {@inheritDoc} */

--- a/integration/src/test/translator/MyTranslator.java
+++ b/integration/src/test/translator/MyTranslator.java
@@ -56,9 +56,9 @@ public class MyTranslator implements ServingTranslator {
     }
 
     @Override
-    public void prepare(NDManager manager, Model model) throws IOException {
+    public void prepare(TranslatorContext ctx) throws IOException {
         if (classes == null) {
-            classes = model.getArtifact("synset.txt", Utils::readLines);
+            classes = ctx.getModel().getArtifact("synset.txt", Utils::readLines);
         }
     }
 

--- a/ml/xgboost/src/main/java/ai/djl/ml/xgboost/XgbEngine.java
+++ b/ml/xgboost/src/main/java/ai/djl/ml/xgboost/XgbEngine.java
@@ -32,11 +32,28 @@ public final class XgbEngine extends Engine {
     public static final String ENGINE_NAME = "XGBoost";
     static final int RANK = 10;
 
+    private Engine alternativeEngine;
+    private boolean initialized;
+
     private XgbEngine() {}
 
     static Engine newInstance() {
         JniUtils.checkCall(0); // Load the native
         return new XgbEngine();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Engine getAlternativeEngine() {
+        if (!initialized && !Boolean.getBoolean("ai.djl.xgboost.disable_alternative")) {
+            Engine engine = Engine.getInstance();
+            if (engine.getRank() < getRank()) {
+                // alternativeEngine should not have the same rank as OnnxRuntime
+                alternativeEngine = engine;
+            }
+            initialized = true;
+        }
+        return alternativeEngine;
     }
 
     /** {@inheritDoc} */
@@ -97,5 +114,11 @@ public final class XgbEngine extends Engine {
     @Override
     public void setRandomSeed(int seed) {
         throw new UnsupportedOperationException("Not supported for XGBoost");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return getEngineName() + ':' + getVersion();
     }
 }

--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxEngine.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxEngine.java
@@ -81,6 +81,12 @@ public final class MxEngine extends Engine {
 
     /** {@inheritDoc} */
     @Override
+    public Engine getAlternativeEngine() {
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public String getEngineName() {
         return ENGINE_NAME;
     }

--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayEx.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayEx.java
@@ -32,8 +32,7 @@ import java.util.List;
 /** {@code MxNDArrayEx} is the MXNet implementation of the {@link NDArrayEx}. */
 class MxNDArrayEx implements NDArrayEx {
 
-    private static final NDArrayIndexer INDEXER = new MxNDArrayIndexer();
-
+    private NDArrayIndexer indexer;
     private MxNDArray array;
 
     /**
@@ -43,6 +42,7 @@ class MxNDArrayEx implements NDArrayEx {
      */
     MxNDArrayEx(MxNDArray parent) {
         this.array = parent;
+        indexer = new MxNDArrayIndexer(array.getManager());
     }
 
     // TODO only used to calculate zero-dim numpy shape
@@ -962,7 +962,7 @@ class MxNDArrayEx implements NDArrayEx {
     /** {@inheritDoc} */
     @Override
     public NDArrayIndexer getIndexer() {
-        return INDEXER;
+        return indexer;
     }
 
     ////////////////////////////////////////

--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayIndexer.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayIndexer.java
@@ -23,9 +23,16 @@ import java.util.Stack;
 /** The {@link NDArrayIndexer} used by the {@link MxNDArray}. */
 public class MxNDArrayIndexer extends NDArrayIndexer {
 
+    private MxNDManager manager;
+
+    MxNDArrayIndexer(MxNDManager manager) {
+        this.manager = manager;
+    }
+
     /** {@inheritDoc} */
     @Override
     public NDArray get(NDArray array, NDIndexFullPick fullPick) {
+        array = manager.adopt(array);
         MxOpParams params = new MxOpParams();
         params.addParam("axis", fullPick.getAxis());
         params.addParam("keepdims", true);
@@ -38,6 +45,7 @@ public class MxNDArrayIndexer extends NDArrayIndexer {
     /** {@inheritDoc} */
     @Override
     public NDArray get(NDArray array, NDIndexFullSlice fullSlice) {
+        array = manager.adopt(array);
         MxOpParams params = new MxOpParams();
         params.addTupleParam("begin", fullSlice.getMin());
         params.addTupleParam("end", fullSlice.getMax());
@@ -56,6 +64,7 @@ public class MxNDArrayIndexer extends NDArrayIndexer {
     /** {@inheritDoc} */
     @Override
     public void set(NDArray array, NDIndexFullSlice fullSlice, NDArray value) {
+        array = manager.adopt(array);
         MxOpParams params = new MxOpParams();
         params.addTupleParam("begin", fullSlice.getMin());
         params.addTupleParam("end", fullSlice.getMax());
@@ -90,6 +99,7 @@ public class MxNDArrayIndexer extends NDArrayIndexer {
     /** {@inheritDoc} */
     @Override
     public void set(NDArray array, NDIndexFullSlice fullSlice, Number value) {
+        array = manager.adopt(array);
         MxOpParams params = new MxOpParams();
         params.addTupleParam("begin", fullSlice.getMin());
         params.addTupleParam("end", fullSlice.getMax());

--- a/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDManager.java
+++ b/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDManager.java
@@ -62,6 +62,25 @@ public class MxNDManager extends BaseNDManager {
         return ByteBuffer.allocateDirect(capacity).order(ByteOrder.nativeOrder());
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public MxNDArray adopt(NDArray array) {
+        if (array instanceof MxNDArray) {
+            return (MxNDArray) array;
+        }
+        MxNDArray ret = create(array.getShape(), array.getDataType());
+        ret.set(array.toByteBuffer());
+        return ret;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public MxNDArray createDirect(Buffer data, Shape shape, DataType dataType) {
+        MxNDArray ret = create(shape, dataType);
+        ret.set(data);
+        return ret;
+    }
+
     /**
      * Creates an MxNDArray with the given Native Memory Pointer and attaches to this manager.
      *

--- a/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtModel.java
+++ b/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtModel.java
@@ -70,13 +70,15 @@ public class OrtModel extends BaseModel {
 
         try {
             Device device = manager.getDevice();
+            OrtSession session;
             if (Device.Type.GPU.equals(device.getDeviceType())) {
                 OrtSession.SessionOptions sessionOptions = new OrtSession.SessionOptions();
                 sessionOptions.addCUDA(manager.getDevice().getDeviceId());
-                block = new OrtSymbolBlock(env.createSession(modelFile.toString(), sessionOptions));
+                session = env.createSession(modelFile.toString(), sessionOptions);
             } else {
-                block = new OrtSymbolBlock(env.createSession(modelFile.toString()));
+                session = env.createSession(modelFile.toString());
             }
+            block = new OrtSymbolBlock(session, (OrtNDManager) manager);
         } catch (OrtException e) {
             throw new MalformedModelException("ONNX Model cannot be loaded", e);
         }
@@ -108,12 +110,5 @@ public class OrtModel extends BaseModel {
             }
         }
         return modelFile;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void close() {
-        ((OrtSymbolBlock) block).close();
-        super.close();
     }
 }

--- a/onnxruntime/onnxruntime-engine/src/test/java/ai/djl/onnxruntime/engine/OrtTest.java
+++ b/onnxruntime/onnxruntime-engine/src/test/java/ai/djl/onnxruntime/engine/OrtTest.java
@@ -19,6 +19,7 @@ import ai.djl.inference.Predictor;
 import ai.djl.modality.Classifications;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.onnxruntime.zoo.tabular.softmax_regression.IrisFlower;
 import ai.djl.repository.zoo.Criteria;
@@ -65,6 +66,26 @@ public class OrtTest {
              * to djl cache directory.
              */
             throw new SkipException("Ignore missing libgomp.so.1 error.");
+        }
+    }
+
+    @Test
+    public void testNDArray() {
+        try (NDManager manager = OrtNDManager.getSystemManager().newSubManager()) {
+            NDArray zeros = manager.zeros(new Shape(1, 2));
+            float[] data = zeros.toFloatArray();
+            Assert.assertEquals(data[0], 0);
+
+            NDArray ones = manager.ones(new Shape(1, 2));
+            data = ones.toFloatArray();
+            Assert.assertEquals(data[0], 1);
+
+            float[] buf = {0f, 1f, 2f, 3f};
+            NDArray array = manager.create(buf);
+            Assert.assertEquals(array.toFloatArray(), buf);
+
+            array = manager.create("string");
+            Assert.assertEquals(array.toStringArray()[0], "string");
         }
     }
 

--- a/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpModel.java
+++ b/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpModel.java
@@ -96,7 +96,7 @@ public class PpModel extends BaseModel {
         }
         paddlePredictor = new PaddlePredictor(JniUtils.createPredictor(config));
         JniUtils.deleteConfig(config);
-        setBlock(new PpSymbolBlock(paddlePredictor));
+        setBlock(new PpSymbolBlock(paddlePredictor, (PpNDManager) manager));
     }
 
     private String[] findModelFile(Path dir) {

--- a/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpPredictor.java
+++ b/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpPredictor.java
@@ -35,7 +35,7 @@ public class PpPredictor<I, O> extends Predictor<I, O> {
     public PpPredictor(Model model, PaddlePredictor predictor, Translator<I, O> translator) {
         super(model, translator, false);
         this.predictor = predictor;
-        block = new PpSymbolBlock(predictor);
+        block = new PpSymbolBlock(predictor, (PpNDManager) model.getNDManager());
     }
 
     /** {@inheritDoc} */

--- a/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/jni/JniUtils.java
+++ b/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/jni/JniUtils.java
@@ -13,6 +13,7 @@
 package ai.djl.paddlepaddle.jni;
 
 import ai.djl.Device;
+import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.paddlepaddle.engine.PaddlePredictor;
@@ -29,6 +30,7 @@ import java.util.Arrays;
  */
 @SuppressWarnings("MissingJavadocMethod")
 public final class JniUtils {
+
     private JniUtils() {}
 
     public static PpNDArray createNdArray(
@@ -37,7 +39,7 @@ public final class JniUtils {
         long handle =
                 PaddleLibrary.LIB.paddleCreateTensor(
                         data, data.remaining(), intShape, PpDataType.toPaddlePaddle(dtype));
-        return new PpNDArray(manager, data, handle);
+        return manager.createInternal(data, handle);
     }
 
     public static DataType getDTypeFromNd(PpNDArray array) {
@@ -120,7 +122,7 @@ public final class JniUtils {
         PaddleLibrary.LIB.deletePredictor(predictor.getHandle());
     }
 
-    public static PpNDArray[] predictorForward(
+    public static NDList predictorForward(
             PaddlePredictor predictor, PpNDArray[] inputs, String[] inputNames) {
         long[] inputHandles = new long[inputs.length];
         for (int i = 0; i < inputs.length; i++) {
@@ -131,9 +133,9 @@ public final class JniUtils {
         PpNDManager manager = (PpNDManager) inputs[0].getManager();
         PpNDArray[] arrays = new PpNDArray[outputs.length];
         for (int i = 0; i < outputs.length; i++) {
-            arrays[i] = new PpNDArray(manager, null, outputs[i]);
+            arrays[i] = manager.createInternal(null, outputs[i]);
         }
-        return arrays;
+        return new NDList(arrays);
     }
 
     public static String[] getInputNames(PaddlePredictor predictor) {

--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtEngine.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtEngine.java
@@ -80,6 +80,12 @@ public final class PtEngine extends Engine {
 
     /** {@inheritDoc} */
     @Override
+    public Engine getAlternativeEngine() {
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public String getEngineName() {
         return ENGINE_NAME;
     }

--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArrayEx.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArrayEx.java
@@ -28,8 +28,7 @@ import java.util.List;
 /** {@code PtNDArrayEx} is the PyTorch implementation of the {@link NDArrayEx}. */
 public class PtNDArrayEx implements NDArrayEx {
 
-    private static final NDArrayIndexer INDEXER = new PtNDArrayIndexer();
-
+    private NDArrayIndexer indexer;
     private PtNDArray array;
 
     /**
@@ -39,6 +38,7 @@ public class PtNDArrayEx implements NDArrayEx {
      */
     PtNDArrayEx(PtNDArray parent) {
         this.array = parent;
+        indexer = new PtNDArrayIndexer(array.getManager());
     }
 
     /** {@inheritDoc} */
@@ -615,7 +615,7 @@ public class PtNDArrayEx implements NDArrayEx {
     /** {@inheritDoc} */
     @Override
     public NDArrayIndexer getIndexer() {
-        return INDEXER;
+        return indexer;
     }
 
     /** {@inheritDoc} */

--- a/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArrayIndexer.java
+++ b/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArrayIndexer.java
@@ -24,11 +24,17 @@ import java.util.Stack;
 /** The {@link NDArrayIndexer} used by the {@link PtNDArray}. */
 public class PtNDArrayIndexer extends NDArrayIndexer {
 
+    private PtNDManager manager;
+
+    PtNDArrayIndexer(PtNDManager manager) {
+        this.manager = manager;
+    }
+
     /** {@inheritDoc} */
     @Override
     public NDArray get(NDArray array, NDIndexFullPick fullPick) {
         return JniUtils.pick(
-                (PtNDArray) array, (PtNDArray) fullPick.getIndices(), fullPick.getAxis());
+                manager.adopt(array), manager.adopt(fullPick.getIndices()), fullPick.getAxis());
     }
 
     /** {@inheritDoc} */
@@ -37,7 +43,7 @@ public class PtNDArrayIndexer extends NDArrayIndexer {
         long[] min = fullSlice.getMin();
         long[] max = fullSlice.getMax();
         long[] step = fullSlice.getStep();
-        try (PtNDArray res = JniUtils.index((PtNDArray) array, min, max, step)) {
+        try (PtNDArray res = JniUtils.index(manager.adopt(array), min, max, step)) {
             return res.squeeze(fullSlice.getToSqueeze());
         }
     }
@@ -57,8 +63,8 @@ public class PtNDArrayIndexer extends NDArrayIndexer {
         prepareValue.add(prepareValue.peek().reshape(targetShape));
         prepareValue.add(prepareValue.peek().broadcast(fullSlice.getShape()));
         JniUtils.indexSet(
-                (PtNDArray) array,
-                (PtNDArray) prepareValue.peek(),
+                manager.adopt(array),
+                manager.adopt(prepareValue.peek()),
                 fullSlice.getMin(),
                 fullSlice.getMax(),
                 fullSlice.getStep());
@@ -73,7 +79,8 @@ public class PtNDArrayIndexer extends NDArrayIndexer {
     @Override
     public void set(NDArray array, NDIndexBooleans indices, NDArray value) {
         try (NDArray mask = indices.getIndex()) {
-            JniUtils.booleanMaskSet((PtNDArray) array, (PtNDArray) value, (PtNDArray) mask);
+            JniUtils.booleanMaskSet(
+                    manager.adopt(array), manager.adopt(value), manager.adopt(mask));
         }
     }
 

--- a/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfEngine.java
+++ b/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfEngine.java
@@ -79,6 +79,12 @@ public final class TfEngine extends Engine implements AutoCloseable {
 
     /** {@inheritDoc} */
     @Override
+    public Engine getAlternativeEngine() {
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public String getEngineName() {
         return ENGINE_NAME;
     }

--- a/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArrayEx.java
+++ b/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArrayEx.java
@@ -27,7 +27,7 @@ import org.tensorflow.internal.c_api.TFE_TensorHandle;
 
 public class TfNDArrayEx implements NDArrayEx {
 
-    private static final NDArrayIndexer INDEXER = new TfNDArrayIndexer();
+    private NDArrayIndexer indexer;
 
     private TfNDArray array;
     private TfNDManager manager;
@@ -40,6 +40,7 @@ public class TfNDArrayEx implements NDArrayEx {
     TfNDArrayEx(TfNDArray array) {
         this.array = array;
         this.manager = array.getManager();
+        indexer = new TfNDArrayIndexer(manager);
     }
 
     /** {@inheritDoc} */
@@ -544,7 +545,7 @@ public class TfNDArrayEx implements NDArrayEx {
     /** {@inheritDoc} */
     @Override
     public NDArrayIndexer getIndexer() {
-        return INDEXER;
+        return indexer;
     }
 
     /** {@inheritDoc} */

--- a/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArrayIndexer.java
+++ b/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArrayIndexer.java
@@ -20,6 +20,12 @@ import ai.djl.ndarray.index.full.NDIndexFullSlice;
 /** The {@link NDArrayIndexer} used by the {@link TfNDArray}. */
 public class TfNDArrayIndexer extends NDArrayIndexer {
 
+    private TfNDManager manager;
+
+    TfNDArrayIndexer(TfNDManager manager) {
+        this.manager = manager;
+    }
+
     /** {@inheritDoc} */
     @Override
     public NDArray get(NDArray array, NDIndexFullPick fullPick) {
@@ -29,13 +35,15 @@ public class TfNDArrayIndexer extends NDArrayIndexer {
     /** {@inheritDoc} */
     @Override
     public NDArray get(NDArray array, NDIndexFullSlice fullSlice) {
-        TfNDManager manager = (TfNDManager) array.getManager();
+        array = manager.adopt(array);
+        TfNDManager tfManager = (TfNDManager) array.getManager();
         int[] toSqueeze = fullSlice.getToSqueeze();
-        try (NDArray begin = manager.create(fullSlice.getMin());
-                NDArray end = manager.create(fullSlice.getMax());
-                NDArray step = manager.create(fullSlice.getStep())) {
+        try (NDArray begin = tfManager.create(fullSlice.getMin());
+                NDArray end = tfManager.create(fullSlice.getMax());
+                NDArray step = tfManager.create(fullSlice.getStep())) {
             NDArray result =
-                    manager.opExecutor("StridedSlice")
+                    tfManager
+                            .opExecutor("StridedSlice")
                             .addInput(array)
                             .addInput(begin)
                             .addInput(end)

--- a/tflite/tflite-engine/src/main/java/ai/djl/tflite/engine/TfLiteSymbolBlock.java
+++ b/tflite/tflite-engine/src/main/java/ai/djl/tflite/engine/TfLiteSymbolBlock.java
@@ -50,8 +50,9 @@ public class TfLiteSymbolBlock extends AbstractSymbolBlock implements AutoClosea
         int outputSize = interpreter.getOutputTensorCount();
         NDList result = new NDList(outputSize);
         for (int i = 0; i < outputSize; i++) {
-            result.add(new TfLiteNDArray(manager, interpreter.getOutputTensor(i)));
+            result.add(manager.createInternal(interpreter.getOutputTensor(i)));
         }
+        result.attach(inputs.head().getManager());
         return result;
     }
 

--- a/tflite/tflite-engine/src/test/java/ai/djl/tflite/engine/TfLiteTest.java
+++ b/tflite/tflite-engine/src/test/java/ai/djl/tflite/engine/TfLiteTest.java
@@ -41,13 +41,13 @@ public class TfLiteTest {
                         .optEngine("TFLite")
                         .optFilter("dataset", "aiyDish")
                         .build();
-        ZooModel<Image, Classifications> model = criteria.loadModel();
-        Predictor<Image, Classifications> predictor = model.newPredictor();
-
-        Image image =
-                ImageFactory.getInstance()
-                        .fromUrl("https://resources.djl.ai/images/sachertorte.jpg");
-        Classifications prediction = predictor.predict(image);
-        Assert.assertEquals(prediction.best().getClassName(), "Sachertorte");
+        try (ZooModel<Image, Classifications> model = criteria.loadModel();
+                Predictor<Image, Classifications> predictor = model.newPredictor()) {
+            Image image =
+                    ImageFactory.getInstance()
+                            .fromUrl("https://resources.djl.ai/images/sachertorte.jpg");
+            Classifications prediction = predictor.predict(image);
+            Assert.assertEquals(prediction.best().getClassName(), "Sachertorte");
+        }
     }
 }


### PR DESCRIPTION
1. make NDArrayAdapter base class
2. Fallback to alternative engine when needed
3. Allow NDArray auto convert between engines
4. Prepare for ops across different engine

Change-Id: Ia1499169c432d7a76e2df550a266b61240a55609

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
