### PR TITLE
[api] NDArray creation should not use alternative engine by default

### DIFF
--- a/api/src/main/java/ai/djl/inference/Predictor.java
+++ b/api/src/main/java/ai/djl/inference/Predictor.java
@@ -83,7 +83,7 @@ public class Predictor<I, O> implements AutoCloseable {
 
     private boolean prepared;
     private Model model;
-    private NDManager manager;
+    protected NDManager manager;
     Metrics metrics;
     protected Block block;
     protected ParameterStore parameterStore;

--- a/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
@@ -60,16 +60,6 @@ public abstract class BaseNDManager implements NDManager {
         return getEngine().defaultDevice();
     }
 
-    /**
-     * Creates a new instance of {@link NDArray} of current engine.
-     *
-     * @param data the data to initialize the {@code NDArray}
-     * @param shape the {@link Shape} of the {@code NDArray}
-     * @param dataType the {@link DataType} of the {@code NDArray}
-     * @return a new instance of {@code NDArray}
-     */
-    public abstract NDArray createDirect(Buffer data, Shape shape, DataType dataType);
-
     /** {@inheritDoc} */
     @Override
     public NDArray create(String data) {
@@ -129,7 +119,7 @@ public abstract class BaseNDManager implements NDManager {
     public NDArray zeros(Shape shape, DataType dataType) {
         int size = (int) shape.size();
         ByteBuffer bb = allocateDirect(size * dataType.getNumOfBytes());
-        return createDirect(bb, shape, dataType);
+        return create(bb, shape, dataType);
     }
 
     /** {@inheritDoc} */
@@ -164,7 +154,7 @@ public abstract class BaseNDManager implements NDManager {
             }
         }
         bb.rewind();
-        return createDirect(bb, shape, dataType);
+        return create(bb, shape, dataType);
     }
 
     /** {@inheritDoc} */

--- a/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
@@ -1037,8 +1037,9 @@ public abstract class NDArrayAdapter implements NDArray {
         }
         if (alternativeArray == null) {
             alternativeArray = alternativeManager.from(this);
+        } else {
+            alternativeArray.set(getDataType().asDataType(toByteBuffer()));
         }
-        alternativeArray.set(getDataType().asDataType(toByteBuffer()));
         return alternativeArray;
     }
 }

--- a/docs/hybrid_engine.md
+++ b/docs/hybrid_engine.md
@@ -42,11 +42,9 @@ runtimeOnly "ai.djl.tensorflow:tensorflow-native-auto:2.4.1"
 
 Internally, DJL will find two or more engines available. When you start using the hybrid engine,
 DJL will search for additional full Engines. Whenever an unsupported NDArray operation is invoked,
-it will delegate to alternative full engine to run the operation. By default, the NDArray is
-created in alternative engine if possible. You can use `NDManager.createDirect()` to force and
-NDArray to be created in hybrid engine. If you don't need preprocessing/postprocessing and trying
-to avoid accidentally memory copy, you can disable this behavior by setting the following system
-properties:
+it will delegate to alternative full engine to run the operation.
+If you don't need preprocessing/postprocessing and trying to avoid loading another engine
+at runtime, you can disable this behavior by setting the following system properties:
 
 ```
 # disable hybrid engine for OnnxRuntime

--- a/engines/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrNDArray.java
+++ b/engines/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrNDArray.java
@@ -33,9 +33,15 @@ public class DlrNDArray extends NDArrayAdapter {
      * @param alternativeManager the alternative manager to execute unsupported operation
      * @param data the underlying data
      * @param shape the shape of {@code DlrNDArray}
+     * @param dataType the {@link DataType} of the {@link NDArray}
      */
-    DlrNDArray(DlrNDManager manager, NDManager alternativeManager, ByteBuffer data, Shape shape) {
-        super(manager, alternativeManager, shape, DataType.FLOAT32, UUID.randomUUID().toString());
+    DlrNDArray(
+            DlrNDManager manager,
+            NDManager alternativeManager,
+            ByteBuffer data,
+            Shape shape,
+            DataType dataType) {
+        super(manager, alternativeManager, shape, dataType, UUID.randomUUID().toString());
         this.data = data;
         manager.attachInternal(uid, this);
     }

--- a/engines/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrPredictor.java
+++ b/engines/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrPredictor.java
@@ -36,7 +36,7 @@ public class DlrPredictor<I, O> extends Predictor<I, O> {
             DlrModel model, String modelDir, Device device, Translator<I, O> translator) {
         super(model, translator, false);
         long modelHandle = JniUtils.createDlrModel(modelDir, device);
-        block = new DlrSymbolBlock(modelHandle);
+        block = new DlrSymbolBlock((DlrNDManager) manager, modelHandle);
         // disable cpu affinity by default
         JniUtils.useDlrCpuAffinity(modelHandle, false);
     }

--- a/engines/dlr/dlr-engine/src/main/java/ai/djl/dlr/jni/JniUtils.java
+++ b/engines/dlr/dlr-engine/src/main/java/ai/djl/dlr/jni/JniUtils.java
@@ -13,7 +13,7 @@
 package ai.djl.dlr.jni;
 
 import ai.djl.Device;
-import ai.djl.ndarray.NDArray;
+import ai.djl.dlr.engine.DlrNDArray;
 import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.types.Shape;
@@ -27,7 +27,7 @@ public final class JniUtils {
 
     private JniUtils() {}
 
-    public static void setDlrInput(long modelHandle, NDArray input, int index) {
+    public static void setDlrInput(long modelHandle, DlrNDArray input, int index) {
         long[] shape = input.getShape().getShape();
         float[] data = input.toFloatArray();
         String name = DlrLibrary.LIB.getDlrInputName(modelHandle, index);

--- a/engines/dlr/dlr-engine/src/test/java/ai/djl/dlr/engine/DlrNDManagerTest.java
+++ b/engines/dlr/dlr-engine/src/test/java/ai/djl/dlr/engine/DlrNDManagerTest.java
@@ -45,7 +45,7 @@ public class DlrNDManagerTest {
             bb.asFloatBuffer().put(buf);
             bb.rewind();
 
-            NDArray dlrArray = manager.createDirect(bb, new Shape(4), DataType.FLOAT32);
+            NDArray dlrArray = manager.create(bb, new Shape(4), DataType.FLOAT32);
             Assert.assertEquals(dlrArray.toFloatArray(), buf);
         }
     }

--- a/engines/ml/xgboost/src/main/java/ai/djl/ml/xgboost/XgbNDArray.java
+++ b/engines/ml/xgboost/src/main/java/ai/djl/ml/xgboost/XgbNDArray.java
@@ -42,8 +42,13 @@ public class XgbNDArray extends NDArrayAdapter {
         manager.attachInternal(uid, this);
     }
 
-    XgbNDArray(NDManager manager, NDManager alternativeManager, ByteBuffer data, Shape shape) {
-        super(manager, alternativeManager, shape, DataType.FLOAT32, UUID.randomUUID().toString());
+    XgbNDArray(
+            NDManager manager,
+            NDManager alternativeManager,
+            ByteBuffer data,
+            Shape shape,
+            DataType dataType) {
+        super(manager, alternativeManager, shape, dataType, UUID.randomUUID().toString());
         this.data = data;
         this.format = SparseFormat.DENSE;
         manager.attachInternal(uid, this);
@@ -51,6 +56,10 @@ public class XgbNDArray extends NDArrayAdapter {
 
     /** {@inheritDoc} */
     public long getHandle() {
+        if (handle == null) {
+            throw new UnsupportedOperationException(
+                    "XgbNDArray only support float32 and shape must be in two dimension.");
+        }
         return handle.get();
     }
 

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
@@ -299,10 +299,7 @@ public class MxNDArray extends NativeResource<Pointer> implements LazyNDArray {
             return;
         }
 
-        // int8, uint8, boolean use ByteBuffer, so need to explicitly input DataType
         DataType inputType = DataType.fromBuffer(data);
-        validate(inputType);
-
         ByteBuffer buf = manager.allocateDirect(size * inputType.getNumOfBytes());
         BaseNDManager.copyBuffer(data, buf);
         JnaUtils.syncCopyFromCPU(getHandle(), buf, size);
@@ -1514,17 +1511,6 @@ public class MxNDArray extends NativeResource<Pointer> implements LazyNDArray {
 
     private int withAxis(int axis) {
         return Math.floorMod(axis, getShape().dimension());
-    }
-
-    private void validate(DataType inputType) {
-        if (getDataType() != inputType
-                && ((dataType != DataType.UINT8 && dataType != DataType.BOOLEAN)
-                        || inputType != DataType.INT8)) {
-            // Infer DataType from Buffer always return INT8, make this two special case that
-            // allows set UINT8 and BOOL array with regular ByteBuffer.
-            throw new IllegalStateException(
-                    "DataType mismatch, required: " + dataType + ", actual: " + inputType);
-        }
     }
 
     /** {@inheritDoc} */

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDManager.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDManager.java
@@ -73,14 +73,6 @@ public class MxNDManager extends BaseNDManager {
         return ret;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public MxNDArray createDirect(Buffer data, Shape shape, DataType dataType) {
-        MxNDArray ret = create(shape, dataType);
-        ret.set(data);
-        return ret;
-    }
-
     /**
      * Creates an MxNDArray with the given Native Memory Pointer and attaches to this manager.
      *

--- a/engines/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtNDManager.java
+++ b/engines/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtNDManager.java
@@ -57,7 +57,7 @@ public class OrtNDManager extends BaseNDManager {
         if (array instanceof OrtNDArray) {
             return (OrtNDArray) array;
         }
-        return createDirect(array.toByteBuffer(), array.getShape(), array.getDataType());
+        return create(array.toByteBuffer(), array.getShape(), array.getDataType());
     }
 
     OrtNDArray createInternal(OnnxTensor tensor) {
@@ -66,20 +66,11 @@ public class OrtNDManager extends BaseNDManager {
 
     /** {@inheritDoc} */
     @Override
-    public OrtNDArray createDirect(Buffer data, Shape shape, DataType dataType) {
+    public OrtNDArray create(Buffer data, Shape shape, DataType dataType) {
         int size = Math.toIntExact(shape.size());
         BaseNDManager.validateBufferSize(data, dataType, size);
         OnnxTensor tensor = OrtUtils.toTensor(env, data, shape, dataType);
         return new OrtNDArray(this, alternativeManager, tensor);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public NDArray create(Buffer data, Shape shape, DataType dataType) {
-        if (alternativeManager != null) {
-            return alternativeManager.create(data, shape, dataType);
-        }
-        return createDirect(data, shape, dataType);
     }
 
     /** {@inheritDoc} */

--- a/engines/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtSymbolBlock.java
+++ b/engines/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtSymbolBlock.java
@@ -82,13 +82,14 @@ public class OrtSymbolBlock extends AbstractSymbolBlock implements AutoCloseable
         }
 
         Map<String, OnnxTensor> container = new ConcurrentHashMap<>();
-        // feed data in to match names
-        for (int i = 0; i < inputNames.size(); ++i) {
-            OrtNDArray ortNDArray = manager.from(inputs.get(i));
-            container.put(inputNames.get(i), ortNDArray.getTensor());
-        }
         // forward
-        try {
+        try (OrtNDManager sub = (OrtNDManager) manager.newSubManager()) {
+            // feed data in to match names
+            for (int i = 0; i < inputNames.size(); ++i) {
+                OrtNDArray ortNDArray = sub.from(inputs.get(i));
+                container.put(inputNames.get(i), ortNDArray.getTensor());
+            }
+
             OrtSession.Result results = session.run(container);
             NDList ret = evaluateOutput(results);
             ret.attach(inputs.head().getManager());

--- a/engines/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpDataType.java
+++ b/engines/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpDataType.java
@@ -29,9 +29,9 @@ public final class PpDataType {
         map.put(DataType.FLOAT32, 0);
         map.put(DataType.INT64, 1);
         map.put(DataType.INT32, 2);
-        map.put(DataType.INT8, 3);
         map.put(DataType.UINT8, 3);
-        map.put(DataType.UNKNOWN, 4);
+        map.put(DataType.INT8, 4);
+        map.put(DataType.FLOAT16, 5);
         return map;
     }
 
@@ -40,8 +40,9 @@ public final class PpDataType {
         map.put(0, DataType.FLOAT32);
         map.put(1, DataType.INT64);
         map.put(2, DataType.INT32);
-        map.put(3, DataType.INT8);
-        map.put(4, DataType.UNKNOWN);
+        map.put(3, DataType.UINT8);
+        map.put(4, DataType.INT8);
+        map.put(5, DataType.FLOAT16);
         return map;
     }
 

--- a/engines/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpNDManager.java
+++ b/engines/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpNDManager.java
@@ -72,7 +72,7 @@ public class PpNDManager extends BaseNDManager {
         if (array instanceof PpNDArray) {
             return (PpNDArray) array;
         }
-        return createDirect(array.toByteBuffer(), array.getShape(), array.getDataType());
+        return create(array.toByteBuffer(), array.getShape(), array.getDataType());
     }
 
     /**
@@ -90,7 +90,7 @@ public class PpNDManager extends BaseNDManager {
 
     /** {@inheritDoc} */
     @Override
-    public PpNDArray createDirect(Buffer data, Shape shape, DataType dataType) {
+    public PpNDArray create(Buffer data, Shape shape, DataType dataType) {
         int size = Math.toIntExact(shape.size());
         BaseNDManager.validateBufferSize(data, dataType, size);
         if (data.isDirect() && data instanceof ByteBuffer) {
@@ -99,15 +99,6 @@ public class PpNDManager extends BaseNDManager {
         ByteBuffer buf = allocateDirect(size * dataType.getNumOfBytes());
         copyBuffer(data, buf);
         return JniUtils.createNdArray(this, buf, shape, dataType);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public NDArray create(Buffer data, Shape shape, DataType dataType) {
-        if (alternativeManager != null) {
-            return alternativeManager.create(data, shape, dataType);
-        }
-        return createDirect(data, shape, dataType);
     }
 
     /** {@inheritDoc} */

--- a/engines/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpSymbolBlock.java
+++ b/engines/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpSymbolBlock.java
@@ -53,19 +53,22 @@ public class PpSymbolBlock extends AbstractSymbolBlock {
             throw new IllegalArgumentException(
                     "Input number mismatch, requires: " + Arrays.toString(inputNames));
         }
-        NDList output = JniUtils.predictorForward(predictor, getInputs(inputs), inputNames);
-        NDManager inputManager = inputs.head().getManager();
-        NDList ret = new NDList();
-        for (NDArray array : output) {
-            ret.add(inputManager.from(array));
+        try (PpNDManager sub = manager.newSubManager()) {
+            NDList output =
+                    JniUtils.predictorForward(predictor, getInputs(sub, inputs), inputNames);
+            NDManager inputManager = inputs.head().getManager();
+            NDList ret = new NDList();
+            for (NDArray array : output) {
+                ret.add(inputManager.from(array));
+            }
+            return ret;
         }
-        return ret;
     }
 
-    private PpNDArray[] getInputs(NDList inputs) {
+    private PpNDArray[] getInputs(PpNDManager sub, NDList inputs) {
         PpNDArray[] inputArray = new PpNDArray[inputs.size()];
         for (int i = 0; i < inputArray.length; i++) {
-            inputArray[i] = manager.from(inputs.get(i));
+            inputArray[i] = sub.from(inputs.get(i));
         }
         return inputArray;
     }

--- a/engines/paddlepaddle/paddlepaddle-model-zoo/src/main/java/ai/djl/paddlepaddle/zoo/cv/objectdetection/PpFaceDetectionTranslator.java
+++ b/engines/paddlepaddle/paddlepaddle-model-zoo/src/main/java/ai/djl/paddlepaddle/zoo/cv/objectdetection/PpFaceDetectionTranslator.java
@@ -65,7 +65,7 @@ public class PpFaceDetectionTranslator implements Translator<Image, DetectedObje
                         array, (int) (shape.get(1) * shrink), (int) (shape.get(0) * shrink));
         array = array.transpose(2, 0, 1).flip(0); // HWC -> CHW RGB -> BGR
         NDArray mean =
-                ctx.getNDManager().create(new float[] {104f, 117f, 123f}, new Shape(3, 1, 1));
+                array.getManager().create(new float[] {104f, 117f, 123f}, new Shape(3, 1, 1));
         array = array.sub(mean).mul(0.007843f); // normalization
         array = array.expandDims(0); // make batch dimension
         return new NDList(array);

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -172,7 +172,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
         // To align with MXNet's behavior, we will create a zeros NDArray.
         // TODO should we access the grad NDArray after we close the parameter NDArray?
         if (res == null) {
-            res = (PtNDArray) getManager().zeros(getShape());
+            res = (PtNDArray) manager.zeros(getShape());
         }
         return res;
     }
@@ -280,10 +280,10 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
         Shape indexShape = index.getShape();
         if (indexShape.equals(getShape())) {
             // Result is flattened since shape is undetermined
-            return JniUtils.booleanMask(this, (PtNDArray) index);
+            return JniUtils.booleanMask(this, manager.from(index));
         } else if (indexShape.equals(getShape().slice(axis))) {
             // index will be broadcasted by default
-            try (PtNDArray flattedResult = JniUtils.booleanMask(this, (PtNDArray) index)) {
+            try (PtNDArray flattedResult = JniUtils.booleanMask(this, manager.from(index))) {
                 // Shape recovery
                 Shape remainder = getShape().slice(0, axis);
                 long selectedSize = flattedResult.getShape().size() / remainder.size();
@@ -325,7 +325,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
         if (getDataType() != other.getDataType()) {
             return false;
         }
-        return JniUtils.contentEqual(this, (PtNDArray) other);
+        return JniUtils.contentEqual(this, manager.from(other));
     }
 
     /** {@inheritDoc} */
@@ -339,7 +339,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray eq(NDArray other) {
-        return JniUtils.eq(this, (PtNDArray) other);
+        return JniUtils.eq(this, manager.from(other));
     }
 
     /** {@inheritDoc} */
@@ -353,7 +353,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray neq(NDArray other) {
-        return JniUtils.neq(this, (PtNDArray) other);
+        return JniUtils.neq(this, manager.from(other));
     }
 
     /** {@inheritDoc} */
@@ -367,7 +367,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray gt(NDArray other) {
-        return JniUtils.gt(this, (PtNDArray) other);
+        return JniUtils.gt(this, manager.from(other));
     }
 
     /** {@inheritDoc} */
@@ -381,7 +381,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray gte(NDArray other) {
-        return JniUtils.gte(this, (PtNDArray) other);
+        return JniUtils.gte(this, manager.from(other));
     }
 
     /** {@inheritDoc} */
@@ -395,7 +395,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray lt(NDArray other) {
-        return JniUtils.lt(this, (PtNDArray) other);
+        return JniUtils.lt(this, manager.from(other));
     }
 
     /** {@inheritDoc} */
@@ -409,7 +409,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray lte(NDArray other) {
-        return JniUtils.lte(this, (PtNDArray) other);
+        return JniUtils.lte(this, manager.from(other));
     }
 
     /** {@inheritDoc} */
@@ -423,7 +423,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray add(NDArray other) {
-        return JniUtils.add(this, (PtNDArray) other);
+        return JniUtils.add(this, manager.from(other));
     }
 
     /** {@inheritDoc} */
@@ -437,7 +437,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray sub(NDArray other) {
-        return JniUtils.sub(this, (PtNDArray) other);
+        return JniUtils.sub(this, manager.from(other));
     }
 
     /** {@inheritDoc} */
@@ -451,7 +451,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray mul(NDArray other) {
-        return JniUtils.mul(this, (PtNDArray) other);
+        return JniUtils.mul(this, manager.from(other));
     }
 
     /** {@inheritDoc} */
@@ -465,7 +465,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray div(NDArray other) {
-        return JniUtils.div(this, (PtNDArray) other);
+        return JniUtils.div(this, manager.from(other));
     }
 
     /** {@inheritDoc} */
@@ -479,7 +479,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray mod(NDArray other) {
-        return JniUtils.remainder(this, (PtNDArray) other);
+        return JniUtils.remainder(this, manager.from(other));
     }
 
     /** {@inheritDoc} */
@@ -493,7 +493,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray pow(NDArray other) {
-        return JniUtils.pow(this, (PtNDArray) other);
+        return JniUtils.pow(this, manager.from(other));
     }
 
     /** {@inheritDoc} */
@@ -507,7 +507,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray addi(NDArray other) {
-        JniUtils.addi(this, (PtNDArray) other);
+        JniUtils.addi(this, manager.from(other));
         return this;
     }
 
@@ -522,7 +522,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray subi(NDArray other) {
-        JniUtils.subi(this, (PtNDArray) other);
+        JniUtils.subi(this, manager.from(other));
         return this;
     }
 
@@ -537,7 +537,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray muli(NDArray other) {
-        JniUtils.muli(this, (PtNDArray) other);
+        JniUtils.muli(this, manager.from(other));
         return this;
     }
 
@@ -552,7 +552,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray divi(NDArray other) {
-        JniUtils.divi(this, (PtNDArray) other);
+        JniUtils.divi(this, manager.from(other));
         return this;
     }
 
@@ -567,7 +567,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray modi(NDArray other) {
-        JniUtils.remainderi(this, (PtNDArray) other);
+        JniUtils.remainderi(this, manager.from(other));
         return this;
     }
 
@@ -582,7 +582,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray powi(NDArray other) {
-        JniUtils.powi(this, (PtNDArray) other);
+        JniUtils.powi(this, manager.from(other));
         return this;
     }
 
@@ -610,7 +610,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray maximum(NDArray other) {
-        return JniUtils.max(this, (PtNDArray) other);
+        return JniUtils.max(this, manager.from(other));
     }
 
     /** {@inheritDoc} */
@@ -624,7 +624,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray minimum(NDArray other) {
-        return JniUtils.min(this, (PtNDArray) other);
+        return JniUtils.min(this, manager.from(other));
     }
 
     /** {@inheritDoc} */
@@ -685,7 +685,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray cbrt() {
-        return JniUtils.pow(this, (PtNDArray) getManager().create(1.0 / 3));
+        return JniUtils.pow(this, (PtNDArray) manager.create(1.0 / 3));
     }
 
     /** {@inheritDoc} */
@@ -994,19 +994,19 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public PtNDArray logicalAnd(NDArray other) {
-        return JniUtils.logicalAnd(this, (PtNDArray) other);
+        return JniUtils.logicalAnd(this, manager.from(other));
     }
 
     /** {@inheritDoc} */
     @Override
     public PtNDArray logicalOr(NDArray other) {
-        return JniUtils.logicalOr(this, (PtNDArray) other);
+        return JniUtils.logicalOr(this, manager.from(other));
     }
 
     /** {@inheritDoc} */
     @Override
     public PtNDArray logicalXor(NDArray other) {
-        return JniUtils.logicalXor(this, (PtNDArray) other);
+        return JniUtils.logicalXor(this, manager.from(other));
     }
 
     /** {@inheritDoc} */
@@ -1191,7 +1191,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
             throw new UnsupportedOperationException(
                     "Dimension mismatch or high dimensional dot operation is not supported. Please use .matMul instead.");
         }
-        return JniUtils.dot(this, (PtNDArray) other);
+        return JniUtils.dot(this, manager.from(other));
     }
 
     /** {@inheritDoc} */
@@ -1200,7 +1200,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
         if (isScalar() || other.isScalar()) {
             throw new IllegalArgumentException("scalar is not allowed for matMul()");
         }
-        return JniUtils.matmul(this, (PtNDArray) other);
+        return JniUtils.matmul(this, manager.from(other));
     }
 
     /** {@inheritDoc} */

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDManager.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDManager.java
@@ -55,7 +55,13 @@ public class PtNDManager extends BaseNDManager {
 
     /** {@inheritDoc} */
     @Override
-    public PtNDArray createDirect(Buffer data, Shape shape, DataType dataType) {
+    public PtNDArray create(Shape shape, DataType dataType) {
+        return JniUtils.createEmptyNdArray(this, shape, dataType, device, SparseFormat.DENSE);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public PtNDArray create(Buffer data, Shape shape, DataType dataType) {
         int size = Math.toIntExact(shape.size());
         BaseNDManager.validateBufferSize(data, dataType, size);
         if (data.isDirect() && data instanceof ByteBuffer) {
@@ -66,18 +72,6 @@ public class PtNDManager extends BaseNDManager {
         copyBuffer(data, buf);
         return JniUtils.createNdFromByteBuffer(
                 this, buf, shape, dataType, SparseFormat.DENSE, device);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public PtNDArray create(Shape shape, DataType dataType) {
-        return JniUtils.createEmptyNdArray(this, shape, dataType, device, SparseFormat.DENSE);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public PtNDArray create(Buffer data, Shape shape, DataType dataType) {
-        return createDirect(data, shape, dataType);
     }
 
     /** {@inheritDoc} */

--- a/engines/tensorrt/src/main/java/ai/djl/tensorrt/engine/TrtNDManager.java
+++ b/engines/tensorrt/src/main/java/ai/djl/tensorrt/engine/TrtNDManager.java
@@ -58,7 +58,7 @@ public class TrtNDManager extends BaseNDManager {
         if (array instanceof TrtNDArray) {
             return (TrtNDArray) array;
         }
-        return createDirect(array.toByteBuffer(), array.getShape(), array.getDataType());
+        return create(array.toByteBuffer(), array.getShape(), array.getDataType());
     }
 
     /** {@inheritDoc} */
@@ -69,16 +69,9 @@ public class TrtNDManager extends BaseNDManager {
         return manager;
     }
 
-    /**
-     * Creates a new instance of {@link TrtNDArray}.
-     *
-     * @param data the data to initialize the {@code TrtNDArray}
-     * @param shape the {@link Shape} of the {@code TrtNDArray}
-     * @param dataType the {@link DataType} of the {@code TrtNDArray}
-     * @return a new instance of {@code TrtNDArray}
-     */
+    /** {@inheritDoc} */
     @Override
-    public TrtNDArray createDirect(Buffer data, Shape shape, DataType dataType) {
+    public TrtNDArray create(Buffer data, Shape shape, DataType dataType) {
         int size = Math.toIntExact(shape.size());
         BaseNDManager.validateBufferSize(data, dataType, size);
         if (data.isDirect() && data instanceof ByteBuffer) {
@@ -92,19 +85,10 @@ public class TrtNDManager extends BaseNDManager {
 
     /** {@inheritDoc} */
     @Override
-    public NDArray create(Buffer data, Shape shape, DataType dataType) {
-        if (alternativeManager != null) {
-            return alternativeManager.create(data, shape, dataType);
-        }
-        return createDirect(data, shape, dataType);
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public NDArray zeros(Shape shape, DataType dataType) {
         int size = Math.toIntExact(dataType.getNumOfBytes() * shape.size());
         ByteBuffer bb = allocateDirect(size);
-        return createDirect(bb, shape, dataType);
+        return create(bb, shape, dataType);
     }
 
     /** {@inheritDoc} */
@@ -139,7 +123,7 @@ public class TrtNDManager extends BaseNDManager {
             }
         }
         bb.rewind();
-        return createDirect(bb, shape, dataType);
+        return create(bb, shape, dataType);
     }
 
     /** The SystemManager is the root {@link TrtNDManager} of which all others are children. */

--- a/engines/tensorrt/src/main/java/ai/djl/tensorrt/engine/TrtSession.java
+++ b/engines/tensorrt/src/main/java/ai/djl/tensorrt/engine/TrtSession.java
@@ -49,7 +49,7 @@ public class TrtSession extends AbstractBlock implements AutoCloseable {
             int size = Math.toIntExact(inputShapes[i].size() * inputTypes[i].getNumOfBytes());
             ByteBuffer bb = manager.allocateDirect(size);
             JniUtils.bind(session, inputName, bb);
-            NDArray array = manager.createDirect(bb, inputShapes[i], inputTypes[i]);
+            NDArray array = manager.create(bb, inputShapes[i], inputTypes[i]);
             array.setName(inputName);
             inputBindings.add(array);
         }
@@ -63,7 +63,7 @@ public class TrtSession extends AbstractBlock implements AutoCloseable {
             int size = Math.toIntExact(outputShapes[i].size() * outputTypes[i].getNumOfBytes());
             ByteBuffer bb = manager.allocateDirect(size);
             JniUtils.bind(session, outputNames[i], bb);
-            NDArray array = manager.createDirect(bb, outputShapes[i], outputTypes[i]);
+            NDArray array = manager.create(bb, outputShapes[i], outputTypes[i]);
             array.setName(outputNames[i]);
             outputBindings.add(array);
         }

--- a/engines/tflite/tflite-engine/src/main/java/ai/djl/tflite/engine/TfLiteNDManager.java
+++ b/engines/tflite/tflite-engine/src/main/java/ai/djl/tflite/engine/TfLiteNDManager.java
@@ -52,7 +52,7 @@ public class TfLiteNDManager extends BaseNDManager {
         if (array instanceof TfLiteNDArray) {
             return (TfLiteNDArray) array;
         }
-        return createDirect(array.toByteBuffer(), array.getShape(), array.getDataType());
+        return create(array.toByteBuffer(), array.getShape(), array.getDataType());
     }
 
     TfLiteNDArray createInternal(Tensor tensor) {
@@ -61,7 +61,7 @@ public class TfLiteNDManager extends BaseNDManager {
 
     /** {@inheritDoc} */
     @Override
-    public TfLiteNDArray createDirect(Buffer data, Shape shape, DataType dataType) {
+    public TfLiteNDArray create(Buffer data, Shape shape, DataType dataType) {
         int size = Math.toIntExact(shape.size());
         BaseNDManager.validateBufferSize(data, dataType, size);
         if (data.isDirect() && data instanceof ByteBuffer) {
@@ -71,15 +71,6 @@ public class TfLiteNDManager extends BaseNDManager {
         ByteBuffer buf = allocateDirect(size * dataType.getNumOfBytes());
         copyBuffer(data, buf);
         return new TfLiteNDArray(this, alternativeManager, buf, shape, dataType);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public NDArray create(Buffer data, Shape shape, DataType dataType) {
-        if (alternativeManager != null) {
-            return alternativeManager.create(data, shape, dataType);
-        }
-        return createDirect(data, shape, dataType);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Change-Id: I269de88ca49f9042813f576a0c00586d3984ac92

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
