### PR TITLE
Make BufferedImageFactory.fromNDArray synchronous

### DIFF
--- a/api/src/main/java/ai/djl/modality/cv/BufferedImageFactory.java
+++ b/api/src/main/java/ai/djl/modality/cv/BufferedImageFactory.java
@@ -108,7 +108,6 @@ public class BufferedImageFactory extends ImageFactory {
             BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
             int[] raw = array.toUint8Array();
             IntStream.range(0, imageArea)
-                    .parallel()
                     .forEach(
                             ele -> {
                                 int x = ele % width;
@@ -127,7 +126,6 @@ public class BufferedImageFactory extends ImageFactory {
             BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
             int[] raw = array.toUint8Array();
             IntStream.range(0, imageArea)
-                    .parallel()
                     .forEach(
                             ele -> {
                                 int x = ele % width;


### PR DESCRIPTION
I made this PR based on this [comment](https://github.com/deepjavalibrary/djl/issues/1278#issuecomment-957994060) by @steinhae in #1278.

I also ran a quick experiment to verify the findings:

```java
try (NDManager manager = NDManager.newBaseManager()) {
  NDArray array = manager.randomInteger(0, 255, new Shape(3, 400, 400), DataType.INT32).toType(DataType.UINT8, true);
  ImageFactory factory = ImageFactory.getInstance();
  for (int i=0; i<5000; i++) {
      factory.fromNDArray(array);
  }
}
```

Found that this change would reduce the time to run this test from about 62 seconds to about 22 seconds.
