### PR TITLE
Removes getPipeline from PreProcessor

### DIFF
--- a/api/src/main/java/ai/djl/modality/cv/translator/BaseImageTranslator.java
+++ b/api/src/main/java/ai/djl/modality/cv/translator/BaseImageTranslator.java
@@ -44,8 +44,9 @@ public abstract class BaseImageTranslator<T> implements Translator<Image, T> {
     private static final float[] MEAN = {0.485f, 0.456f, 0.406f};
     private static final float[] STD = {0.229f, 0.224f, 0.225f};
 
+    protected Pipeline pipeline;
+
     private Image.Flag flag;
-    private Pipeline pipeline;
     private Batchifier batchifier;
 
     /**
@@ -63,12 +64,6 @@ public abstract class BaseImageTranslator<T> implements Translator<Image, T> {
     @Override
     public Batchifier getBatchifier() {
         return batchifier;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Pipeline getPipeline() {
-        return pipeline;
     }
 
     /** {@inheritDoc} */

--- a/api/src/main/java/ai/djl/translate/PreProcessor.java
+++ b/api/src/main/java/ai/djl/translate/PreProcessor.java
@@ -22,15 +22,6 @@ import ai.djl.ndarray.NDList;
 public interface PreProcessor<I> {
 
     /**
-     * Gets the {@link Pipeline} applied to the input.
-     *
-     * @return the {@link Pipeline}
-     */
-    default Pipeline getPipeline() {
-        throw new UnsupportedOperationException("Not implemented.");
-    }
-
-    /**
      * Processes the input and converts it to NDList.
      *
      * @param ctx the toolkit for creating the input NDArray


### PR DESCRIPTION
The pipeline is not a universal part of the PreProcessor and is rarely used. So,
it shouldn't be part of the main API but could be used by various
implementations.

This also cleans up the InstanceSegmentationTranslator a bit. It no longer
creates a new pipeline every time preprocess is called but uses a single
pipeline. It also no longer extends Transform but moves the necessary Transform
functionality to a nested class. Making it extend transform is odd and
potentially confusing, while the separation helps clarify the purpose of the
Transform.