### PR TITLE
Fix the python version bug in the benchmark workflow files

### DIFF
--- a/.github/workflows/native_jni_s3_pytorch.yml
+++ b/.github/workflows/native_jni_s3_pytorch.yml
@@ -71,7 +71,7 @@ jobs:
           add-apt-repository -y ppa:deadsnakes/ppa
           apt-get update
           apt-get install -y python3 python3-distutils
-          curl -O https://bootstrap.pypa.io/get-pip.py
+          curl -O https://bootstrap.pypa.io/pip/3.6/get-pip.py
           python3 get-pip.py
           pip3 install awscli --upgrade
       - name: Release JNI prep


### PR DESCRIPTION
## Description ##

There is an error reported from
`/.github/workflows/native_jni_s3_pytorch.yml`

The problem happens at line 74-75 with the error message:
```
ERROR: This script does not work on Python 3.6 The minimum supported Python version is 3.7. Please use https://bootstrap.pypa.io/pip/3.6/get-pip.py instead.
```

This error is reported from the file 

'https://bootstrap.pypa.io/get-pip.py'

It is fixed by downloading from the compatible source
`curl -O https://bootstrap.pypa.io/pip/3.6/get-pip.py`