### PR TITLE
[pytorch] Fixes jni dependency in README document

### DIFF
--- a/engines/pytorch/pytorch-engine/README.md
+++ b/engines/pytorch/pytorch-engine/README.md
@@ -107,7 +107,7 @@ installed on your GPU machine, you can use one of the following library:
 </dependency>
 <dependency>
     <groupId>ai.djl.pytorch</groupId>
-    <artifactId>pytorch-native-jni</artifactId>
+    <artifactId>pytorch-jni</artifactId>
     <version>1.10.0-0.15.0</version>
     <scope>runtime</scope>
 </dependency>
@@ -123,7 +123,7 @@ installed on your GPU machine, you can use one of the following library:
 </dependency>
 <dependency>
     <groupId>ai.djl.pytorch</groupId>
-    <artifactId>pytorch-native-jni</artifactId>
+    <artifactId>pytorch-jni</artifactId>
     <version>1.10.0-0.15.0</version>
     <scope>runtime</scope>
 </dependency>
@@ -144,7 +144,7 @@ installed on your GPU machine, you can use one of the following library:
 </dependency>
 <dependency>
     <groupId>ai.djl.pytorch</groupId>
-    <artifactId>pytorch-native-jni</artifactId>
+    <artifactId>pytorch-jni</artifactId>
     <version>1.10.0-0.15.0</version>
     <scope>runtime</scope>
 </dependency>
@@ -169,7 +169,7 @@ All the package were built with GCC 7, we provided a newer `libstdc++.so.6.24` i
 </dependency>
 <dependency>
     <groupId>ai.djl.pytorch</groupId>
-    <artifactId>pytorch-native-jni</artifactId>
+    <artifactId>pytorch-jni</artifactId>
     <version>1.10.0-0.15.0</version>
     <scope>runtime</scope>
 </dependency>
@@ -185,7 +185,7 @@ All the package were built with GCC 7, we provided a newer `libstdc++.so.6.24` i
 </dependency>
 <dependency>
     <groupId>ai.djl.pytorch</groupId>
-    <artifactId>pytorch-native-jni</artifactId>
+    <artifactId>pytorch-jni</artifactId>
     <version>1.10.0-0.15.0</version>
     <scope>runtime</scope>
 </dependency>
@@ -215,7 +215,7 @@ For the Windows platform, you can choose between CPU and GPU.
 </dependency>
 <dependency>
     <groupId>ai.djl.pytorch</groupId>
-    <artifactId>pytorch-native-jni</artifactId>
+    <artifactId>pytorch-jni</artifactId>
     <version>1.10.0-0.15.0</version>
     <scope>runtime</scope>
 </dependency>
@@ -231,7 +231,7 @@ For the Windows platform, you can choose between CPU and GPU.
 </dependency>
 <dependency>
     <groupId>ai.djl.pytorch</groupId>
-    <artifactId>pytorch-native-jni</artifactId>
+    <artifactId>pytorch-jni</artifactId>
     <version>1.10.0-0.15.0</version>
     <scope>runtime</scope>
 </dependency>
@@ -252,7 +252,7 @@ For the Windows platform, you can choose between CPU and GPU.
 </dependency>
 <dependency>
     <groupId>ai.djl.pytorch</groupId>
-    <artifactId>pytorch-native-jni</artifactId>
+    <artifactId>pytorch-jni</artifactId>
     <version>1.10.0-0.15.0</version>
     <scope>runtime</scope>
 </dependency>


### PR DESCRIPTION
Change-Id: Ie8a35287676762c53af3e65b253e8d7af3f384fc

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
