### PR TITLE
[api] Fixes topK items for DetectedObjects and make it configurable to Classifications

### DIFF
--- a/api/src/main/java/ai/djl/modality/cv/output/DetectedObjects.java
+++ b/api/src/main/java/ai/djl/modality/cv/output/DetectedObjects.java
@@ -45,6 +45,7 @@ public class DetectedObjects extends Classifications {
             List<String> classNames, List<Double> probabilities, List<BoundingBox> boundingBoxes) {
         super(classNames, probabilities);
         this.boundingBoxes = boundingBoxes;
+        setTopK(Integer.MAX_VALUE);
     }
 
     /** {@inheritDoc} */

--- a/api/src/main/java/ai/djl/modality/cv/translator/ImageClassificationTranslator.java
+++ b/api/src/main/java/ai/djl/modality/cv/translator/ImageClassificationTranslator.java
@@ -27,6 +27,7 @@ public class ImageClassificationTranslator extends BaseImageTranslator<Classific
 
     private SynsetLoader synsetLoader;
     private boolean applySoftmax;
+    private int topK;
 
     private List<String> classes;
 
@@ -39,6 +40,7 @@ public class ImageClassificationTranslator extends BaseImageTranslator<Classific
         super(builder);
         this.synsetLoader = builder.synsetLoader;
         this.applySoftmax = builder.applySoftmax;
+        this.topK = builder.topK;
     }
 
     /** {@inheritDoc} */
@@ -56,7 +58,7 @@ public class ImageClassificationTranslator extends BaseImageTranslator<Classific
         if (applySoftmax) {
             probabilitiesNd = probabilitiesNd.softmax(0);
         }
-        return new Classifications(classes, probabilitiesNd);
+        return new Classifications(classes, probabilitiesNd, topK);
     }
 
     /**
@@ -85,8 +87,20 @@ public class ImageClassificationTranslator extends BaseImageTranslator<Classific
     public static class Builder extends ClassificationBuilder<Builder> {
 
         private boolean applySoftmax;
+        private int topK = 5;
 
         Builder() {}
+
+        /**
+         * Set the topK number of classes to be displayed.
+         *
+         * @param topK the number of top classes to return
+         * @return the builder
+         */
+        public Builder optTopK(int topK) {
+            this.topK = topK;
+            return this;
+        }
 
         /**
          * Sets whether to apply softmax when processing output. Some models already include softmax
@@ -111,6 +125,7 @@ public class ImageClassificationTranslator extends BaseImageTranslator<Classific
         protected void configPostProcess(Map<String, ?> arguments) {
             super.configPostProcess(arguments);
             applySoftmax = ArgumentsUtil.booleanValue(arguments, "applySoftmax");
+            topK = ArgumentsUtil.intValue(arguments, "topK", 5);
         }
 
         /**


### PR DESCRIPTION
Change-Id: I4ffd29cff5205f32ee18afa5269d70491634936e

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
