### PR TITLE
[pytorch] Implement padding to bert tokenizer

### DIFF
--- a/engines/pytorch/pytorch-model-zoo/src/main/java/ai/djl/pytorch/zoo/nlp/qa/PtBertQATranslator.java
+++ b/engines/pytorch/pytorch-model-zoo/src/main/java/ai/djl/pytorch/zoo/nlp/qa/PtBertQATranslator.java
@@ -62,7 +62,12 @@ public class PtBertQATranslator extends QATranslator {
             question = question.toLowerCase(locale);
             paragraph = paragraph.toLowerCase(locale);
         }
-        BertToken token = tokenizer.encode(question, paragraph);
+        BertToken token;
+        if (padding) {
+            token = tokenizer.encode(question, paragraph, maxLength);
+        } else {
+            token = tokenizer.encode(question, paragraph);
+        }
         tokens = token.getTokens();
         NDManager manager = ctx.getNDManager();
         long[] indices = tokens.stream().mapToLong(vocabulary::getIndex).toArray();


### PR DESCRIPTION
Change-Id: I033baaaa1753570e62e11d2096c6ef03cd1aa48f

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
