### PR TITLE
Create IndexEvaluator and IndexLoss

### DIFF
--- a/api/src/main/java/ai/djl/training/DefaultTrainingConfig.java
+++ b/api/src/main/java/ai/djl/training/DefaultTrainingConfig.java
@@ -24,6 +24,7 @@ import ai.djl.training.optimizer.Optimizer;
 import ai.djl.util.PairList;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
@@ -133,6 +134,18 @@ public class DefaultTrainingConfig implements TrainingConfig {
      */
     public DefaultTrainingConfig optExecutorService(ExecutorService executorService) {
         this.executorService = executorService;
+        return this;
+    }
+
+    /**
+     * Adds multiple {@link Evaluator}s that needs to be computed during training.
+     *
+     * @param evaluators the evaluators to be added
+     * @param <T> the type of evaluator to be added
+     * @return this {@code DefaultTrainingConfig}
+     */
+    public <T extends Evaluator> DefaultTrainingConfig addEvaluators(Collection<T> evaluators) {
+        evaluators.forEach(this::addEvaluator);
         return this;
     }
 

--- a/api/src/main/java/ai/djl/training/evaluator/AbstractAccuracy.java
+++ b/api/src/main/java/ai/djl/training/evaluator/AbstractAccuracy.java
@@ -29,30 +29,26 @@ public abstract class AbstractAccuracy extends Evaluator {
 
     protected Map<String, Long> correctInstances;
     protected int axis;
-    protected int index;
 
     /**
-     * Creates an accuracy evaluator that computes accuracy across axis 1 along given index.
+     * Creates an accuracy evaluator that computes accuracy across axis 1.
      *
      * @param name the name of the evaluator, default is "Accuracy"
-     * @param index the index of the NDArray in labels to compute accuracy for
      */
-    public AbstractAccuracy(String name, int index) {
-        this(name, index, 1);
+    public AbstractAccuracy(String name) {
+        this(name, 1);
     }
 
     /**
      * Creates an accuracy evaluator.
      *
      * @param name the name of the evaluator, default is "Accuracy"
-     * @param index the index of the NDArray in labels to compute accuracy for
      * @param axis the axis that represent classes in prediction, default 1
      */
-    public AbstractAccuracy(String name, int index, int axis) {
+    public AbstractAccuracy(String name, int axis) {
         super(name);
         correctInstances = new ConcurrentHashMap<>();
         this.axis = axis;
-        this.index = index;
     }
 
     /**

--- a/api/src/main/java/ai/djl/training/evaluator/Accuracy.java
+++ b/api/src/main/java/ai/djl/training/evaluator/Accuracy.java
@@ -25,36 +25,34 @@ public class Accuracy extends AbstractAccuracy {
      * index.
      */
     public Accuracy() {
-        this("Accuracy", 0, 1);
+        this("Accuracy", 1);
     }
 
     /**
-     * Creates a multiclass accuracy evaluator that computes accuracy across axis 1 along given
+     * Creates a multiclass accuracy evaluator that computes accuracy across axis 1 along the 0th
      * index.
      *
      * @param name the name of the evaluator, default is "Accuracy"
-     * @param index the index of the NDArray in labels to compute accuracy for
      */
-    public Accuracy(String name, int index) {
-        super(name, index);
+    public Accuracy(String name) {
+        this(name, 1);
     }
 
     /**
      * Creates a multiclass accuracy evaluator.
      *
      * @param name the name of the evaluator, default is "Accuracy"
-     * @param index the index of the NDArray in labels to compute accuracy for
      * @param axis the axis that represent classes in prediction, default 1
      */
-    public Accuracy(String name, int index, int axis) {
-        super(name, index, axis);
+    public Accuracy(String name, int axis) {
+        super(name, axis);
     }
 
     /** {@inheritDoc} */
     @Override
     protected Pair<Long, NDArray> accuracyHelper(NDList labels, NDList predictions) {
-        NDArray label = labels.get(index);
-        NDArray prediction = predictions.get(index);
+        NDArray label = labels.head();
+        NDArray prediction = predictions.head();
         checkLabelShapes(label, prediction);
         NDArray predictionReduced;
         if (!label.getShape().equals(prediction.getShape())) {

--- a/api/src/main/java/ai/djl/training/evaluator/BinaryAccuracy.java
+++ b/api/src/main/java/ai/djl/training/evaluator/BinaryAccuracy.java
@@ -35,11 +35,10 @@ public class BinaryAccuracy extends AbstractAccuracy {
      *
      * @param name the name of the evaluator, default is "Accuracy"
      * @param threshold the value differentiating the posive and negative classes (usually 0 or .5)
-     * @param index the index of the NDArray in labels to compute accuracy for
      * @param axis the axis that represent classes in prediction, default 1
      */
-    public BinaryAccuracy(String name, float threshold, int index, int axis) {
-        super(name, index, axis);
+    public BinaryAccuracy(String name, float threshold, int axis) {
+        super(name, axis);
         this.threshold = threshold;
     }
 
@@ -49,10 +48,9 @@ public class BinaryAccuracy extends AbstractAccuracy {
      *
      * @param name the name of the evaluator, default is "Accuracy"
      * @param threshold the value differentiating the posive and negative classes (usually 0 or .5)
-     * @param index the index of the NDArray in labels to compute accuracy for
      */
-    public BinaryAccuracy(String name, float threshold, int index) {
-        this(name, threshold, index, 1);
+    public BinaryAccuracy(String name, float threshold) {
+        this(name, threshold, 1);
     }
 
     /**
@@ -62,7 +60,7 @@ public class BinaryAccuracy extends AbstractAccuracy {
      * @param threshold the value differentiating the posive and negative classes (usually 0 or .5)
      */
     public BinaryAccuracy(float threshold) {
-        this("BinaryAccuracy", threshold, 0, 1);
+        this("BinaryAccuracy", threshold, 1);
     }
 
     /** Creates a binary (two class) accuracy evaluator with 0 threshold. */
@@ -76,8 +74,8 @@ public class BinaryAccuracy extends AbstractAccuracy {
         Preconditions.checkArgument(
                 labels.size() == predictions.size(),
                 "labels and prediction length does not match.");
-        NDArray label = labels.get(index);
-        NDArray prediction = predictions.get(index);
+        NDArray label = labels.head();
+        NDArray prediction = predictions.head();
         checkLabelShapes(label, prediction, false);
         NDArray predictionReduced = prediction.gte(threshold);
         // result of sum is int64 now

--- a/api/src/main/java/ai/djl/training/evaluator/IndexEvaluator.java
+++ b/api/src/main/java/ai/djl/training/evaluator/IndexEvaluator.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.training.evaluator;
+
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDList;
+
+/**
+ * A wrapper for an {@link Evaluator} that evaluates on only a particular {@link NDArray} in the
+ * predictions and/or labels {@link NDList}s.
+ */
+public class IndexEvaluator extends Evaluator {
+
+    private Evaluator evaluator;
+    private Integer predictionsIndex;
+    private Integer labelsIndex;
+
+    /**
+     * Constructs an {@link IndexEvaluator} with the same index for both predictions and labels.
+     *
+     * @param evaluator the base evaluator
+     * @param index the index for both predictions and labels
+     */
+    public IndexEvaluator(Evaluator evaluator, int index) {
+        this(evaluator, index, index);
+    }
+
+    /**
+     * Constructs an {@link IndexEvaluator}.
+     *
+     * @param evaluator the base evaluator
+     * @param predictionsIndex the predictions index
+     * @param labelsIndex the labels index
+     */
+    public IndexEvaluator(Evaluator evaluator, Integer predictionsIndex, Integer labelsIndex) {
+        super(evaluator.getName());
+        this.evaluator = evaluator;
+        this.predictionsIndex = predictionsIndex;
+        this.labelsIndex = labelsIndex;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray evaluate(NDList labels, NDList predictions) {
+        return evaluator.evaluate(getLabels(labels), getPredictions(predictions));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void addAccumulator(String key) {
+        evaluator.addAccumulator(key);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateAccumulator(String key, NDList labels, NDList predictions) {
+        evaluator.updateAccumulator(key, getLabels(labels), getPredictions(predictions));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void resetAccumulator(String key) {
+        evaluator.resetAccumulator(key);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public float getAccumulator(String key) {
+        return evaluator.getAccumulator(key);
+    }
+
+    private NDList getPredictions(NDList predictions) {
+        if (predictionsIndex == null) {
+            return predictions;
+        }
+        return new NDList(predictions.get(predictionsIndex));
+    }
+
+    private NDList getLabels(NDList labels) {
+        if (labelsIndex == null) {
+            return labels;
+        }
+        return new NDList(labels.get(labelsIndex));
+    }
+}

--- a/api/src/main/java/ai/djl/training/evaluator/TopKAccuracy.java
+++ b/api/src/main/java/ai/djl/training/evaluator/TopKAccuracy.java
@@ -34,11 +34,10 @@ public class TopKAccuracy extends AbstractAccuracy {
      * Creates a {@code TopKAccuracy} instance.
      *
      * @param name the accuracy name, default "Top_K_Accuracy"
-     * @param index the index of the {@link NDArray} in labels to compute topK accuracy for
      * @param topK the value of K
      */
-    public TopKAccuracy(String name, int index, int topK) {
-        super(name, index);
+    public TopKAccuracy(String name, int topK) {
+        super(name);
         if (topK > 1) {
             this.topK = topK;
         } else {
@@ -48,30 +47,19 @@ public class TopKAccuracy extends AbstractAccuracy {
 
     /**
      * Creates an instance of {@code TopKAccuracy} evaluator that computes topK accuracy across axis
-     * 1 along the given index.
-     *
-     * @param index the index of the {@link NDArray} in labels to compute topK accuracy for
-     * @param topK the value of K
-     */
-    public TopKAccuracy(int index, int topK) {
-        this("Top_" + topK + "_Accuracy", index, topK);
-    }
-
-    /**
-     * Creates an instance of {@code TopKAccuracy} evaluator that computes topK accuracy across axis
      * 1 along the 0th index.
      *
      * @param topK the value of K
      */
     public TopKAccuracy(int topK) {
-        this("Top_" + topK + "_Accuracy", 0, topK);
+        this("Top_" + topK + "_Accuracy", topK);
     }
 
     /** {@inheritDoc} */
     @Override
     protected Pair<Long, NDArray> accuracyHelper(NDList labels, NDList predictions) {
-        NDArray label = labels.get(index);
-        NDArray prediction = predictions.get(index);
+        NDArray label = labels.head();
+        NDArray prediction = predictions.head();
         // number of labels and predictions should be the same
         checkLabelShapes(label, prediction);
         // ascending by default

--- a/api/src/main/java/ai/djl/training/loss/IndexLoss.java
+++ b/api/src/main/java/ai/djl/training/loss/IndexLoss.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.training.loss;
+
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDList;
+
+/**
+ * A wrapper for a {@link Loss} that evaluates on only a particular {@link NDArray} in the
+ * predictions and/or labels {@link NDList}s.
+ */
+public class IndexLoss extends Loss {
+
+    private Loss loss;
+    private Integer predictionsIndex;
+    private Integer labelsIndex;
+
+    /**
+     * Constructs an {@link IndexLoss} with the same index for both predictions and labels.
+     *
+     * @param loss the base evaluator
+     * @param index the index for both predictions and labels
+     */
+    public IndexLoss(Loss loss, int index) {
+        this(loss, index, index);
+    }
+
+    /**
+     * Constructs an {@link IndexLoss}.
+     *
+     * @param loss the base evaluator
+     * @param predictionsIndex the predictions index
+     * @param labelsIndex the labels index
+     */
+    public IndexLoss(Loss loss, Integer predictionsIndex, Integer labelsIndex) {
+        super(loss.getName());
+        this.loss = loss;
+        this.predictionsIndex = predictionsIndex;
+        this.labelsIndex = labelsIndex;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray evaluate(NDList labels, NDList predictions) {
+        return loss.evaluate(getLabels(labels), getPredictions(predictions));
+    }
+
+    private NDList getPredictions(NDList predictions) {
+        if (predictionsIndex == null) {
+            return predictions;
+        }
+        return new NDList(predictions.get(predictionsIndex));
+    }
+
+    private NDList getLabels(NDList labels) {
+        if (labelsIndex == null) {
+            return labels;
+        }
+        return new NDList(labels.get(labelsIndex));
+    }
+}

--- a/api/src/main/java/ai/djl/training/loss/SimpleCompositeLoss.java
+++ b/api/src/main/java/ai/djl/training/loss/SimpleCompositeLoss.java
@@ -15,23 +15,19 @@ package ai.djl.training.loss;
 import ai.djl.ndarray.NDList;
 import ai.djl.util.Pair;
 import java.util.ArrayList;
-import java.util.List;
 
 /**
  * {@code SimpleCompositeLoss} is an implementation of the {@link Loss} abstract class that can
  * combine different {@link Loss} functions by adding the individual losses together.
  *
- * <p>This class can be used when the losses either accept a single index of the labels and
- * predictions or the entire lists. For more complicated composite losses, extend the {@link
- * AbstractCompositeLoss}.
+ * <p>For cases where the losses use only a single index of the labels and/or predictions, use the
+ * {@link IndexLoss}.
  *
  * <p>For an example of using this loss, see <a
  * href="https://github.com/deepjavalibrary/djl/blob/master/examples/src/main/java/ai/djl/examples/training/TrainCaptcha.java">the
  * captcha training example.</a>
  */
 public class SimpleCompositeLoss extends AbstractCompositeLoss {
-
-    private List<Integer> indices;
 
     /**
      * Creates a new empty instance of {@code CompositeLoss} that can combine the given {@link Loss}
@@ -50,7 +46,6 @@ public class SimpleCompositeLoss extends AbstractCompositeLoss {
     public SimpleCompositeLoss(String name) {
         super(name);
         components = new ArrayList<>();
-        indices = new ArrayList<>();
     }
 
     /**
@@ -61,21 +56,6 @@ public class SimpleCompositeLoss extends AbstractCompositeLoss {
      */
     public SimpleCompositeLoss addLoss(Loss loss) {
         components.add(loss);
-        indices.add(null);
-        return this;
-    }
-
-    /**
-     * Adds a Loss that applies to a single index of the label and predictions to this composite
-     * loss.
-     *
-     * @param loss the loss to add
-     * @param index the index in the label and predictions NDLists this loss applies to
-     * @return this composite loss
-     */
-    public SimpleCompositeLoss addLoss(Loss loss, int index) {
-        components.add(loss);
-        indices.add(index);
         return this;
     }
 
@@ -83,11 +63,6 @@ public class SimpleCompositeLoss extends AbstractCompositeLoss {
     @Override
     protected Pair<NDList, NDList> inputForComponent(
             int componentIndex, NDList labels, NDList predictions) {
-        if (indices.get(componentIndex) != null) {
-            int index = indices.get(componentIndex);
-            return new Pair<>(new NDList(labels.get(index)), new NDList(predictions.get(index)));
-        } else {
-            return new Pair<>(labels, predictions);
-        }
+        return new Pair<>(labels, predictions);
     }
 }

--- a/examples/src/main/java/ai/djl/examples/training/TrainSeq2Seq.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainSeq2Seq.java
@@ -149,7 +149,7 @@ public final class TrainSeq2Seq {
                 });
 
         return new DefaultTrainingConfig(new MaskedSoftmaxCrossEntropyLoss())
-                .addEvaluator(new Accuracy("Accuracy", 0, 2))
+                .addEvaluator(new Accuracy("Accuracy", 2))
                 .optDevices(Engine.getInstance().getDevices(arguments.getMaxGpus()))
                 .optExecutorService(executorService)
                 .addTrainingListeners(TrainingListener.Defaults.logging(outputDir))


### PR DESCRIPTION
Right now, there is inconsistent handling for how evaluators and losses can be
applied to only a single array within an NDList. This can happen often when
using multiple losses such as with the AbstractCompositeLoss cases.

Before, we had indexing through SimpleCompositeLoss. However, this would not
work with the trainer evaluators as well. So, the solution must be to move the
tracking of indices into the evaluators/losses.

This creates the indexed variations as a wrapper class so it requires less
updating for existing classes and keeps them simpler. As part of it, the classes
that already had indexing support including some accuracy evaluators and
SimpleCompositeLoss had it removed.