### PR TITLE
[pytorch] workaround libtorch.dylob 1.8.1 loading issue

### DIFF
--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
@@ -93,6 +93,10 @@ public final class LibUtils {
 
     private static void loadLibTorch(LibTorch libTorch) {
         Path libDir = libTorch.dir.toAbsolutePath();
+        if ("1.8.1".equals(getVersion()) && System.getProperty("os.name").startsWith("Mac")) {
+            // PyTorch 1.8.1 libtorch_cpu.dylib cannot be loaded individually
+            return;
+        }
         List<String> deferred =
                 Arrays.asList(
                         System.mapLibraryName("fbgemm"),


### PR DESCRIPTION
Change-Id: Id2fc3a7cab1646fe921df3cc0e6c619e8857eeda

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
