### PR TITLE
[jupyter] remove unecessary maven import

### DIFF
--- a/jupyter/pytorch/load_your_own_pytorch_bert.ipynb
+++ b/jupyter/pytorch/load_your_own_pytorch_bert.ipynb
@@ -44,8 +44,7 @@
     "%maven ai.djl:api:0.16.0\n",
     "%maven ai.djl.pytorch:pytorch-engine:0.16.0\n",
     "%maven ai.djl.pytorch:pytorch-model-zoo:0.16.0\n",
-    "%maven org.slf4j:slf4j-simple:1.7.32\n",
-    "%maven net.java.dev.jna:jna:5.8.0"
+    "%maven org.slf4j:slf4j-simple:1.7.32"
    ]
   },
   {


### PR DESCRIPTION
Change-Id: I159a7321f3d66aebf193063532ab70ccb9d657cb

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
