### PR TITLE
LayerNorm for MXNet

### DIFF
--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayEx.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayEx.java
@@ -652,9 +652,10 @@ class MxNDArrayEx implements NDArrayEx {
                                                 input.getShape()
                                                         .slice(
                                                                 0,
-                                                                (input.getShape().dimension()
-                                                                        - normalizedShape
-                                                                                .dimension()))
+                                                                Math.toIntExact(
+                                                                        input.getShape().dimension()
+                                                                                - normalizedShape
+                                                                                        .dimension()))
                                                         .add(normalizedShape.size())),
                                         gamma.reshape(normalizedShape.size()),
                                         beta.reshape(normalizedShape.size())),

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayEx.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayEx.java
@@ -643,20 +643,22 @@ class MxNDArrayEx implements NDArrayEx {
         params.addParam("axis", -1);
         params.addParam("eps", eps);
 
+        NDArray reshapedInput =
+                input.reshape(
+                        input.getShape()
+                                .slice(
+                                        0,
+                                        Math.toIntExact(
+                                                input.getShape().dimension()
+                                                        - normalizedShape.dimension()))
+                                .add(normalizedShape.size()));
+
         return new NDList(
                 getManager()
                         .invoke(
                                 "_npx_layer_norm",
                                 new NDList(
-                                        input.reshape(
-                                                input.getShape()
-                                                        .slice(
-                                                                0,
-                                                                Math.toIntExact(
-                                                                        input.getShape().dimension()
-                                                                                - normalizedShape
-                                                                                        .dimension()))
-                                                        .add(normalizedShape.size())),
+                                        reshapedInput,
                                         gamma.reshape(normalizedShape.size()),
                                         beta.reshape(normalizedShape.size())),
                                 params)

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayEx.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayEx.java
@@ -639,39 +639,28 @@ class MxNDArrayEx implements NDArrayEx {
     public NDList layerNorm(
             NDArray input, Shape normalizedShape, NDArray gamma, NDArray beta, float eps) {
 
-        Shape originalShape = input.getShape();
-
-        long normalizedShapeSize = normalizedShape.size();
-
-        long inputShapeDims = input.getShape().dimension();
-        long normalizedShapeDims = normalizedShape.dimension();
-
-        long tempDims = inputShapeDims - normalizedShapeDims + 1;
-        long[] tempShapeRaw = new long[(int) tempDims];
-        for (int d = 0; d < tempDims - 1; d++) {
-            tempShapeRaw[d] = input.getShape().get(d);
-        }
-        tempShapeRaw[(int) tempDims - 1] = normalizedShapeSize;
-        Shape tempShape = new Shape(tempShapeRaw);
-
-        NDArray reshapedInput = input.reshape(tempShape);
-        NDArray reshapedGamma = gamma.reshape(normalizedShape.size());
-        NDArray reshapedBeta = beta.reshape(normalizedShape.size());
-
         MxOpParams params = new MxOpParams();
         params.addParam("axis", -1);
         params.addParam("eps", eps);
 
-        NDList list =
+        return new NDList(
                 getManager()
                         .invoke(
                                 "_npx_layer_norm",
-                                new NDList(reshapedInput, reshapedGamma, reshapedBeta),
-                                params);
-
-        NDArray a = list.get(0);
-        NDArray b = a.reshape(originalShape);
-        return new NDList(b);
+                                new NDList(
+                                        input.reshape(
+                                                input.getShape()
+                                                        .slice(
+                                                                0,
+                                                                (input.getShape().dimension()
+                                                                        - normalizedShape
+                                                                                .dimension()))
+                                                        .add(normalizedShape.size())),
+                                        gamma.reshape(normalizedShape.size()),
+                                        beta.reshape(normalizedShape.size())),
+                                params)
+                        .get(0)
+                        .reshape(input.getShape()));
     }
 
     /** {@inheritDoc} */

--- a/integration/src/main/java/ai/djl/integration/tests/nn/BlockCoreTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/nn/BlockCoreTest.java
@@ -207,7 +207,7 @@ public class BlockCoreTest {
     @SuppressWarnings("try")
     @Test
     public void testLayerNorm() throws IOException, MalformedModelException {
-        TestRequirements.engine("PyTorch");
+        TestRequirements.engine("PyTorch", "MXNet");
 
         TrainingConfig config =
                 new DefaultTrainingConfig(Loss.l2Loss())
@@ -236,7 +236,7 @@ public class BlockCoreTest {
     @SuppressWarnings("try")
     @Test
     public void test2LayerNorm() throws IOException, MalformedModelException {
-        TestRequirements.engine("PyTorch");
+        TestRequirements.engine("PyTorch", "MXNet");
 
         TrainingConfig config =
                 new DefaultTrainingConfig(Loss.l2Loss())


### PR DESCRIPTION
## Description ##

Adds LayerNorm support for MXNet (for PyTorch it already exists).
See https://github.com/deepjavalibrary/djl/issues/1341
