### PR TITLE
Add mavenCentral() to buildscript repository

### DIFF
--- a/tools/gradle/java-formatter.gradle
+++ b/tools/gradle/java-formatter.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        mavenCentral()
         maven {
             url "https://plugins.gradle.org/m2/"
         }


### PR DESCRIPTION
Change-Id: I9d8614e5680ce11c8c6c2b8a450c0fca4b4672a5

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
