### PR TITLE
Refactor ml extension support

### DIFF
--- a/api/src/main/java/ai/djl/util/passthrough/PassthroughNDArray.java
+++ b/api/src/main/java/ai/djl/util/passthrough/PassthroughNDArray.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.util.passthrough;
+
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDArrayAdapter;
+import java.nio.ByteBuffer;
+
+/**
+ * An {@link NDArray} that stores an arbitrary Java object.
+ *
+ * <p>This class is mainly for use in extensions and hybrid engines. Despite it's name, it will
+ * often not contain actual {@link NDArray}s but just any object necessary to conform to the DJL
+ * predictor API.
+ */
+public class PassthroughNDArray extends NDArrayAdapter {
+
+    private Object object;
+
+    /**
+     * Constructs a {@link PassthroughNDArray} storing an object.
+     *
+     * @param object the object to store
+     */
+    public PassthroughNDArray(Object object) {
+        super(null, null, null, null, null);
+        this.object = object;
+    }
+
+    /**
+     * Returns the object stored.
+     *
+     * @return the object stored
+     */
+    public Object getObject() {
+        return object;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ByteBuffer toByteBuffer() {
+        throw new UnsupportedOperationException("Operation not supported for FastText");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void intern(NDArray replaced) {
+        throw new UnsupportedOperationException("Operation not supported for FastText");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void detach() {}
+}

--- a/api/src/main/java/ai/djl/util/passthrough/PassthroughNDManager.java
+++ b/api/src/main/java/ai/djl/util/passthrough/PassthroughNDManager.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.util.passthrough;
+
+import ai.djl.Device;
+import ai.djl.engine.Engine;
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.NDManager;
+import ai.djl.ndarray.NDResource;
+import ai.djl.ndarray.types.DataType;
+import ai.djl.ndarray.types.Shape;
+import ai.djl.util.PairList;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+
+/** An {@link NDManager} that does nothing, for use in extensions and hybrid engines. */
+public final class PassthroughNDManager implements NDManager {
+
+    private static final String UNSUPPORTED = "Not supported by PassthroughNDManager";
+    public static final PassthroughNDManager INSTANCE = new PassthroughNDManager();
+
+    private PassthroughNDManager() {}
+
+    @Override
+    public Device defaultDevice() {
+        return Device.cpu();
+    }
+
+    @Override
+    public ByteBuffer allocateDirect(int capacity) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public NDArray from(NDArray array) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public NDArray create(String[] data, Charset charset, Shape shape) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public NDArray create(Shape shape, DataType dataType) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public NDArray createCSR(Buffer data, long[] indptr, long[] indices, Shape shape) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public NDArray createRowSparse(Buffer data, Shape dataShape, long[] indices, Shape shape) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public NDArray createCoo(Buffer data, long[][] indices, Shape shape) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public NDList load(Path path) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public void setName(String name) {}
+
+    @Override
+    public String getName() {
+        return "PassthroughNDManager";
+    }
+
+    @Override
+    public NDArray zeros(Shape shape, DataType dataType) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public NDArray ones(Shape shape, DataType dataType) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public NDArray full(Shape shape, float value, DataType dataType) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public NDArray arange(float start, float stop, float step, DataType dataType) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public NDArray eye(int rows, int cols, int k, DataType dataType) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public NDArray linspace(float start, float stop, int num, boolean endpoint) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public NDArray randomInteger(long low, long high, Shape shape, DataType dataType) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public NDArray randomUniform(float low, float high, Shape shape, DataType dataType) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public NDArray randomNormal(float loc, float scale, Shape shape, DataType dataType) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public NDArray truncatedNormal(float loc, float scale, Shape shape, DataType dataType) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public NDArray randomMultinomial(int n, NDArray pValues) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public NDArray randomMultinomial(int n, NDArray pValues, Shape shape) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public boolean isOpen() {
+        return true;
+    }
+
+    @Override
+    public NDManager getParentManager() {
+        return this;
+    }
+
+    @Override
+    public NDManager newSubManager() {
+        return this;
+    }
+
+    @Override
+    public NDManager newSubManager(Device device) {
+        return this;
+    }
+
+    @Override
+    public Device getDevice() {
+        return Device.cpu();
+    }
+
+    @Override
+    public void attachInternal(String resourceId, AutoCloseable resource) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public void tempAttachInternal(
+            NDManager originalManager, String resourceId, NDResource resource) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public void detachInternal(String resourceId) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public void invoke(
+            String operation, NDArray[] src, NDArray[] dest, PairList<String, ?> params) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public NDList invoke(String operation, NDList src, PairList<String, ?> params) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    @Override
+    public Engine getEngine() {
+        return null;
+    }
+
+    @Override
+    public void close() {}
+}

--- a/api/src/main/java/ai/djl/util/passthrough/PassthroughTranslator.java
+++ b/api/src/main/java/ai/djl/util/passthrough/PassthroughTranslator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.util.passthrough;
+
+import ai.djl.ndarray.NDList;
+import ai.djl.translate.NoBatchifyTranslator;
+import ai.djl.translate.TranslatorContext;
+
+/**
+ * A translator that stores and removes data from a {@link PassthroughNDArray}.
+ *
+ * @param <I> translator input type
+ * @param <O> translator output type
+ */
+public class PassthroughTranslator<I, O> implements NoBatchifyTranslator<I, O> {
+
+    @Override
+    public NDList processInput(TranslatorContext ctx, I input) throws Exception {
+        return new NDList(new PassthroughNDArray(input));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public O processOutput(TranslatorContext ctx, NDList list) {
+        PassthroughNDArray wrapper = (PassthroughNDArray) list.singletonOrThrow();
+        return (O) wrapper.getObject();
+    }
+}

--- a/api/src/main/java/ai/djl/util/passthrough/package-info.java
+++ b/api/src/main/java/ai/djl/util/passthrough/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+/** Contains passthrough DJL classes for use in extensions and hybrid engines. */
+package ai.djl.util.passthrough;

--- a/extensions/fasttext/README.md
+++ b/extensions/fasttext/README.md
@@ -5,8 +5,10 @@
 This module contains the NLP support with fastText implementation.
 
 fastText module's implementation in DJL is not considered as an Engine, it doesn't support Trainer and Predictor.
-The training and inference functionality is directly provided through [FtModel](https://javadoc.io/doc/ai.djl.fasttext/fasttext-engine/latest/ai/djl/fasttext/FtModel.html)
-class. You can find examples [here](https://github.com/deepjavalibrary/djl/blob/master/extensions/fasttext/src/test/java/ai/djl/fasttext/CookingStackExchangeTest.java).
+Training is only supported by using [TrainFastText](https://javadoc.io/doc/ai.djl.fasttext/fasttext-engine/latest/ai/djl/fasttext/TrainFastText.html).
+This produces a special block which can perform inference on its own or by using a model and predictor.
+Pre-trained FastText models can also be loaded by using the standard DJL criteria.
+You can find examples [here](https://github.com/deepjavalibrary/djl/blob/master/extensions/fasttext/src/test/java/ai/djl/fasttext/CookingStackExchangeTest.java).
 
 Current implementation has the following limitations:
 

--- a/extensions/fasttext/src/main/java/ai/djl/fasttext/FtAbstractBlock.java
+++ b/extensions/fasttext/src/main/java/ai/djl/fasttext/FtAbstractBlock.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.fasttext;
+
+import ai.djl.fasttext.jni.FtWrapper;
+import ai.djl.nn.AbstractSymbolBlock;
+import java.nio.file.Path;
+
+/**
+ * A parent class containing shared behavior for {@link ai.djl.nn.SymbolBlock}s based on fasttext
+ * models.
+ */
+public abstract class FtAbstractBlock extends AbstractSymbolBlock implements AutoCloseable {
+
+    protected FtWrapper fta;
+
+    protected Path modelFile;
+
+    /**
+     * Constructs a {@link FtAbstractBlock}.
+     *
+     * @param fta the {@link FtWrapper} containing the "fasttext model"
+     */
+    public FtAbstractBlock(FtWrapper fta) {
+        this.fta = fta;
+    }
+
+    /**
+     * Returns the fasttext model file for the block.
+     *
+     * @return the fasttext model file for the block
+     */
+    public Path getModelFile() {
+        return modelFile;
+    }
+
+    /**
+     * Embeds a word using fasttext.
+     *
+     * @param word the word to embed
+     * @return the embedding
+     * @see ai.djl.modality.nlp.embedding.WordEmbedding
+     */
+    public float[] embedWord(String word) {
+        return fta.getWordVector(word);
+    }
+
+    @Override
+    public void close() {
+        fta.unloadModel();
+        fta.close();
+    }
+}

--- a/extensions/fasttext/src/main/java/ai/djl/fasttext/FtModel.java
+++ b/extensions/fasttext/src/main/java/ai/djl/fasttext/FtModel.java
@@ -41,7 +41,8 @@ import java.util.function.Function;
 /**
  * {@code FtModel} is the fastText implementation of {@link Model}.
  *
- * <p>FtModel contains all the methods in Model to load and process a model.
+ * <p>FtModel contains all the methods in Model to load and process a model. However, it only
+ * supports training by using {@link TrainFastText}.
  */
 public class FtModel implements Model {
 

--- a/extensions/fasttext/src/main/java/ai/djl/fasttext/TrainFastText.java
+++ b/extensions/fasttext/src/main/java/ai/djl/fasttext/TrainFastText.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.fasttext;
+
+import ai.djl.basicdataset.RawDataset;
+import ai.djl.fasttext.zoo.nlp.textclassification.FtTextClassification;
+import java.io.IOException;
+import java.nio.file.Path;
+
+/** A utility to aggregate options for training with fasttext. */
+public final class TrainFastText {
+
+    private TrainFastText() {}
+
+    /**
+     * Trains a fastText {@link ai.djl.Application.NLP#TEXT_CLASSIFICATION} model.
+     *
+     * @param config the training configuration to use
+     * @param dataset the training dataset
+     * @return the result of the training
+     * @throws IOException when IO operation fails in loading a resource
+     * @see FtTextClassification#fit(FtTrainingConfig, RawDataset)
+     */
+    public static FtTextClassification textClassification(
+            FtTrainingConfig config, RawDataset<Path> dataset) throws IOException {
+        return FtTextClassification.fit(config, dataset);
+    }
+}

--- a/extensions/fasttext/src/main/java/ai/djl/fasttext/jni/FastTextLibrary.java
+++ b/extensions/fasttext/src/main/java/ai/djl/fasttext/jni/FastTextLibrary.java
@@ -34,6 +34,7 @@ final class FastTextLibrary {
 
     native String getModelType(long handle);
 
+    @SuppressWarnings("PMD.LooseCoupling")
     native int predictProba(
             long handle,
             String text,

--- a/extensions/fasttext/src/main/java/ai/djl/fasttext/jni/FastTextLibrary.java
+++ b/extensions/fasttext/src/main/java/ai/djl/fasttext/jni/FastTextLibrary.java
@@ -12,6 +12,8 @@
  */
 package ai.djl.fasttext.jni;
 
+import java.util.ArrayList;
+
 /** A class containing utilities to interact with the SentencePiece Engine's JNI layer. */
 @SuppressWarnings("MissingJavadocMethod")
 final class FastTextLibrary {
@@ -33,7 +35,11 @@ final class FastTextLibrary {
     native String getModelType(long handle);
 
     native int predictProba(
-            long handle, String text, int topK, String[] classes, float[] probabilities);
+            long handle,
+            String text,
+            int topK,
+            ArrayList<String> classes,
+            ArrayList<Float> probabilities);
 
     native float[] getWordVector(long handle, String word);
 

--- a/extensions/fasttext/src/main/java/ai/djl/fasttext/jni/FtWrapper.java
+++ b/extensions/fasttext/src/main/java/ai/djl/fasttext/jni/FtWrapper.java
@@ -59,25 +59,26 @@ public final class FtWrapper extends NativeResource<Long> {
     }
 
     public Classifications predictProba(String text, int topK, String labelPrefix) {
-        String[] labels = new String[topK];
-        float[] probs = new float[topK];
+        int cap = topK != -1 ? topK : 10;
+        ArrayList<String> labels = new ArrayList<>(cap);
+        ArrayList<Float> probs = new ArrayList<>(cap);
 
         int size = FastTextLibrary.LIB.predictProba(getHandle(), text, topK, labels, probs);
 
         List<String> classes = new ArrayList<>(size);
         List<Double> probabilities = new ArrayList<>(size);
         for (int i = 0; i < size; ++i) {
-            String label = labels[i];
+            String label = labels.get(i);
             if (label.startsWith(labelPrefix)) {
                 label = label.substring(labelPrefix.length());
             }
             classes.add(label);
-            probabilities.add((double) probs[i]);
+            probabilities.add((double) probs.get(i));
         }
         return new Classifications(classes, probabilities);
     }
 
-    public float[] getDataVector(String word) {
+    public float[] getWordVector(String word) {
         return FastTextLibrary.LIB.getWordVector(getHandle(), word);
     }
 

--- a/extensions/fasttext/src/main/java/ai/djl/fasttext/zoo/nlp/textclassification/FtTextClassification.java
+++ b/extensions/fasttext/src/main/java/ai/djl/fasttext/zoo/nlp/textclassification/FtTextClassification.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.fasttext.zoo.nlp.textclassification;
+
+import ai.djl.basicdataset.RawDataset;
+import ai.djl.fasttext.FtAbstractBlock;
+import ai.djl.fasttext.FtTrainingConfig;
+import ai.djl.fasttext.jni.FtWrapper;
+import ai.djl.fasttext.zoo.nlp.word_embedding.FtWordEmbeddingBlock;
+import ai.djl.modality.Classifications;
+import ai.djl.ndarray.NDList;
+import ai.djl.training.ParameterStore;
+import ai.djl.training.TrainingResult;
+import ai.djl.util.PairList;
+import ai.djl.util.passthrough.PassthroughNDArray;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** A {@link FtAbstractBlock} for {@link ai.djl.Application.NLP#TEXT_CLASSIFICATION}. */
+public class FtTextClassification extends FtAbstractBlock {
+
+    public static final String DEFAULT_LABEL_PREFIX = "__label__";
+
+    private String labelPrefix;
+
+    private TrainingResult trainingResult;
+
+    /**
+     * Constructs a {@link FtTextClassification}.
+     *
+     * @param fta the {@link FtWrapper} containing the "fasttext model"
+     * @param labelPrefix the prefix to use for labels
+     */
+    public FtTextClassification(FtWrapper fta, String labelPrefix) {
+        super(fta);
+        this.labelPrefix = labelPrefix;
+    }
+
+    /**
+     * Trains the fastText model.
+     *
+     * @param config the training configuration to use
+     * @param dataset the training dataset
+     * @return the result of the training
+     * @throws IOException when IO operation fails in loading a resource
+     */
+    public static FtTextClassification fit(FtTrainingConfig config, RawDataset<Path> dataset)
+            throws IOException {
+        Path outputDir = config.getOutputDir();
+        if (Files.notExists(outputDir)) {
+            Files.createDirectory(outputDir);
+        }
+        String fitModelName = config.getModelName();
+        FtWrapper fta = FtWrapper.newInstance();
+        Path modelFile = outputDir.resolve(fitModelName).toAbsolutePath();
+
+        String[] args = config.toCommand(dataset.getData().toString());
+
+        fta.runCmd(args);
+
+        TrainingResult result = new TrainingResult();
+        int epoch = config.getEpoch();
+        if (epoch <= 0) {
+            epoch = 5;
+        }
+        result.setEpoch(epoch);
+
+        FtTextClassification block = new FtTextClassification(fta, config.getLabelPrefix());
+        block.modelFile = modelFile;
+        block.trainingResult = result;
+        return block;
+    }
+
+    /**
+     * Returns the fasttext label prefix.
+     *
+     * @return the fasttext label prefix
+     */
+    public String getLabelPrefix() {
+        return labelPrefix;
+    }
+
+    /**
+     * Returns the results of training, or null if not trained.
+     *
+     * @return the results of training, or null if not trained
+     */
+    public TrainingResult getTrainingResult() {
+        return trainingResult;
+    }
+
+    @Override
+    protected NDList forwardInternal(
+            ParameterStore parameterStore,
+            NDList inputs,
+            boolean training,
+            PairList<String, Object> params) {
+        PassthroughNDArray inputWrapper = (PassthroughNDArray) inputs.singletonOrThrow();
+        String input = (String) inputWrapper.getObject();
+        Classifications result = fta.predictProba(input, -1, labelPrefix);
+        return new NDList(new PassthroughNDArray(result));
+    }
+
+    /**
+     * Converts the block into the equivalent {@link FtWordEmbeddingBlock}.
+     *
+     * @return the equivalent {@link FtWordEmbeddingBlock}
+     */
+    public FtWordEmbeddingBlock toWordEmbedding() {
+        return new FtWordEmbeddingBlock(fta);
+    }
+
+    /**
+     * Returns the classifications of the input text.
+     *
+     * @param text the input text to be classified
+     * @return classifications of the input text
+     */
+    public Classifications classify(String text) {
+        return classify(text, -1);
+    }
+
+    /**
+     * Returns top K classifications of the input text.
+     *
+     * @param text the input text to be classified
+     * @param topK the value of K
+     * @return classifications of the input text
+     */
+    public Classifications classify(String text, int topK) {
+        return fta.predictProba(text, topK, labelPrefix);
+    }
+}

--- a/extensions/fasttext/src/main/java/ai/djl/fasttext/zoo/nlp/textclassification/TextClassificationModelLoader.java
+++ b/extensions/fasttext/src/main/java/ai/djl/fasttext/zoo/nlp/textclassification/TextClassificationModelLoader.java
@@ -24,6 +24,7 @@ import ai.djl.repository.zoo.Criteria;
 import ai.djl.repository.zoo.ModelNotFoundException;
 import ai.djl.repository.zoo.ZooModel;
 import ai.djl.util.Progress;
+import ai.djl.util.passthrough.PassthroughTranslator;
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -66,6 +67,6 @@ public class TextClassificationModelLoader extends BaseModelLoader {
         Model model = new FtModel(modelName);
         Path modelPath = mrl.getRepository().getResourceDirectory(artifact);
         model.load(modelPath, modelName, criteria.getOptions());
-        return new ZooModel<>(model, null);
+        return new ZooModel<>(model, new PassthroughTranslator<>());
     }
 }

--- a/extensions/fasttext/src/main/java/ai/djl/fasttext/zoo/nlp/word_embedding/FtWordEmbeddingBlock.java
+++ b/extensions/fasttext/src/main/java/ai/djl/fasttext/zoo/nlp/word_embedding/FtWordEmbeddingBlock.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.fasttext.zoo.nlp.word_embedding;
+
+import ai.djl.fasttext.FtAbstractBlock;
+import ai.djl.fasttext.jni.FtWrapper;
+import ai.djl.ndarray.NDList;
+import ai.djl.training.ParameterStore;
+import ai.djl.util.PairList;
+import ai.djl.util.passthrough.PassthroughNDArray;
+
+/** A {@link FtAbstractBlock} for {@link ai.djl.Application.NLP#WORD_EMBEDDING}. */
+public class FtWordEmbeddingBlock extends FtAbstractBlock {
+
+    /**
+     * Constructs a {@link FtWordEmbeddingBlock}.
+     *
+     * @param fta the {@link FtWrapper} for the "fasttext model".
+     */
+    public FtWordEmbeddingBlock(FtWrapper fta) {
+        super(fta);
+    }
+
+    @Override
+    protected NDList forwardInternal(
+            ParameterStore parameterStore,
+            NDList inputs,
+            boolean training,
+            PairList<String, Object> params) {
+        PassthroughNDArray inputWrapper = (PassthroughNDArray) inputs.singletonOrThrow();
+        String input = (String) inputWrapper.getObject();
+        float[] result = embedWord(input);
+        return new NDList(new PassthroughNDArray(result));
+    }
+}

--- a/extensions/fasttext/src/main/java/ai/djl/fasttext/zoo/nlp/word_embedding/package-info.java
+++ b/extensions/fasttext/src/main/java/ai/djl/fasttext/zoo/nlp/word_embedding/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+/**
+ * Contains classes for the {@link ai.djl.Application.NLP#WORD_EMBEDDING} models in the {@link
+ * ai.djl.fasttext.zoo.FtModelZoo}.
+ */
+package ai.djl.fasttext.zoo.nlp.word_embedding;

--- a/extensions/fasttext/src/test/java/ai/djl/fasttext/CookingStackExchangeTest.java
+++ b/extensions/fasttext/src/test/java/ai/djl/fasttext/CookingStackExchangeTest.java
@@ -66,7 +66,7 @@ public class CookingStackExchangeTest {
                         .optLoss(FtTrainingConfig.FtLoss.HS)
                         .build();
 
-        FtTextClassification block = FtTextClassification.fit(config, dataset);
+        FtTextClassification block = TrainFastText.textClassification(config, dataset);
         TrainingResult result = block.getTrainingResult();
         Assert.assertEquals(result.getEpoch(), 5);
         Assert.assertTrue(Files.exists(Paths.get("build/cooking.bin")));

--- a/extensions/fasttext/src/test/java/ai/djl/fasttext/CookingStackExchangeTest.java
+++ b/extensions/fasttext/src/test/java/ai/djl/fasttext/CookingStackExchangeTest.java
@@ -12,19 +12,26 @@
  */
 package ai.djl.fasttext;
 
+import ai.djl.Application;
 import ai.djl.MalformedModelException;
 import ai.djl.ModelException;
 import ai.djl.basicdataset.nlp.CookingStackExchange;
+import ai.djl.fasttext.zoo.nlp.textclassification.FtTextClassification;
+import ai.djl.fasttext.zoo.nlp.word_embedding.FtWord2VecWordEmbedding;
+import ai.djl.inference.Predictor;
 import ai.djl.modality.Classifications;
 import ai.djl.modality.nlp.DefaultVocabulary;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.types.Shape;
+import ai.djl.repository.Artifact;
 import ai.djl.repository.zoo.Criteria;
 import ai.djl.repository.zoo.ModelNotFoundException;
+import ai.djl.repository.zoo.ModelZoo;
 import ai.djl.repository.zoo.ZooModel;
 import ai.djl.testing.TestRequirements;
 import ai.djl.training.TrainingResult;
+import ai.djl.translate.TranslateException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -33,6 +40,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -43,30 +52,30 @@ public class CookingStackExchangeTest {
     private static final Logger logger = LoggerFactory.getLogger(CookingStackExchangeTest.class);
 
     @Test
-    public void testTrainTextClassification() throws IOException {
+    public void testTrainTextClassification() throws IOException, TranslateException {
         TestRequirements.notWindows(); // fastText is not supported on windows
 
-        try (FtModel model = new FtModel("cooking")) {
-            CookingStackExchange dataset = CookingStackExchange.builder().build();
+        CookingStackExchange dataset = CookingStackExchange.builder().build();
 
-            // setup training configuration
-            FtTrainingConfig config =
-                    FtTrainingConfig.builder()
-                            .setOutputDir(Paths.get("build"))
-                            .setModelName("cooking")
-                            .optEpoch(5)
-                            .optLoss(FtTrainingConfig.FtLoss.HS)
-                            .build();
+        // setup training configuration
+        FtTrainingConfig config =
+                FtTrainingConfig.builder()
+                        .setOutputDir(Paths.get("build"))
+                        .setModelName("cooking")
+                        .optEpoch(5)
+                        .optLoss(FtTrainingConfig.FtLoss.HS)
+                        .build();
 
-            TrainingResult result = model.fit(config, dataset);
-            Assert.assertEquals(result.getEpoch(), 5);
-            Assert.assertTrue(Files.exists(Paths.get("build/cooking.bin")));
-        }
+        FtTextClassification block = FtTextClassification.fit(config, dataset);
+        TrainingResult result = block.getTrainingResult();
+        Assert.assertEquals(result.getEpoch(), 5);
+        Assert.assertTrue(Files.exists(Paths.get("build/cooking.bin")));
     }
 
     @Test
     public void testTextClassification()
-            throws IOException, MalformedModelException, ModelNotFoundException {
+            throws IOException, MalformedModelException, ModelNotFoundException,
+                    TranslateException {
         TestRequirements.notWindows(); // fastText is not supported on windows
 
         Criteria<String, Classifications> criteria =
@@ -75,11 +84,18 @@ public class CookingStackExchangeTest {
                         .optArtifactId("ai.djl.fasttext:cooking_stackexchange")
                         .optOption("label-prefix", "__label")
                         .build();
+        Map<Application, List<Artifact>> models = ModelZoo.listModels(criteria);
+        models.forEach(
+                (app, list) -> {
+                    String appName = app.toString();
+                    list.forEach(artifact -> logger.info("{} {}", appName, artifact));
+                });
         try (ZooModel<String, Classifications> model = criteria.loadModel()) {
             String input = "Which baking dish is best to bake a banana bread ?";
-            FtModel ftModel = (FtModel) model.getWrappedModel();
-            Classifications result = ftModel.classify(input, 8);
-            Assert.assertEquals(result.item(0).getClassName(), "__bread");
+            try (Predictor<String, Classifications> predictor = model.newPredictor()) {
+                Classifications result = predictor.predict(input);
+                Assert.assertEquals(result.item(0).getClassName(), "__bread");
+            }
         }
     }
 
@@ -95,10 +111,9 @@ public class CookingStackExchangeTest {
         try (ZooModel<String, Classifications> model = criteria.loadModel();
                 NDManager manager = NDManager.newBaseManager()) {
 
-            FtModel ftModel = (FtModel) model.getWrappedModel();
             FtWord2VecWordEmbedding fasttextWord2VecWordEmbedding =
                     new FtWord2VecWordEmbedding(
-                            ftModel, new DefaultVocabulary(Collections.singletonList("bread")));
+                            model, new DefaultVocabulary(Collections.singletonList("bread")));
             long index = fasttextWord2VecWordEmbedding.preprocessWordToEmbed("bread");
             NDArray embedding = fasttextWord2VecWordEmbedding.embedWord(manager, index);
             Assert.assertEquals(embedding.getShape(), new Shape(100));
@@ -125,7 +140,7 @@ public class CookingStackExchangeTest {
             model.load(modelFile);
             String text =
                     "Convair was an american aircraft manufacturing company which later expanded into rockets and spacecraft .";
-            Classifications result = model.classify(text, 5);
+            Classifications result = ((FtTextClassification) model.getBlock()).classify(text, 5);
 
             logger.info("{}", result);
             Assert.assertEquals(result.item(0).getClassName(), "Company");


### PR DESCRIPTION
This makes a few changes, specifically to fasttext, but it can apply to other
DJL ml wrappers as well. First, it creates several passthrough utility classes
with the goal that ml models can be loaded through the model zoo and run through
the predictor.

Next, it modifies the base of the ml construct to better support engines that
have multiple applications. Each application now manifests as a type of
SymbolBlock rather than a model. Then, the single model class can run any of
them. The model is still created for each engine because it contains general
loading functionality that can determine which block should be used to load the
given target.

It also has to update the fasttext JNI to support this. First, it fixes the
modelType to actually return different results. Then, it modifies the
predictProba method to use an ArrayList instead of an Array. The main difference
is because it is possible to pass a topk of -1 in order to load all elements.
However, this doesn't work with the previous array setup.

Change-Id: I5fbaceb2ac4711a942b9d15dac6e6fed386dd46e
