### PR TITLE
[api] Use engine specific split()

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
@@ -706,6 +706,12 @@ public abstract class NDArrayAdapter implements NDArray {
 
     /** {@inheritDoc} */
     @Override
+    public NDList split(long sections, int axis) {
+        return getAlternativeArray().split(sections, axis);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public NDList split(long[] indices, int axis) {
         return getAlternativeArray().split(indices, axis);
     }


### PR DESCRIPTION
Change-Id: I428826df885e1742c7776d840ec5692d2422ee34

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
