### PR TITLE
[hadoop] Exclude log4j dependency from hadoop extension

### DIFF
--- a/extensions/hadoop/build.gradle
+++ b/extensions/hadoop/build.gradle
@@ -2,7 +2,10 @@ group "ai.djl.hadoop"
 
 dependencies {
     api project(":api")
-    api "org.apache.hadoop:hadoop-client:${hadoop_version}"
+    api ("org.apache.hadoop:hadoop-client:${hadoop_version}") {
+        exclude group: "log4j", module: "log4j"
+        exclude group: "org.slf4j", module: "slf4j-log4j12"
+    }
 
     testImplementation project(":engines:mxnet:mxnet-engine")
     testImplementation "org.apache.hadoop:hadoop-minicluster:${hadoop_version}"


### PR DESCRIPTION
Change-Id: I2f67efdb758e13087598a5f922871cf12b71ea3d

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
