### PR TITLE
[ci] PyTorch 1.9.1 requires glibc 2.27, no longer support AL2

### DIFF
--- a/.github/workflows/native_jni_s3_pytorch.yml
+++ b/.github/workflows/native_jni_s3_pytorch.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ macos-latest, windows-latest ]
+        operating-system: [ macos-latest, ubuntu-18.04, windows-latest ]
 
     steps:
       - uses: actions/checkout@v2
@@ -37,45 +37,6 @@ jobs:
           aws-region: us-east-2
       - name: Copy files to S3 with the AWS CLI
         shell: bash
-        run: |
-          PYTORCH_VERSION="$(cat gradle.properties | awk -F '=' '/pytorch_version/ {print $2}')"
-          aws s3 sync engines/pytorch/pytorch-native/jnilib s3://djl-ai/publish/pytorch-${PYTORCH_VERSION}/jnilib
-          aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/pytorch-${PYTORCH_VERSION}/jnilib*"
-
-  build-pytorch-jni-linux-cpu:
-    if: github.repository == 'deepjavalibrary/djl'
-    runs-on: ubuntu-latest
-    container: amazonlinux:2
-    steps:
-      - name: Install Environment
-        run: |
-          yum -y update
-          yum -y groupinstall "Development Tools"
-          yum -y install patch cmake3
-          ln -sf /usr/bin/cmake3 /usr/bin/cmake
-          pip3 install awscli --upgrade
-      - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-      - uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-      - name: Release JNI prep
-        run: |
-          ./gradlew :engines:pytorch:pytorch-native:releaseJNI
-          ./gradlew -Pjni :integration:test "-Dai.djl.default_engine=PyTorch"
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
-      - name: Copy files to S3 with the AWS CLI
         run: |
           PYTORCH_VERSION="$(cat gradle.properties | awk -F '=' '/pytorch_version/ {print $2}')"
           aws s3 sync engines/pytorch/pytorch-native/jnilib s3://djl-ai/publish/pytorch-${PYTORCH_VERSION}/jnilib


### PR DESCRIPTION
Change-Id: I86eff6139a38544f98db3ee9ab9af0df7a972f47

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
