### PR TITLE
[api] Make resource loading compatible with java9 module

### DIFF
--- a/api/src/main/java/ai/djl/util/ClassLoaderUtils.java
+++ b/api/src/main/java/ai/djl/util/ClassLoaderUtils.java
@@ -14,6 +14,7 @@ package ai.djl.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -166,5 +167,46 @@ public final class ClassLoaderUtils {
             return ClassLoaderUtils.class.getClassLoader(); // NOPMD
         }
         return cl;
+    }
+
+    /**
+     * Finds all the resources with the given name.
+     *
+     * @param name the resource name
+     * @return An enumeration of {@link java.net.URL URL} objects for the resource
+     * @throws IOException if I/O errors occur
+     */
+    public static Enumeration<URL> getResources(String name) throws IOException {
+        return getContextClassLoader().getResources(name);
+    }
+
+    /**
+     * Finds the first resource in class path with the given name.
+     *
+     * @param name the resource name
+     * @return an enumeration of {@link java.net.URL URL} objects for the resource
+     * @throws IOException if I/O errors occur
+     */
+    public static URL getResource(String name) throws IOException {
+        Enumeration<URL> en = getResources(name);
+        if (en.hasMoreElements()) {
+            return en.nextElement();
+        }
+        return null;
+    }
+
+    /**
+     * Returns an {@code InputStream} for reading from the resource.
+     *
+     * @param name the resource name
+     * @return an {@code InputStream} for reading
+     * @throws IOException if I/O errors occur
+     */
+    public static InputStream getResourceAsStream(String name) throws IOException {
+        URL url = getResource(name);
+        if (url == null) {
+            throw new IOException("Resource not found in classpath: " + name);
+        }
+        return url.openStream();
     }
 }

--- a/api/src/main/java/ai/djl/util/Platform.java
+++ b/api/src/main/java/ai/djl/util/Platform.java
@@ -136,21 +136,23 @@ public final class Platform {
     }
 
     private static Platform fromSystem(String engine) {
-        String engineProp = '/' + engine + "-engine.properties";
+        String engineProp = engine + "-engine.properties";
         String versionKey = engine + "_version";
         Platform platform = fromSystem();
         platform.placeholder = true;
 
-        URL url = Platform.class.getResource(engineProp);
-        if (url != null) {
-            try (InputStream is = url.openStream()) {
-                Properties prop = new Properties();
-                prop.load(is);
-                platform.version = prop.getProperty(versionKey);
-                platform.apiVersion = prop.getProperty("djl_version");
-            } catch (IOException e) {
-                throw new AssertionError("Failed to read property file: " + engineProp, e);
+        try {
+            URL url = ClassLoaderUtils.getResource(engineProp);
+            if (url != null) {
+                try (InputStream is = url.openStream()) {
+                    Properties prop = new Properties();
+                    prop.load(is);
+                    platform.version = prop.getProperty(versionKey);
+                    platform.apiVersion = prop.getProperty("djl_version");
+                }
             }
+        } catch (IOException e) {
+            throw new AssertionError("Failed to read property file: " + engineProp, e);
         }
         return platform;
     }

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/AmesRandomAccess.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/AmesRandomAccess.java
@@ -27,6 +27,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.commons.csv.CSVFormat;
 
@@ -237,7 +238,9 @@ public class AmesRandomAccess extends CsvDataset {
 
         private void parseFeatures() {
             if (af == null) {
-                try (InputStream is = AmesRandomAccess.class.getResourceAsStream("ames.json");
+                try (InputStream is =
+                                Objects.requireNonNull(
+                                        AmesRandomAccess.class.getResourceAsStream("ames.json"));
                         Reader reader = new InputStreamReader(is, StandardCharsets.UTF_8)) {
                     af = JsonUtils.GSON.fromJson(reader, AmesFeatures.class);
                 } catch (IOException e) {

--- a/engines/dlr/dlr-engine/src/main/java/ai/djl/dlr/jni/LibUtils.java
+++ b/engines/dlr/dlr-engine/src/main/java/ai/djl/dlr/jni/LibUtils.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.dlr.jni;
 
+import ai.djl.util.ClassLoaderUtils;
 import ai.djl.util.Platform;
 import ai.djl.util.Utils;
 import java.io.File;
@@ -93,12 +94,9 @@ public final class LibUtils {
             Files.createDirectories(dlrCacheRoot);
             tmp = Files.createTempDirectory(dlrCacheRoot, "tmp");
             for (String file : platform.getLibraries()) {
-                String libPath = "/native/lib/" + file;
+                String libPath = "native/lib/" + file;
                 logger.info("Extracting {} to cache ...", libPath);
-                try (InputStream is = LibUtils.class.getResourceAsStream(libPath)) {
-                    if (is == null) {
-                        throw new IllegalStateException("native library not found: " + libPath);
-                    }
+                try (InputStream is = ClassLoaderUtils.getResourceAsStream(libPath)) {
                     Files.copy(is, tmp.resolve(file), StandardCopyOption.REPLACE_EXISTING);
                 }
             }
@@ -165,11 +163,8 @@ public final class LibUtils {
         }
         Path tmp = null;
         // both cpu & gpu share the same jnilib
-        String lib = "/jnilib/" + classifier + '/' + name;
-        try (InputStream is = LibUtils.class.getResourceAsStream(lib)) {
-            if (is == null) {
-                throw new UnsupportedOperationException("DLR is not supported by this platform");
-            }
+        String lib = "jnilib/" + classifier + '/' + name;
+        try (InputStream is = ClassLoaderUtils.getResourceAsStream(lib)) {
             tmp = Files.createTempFile(nativeDir, "jni", "tmp");
             Files.copy(is, tmp, StandardCopyOption.REPLACE_EXISTING);
             Utils.moveQuietly(tmp, path);

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/jna/LibUtils.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/jna/LibUtils.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.mxnet.jna;
 
+import ai.djl.util.ClassLoaderUtils;
 import ai.djl.util.Platform;
 import ai.djl.util.Utils;
 import com.sun.jna.Library;
@@ -137,12 +138,9 @@ public final class LibUtils {
             Files.createDirectories(cacheFolder);
             tmp = Files.createTempDirectory(cacheFolder, "tmp");
             for (String file : platform.getLibraries()) {
-                String libPath = "/native/lib/" + file;
+                String libPath = "native/lib/" + file;
                 logger.info("Extracting {} to cache ...", libPath);
-                try (InputStream is = LibUtils.class.getResourceAsStream(libPath)) {
-                    if (is == null) {
-                        throw new IllegalStateException("MXNet library not found: " + libPath);
-                    }
+                try (InputStream is = ClassLoaderUtils.getResourceAsStream(libPath)) {
                     Files.copy(is, tmp.resolve(file), StandardCopyOption.REPLACE_EXISTING);
                 }
             }

--- a/engines/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/jni/LibUtils.java
+++ b/engines/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/jni/LibUtils.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.paddlepaddle.jni;
 
+import ai.djl.util.ClassLoaderUtils;
 import ai.djl.util.Platform;
 import ai.djl.util.Utils;
 import java.io.File;
@@ -143,14 +144,11 @@ public final class LibUtils {
 
         Path tmp = null;
         // Paddle GPU and CPU share the same jni so file
-        String libPath = "/jnilib/" + classifier + "/cpu/" + name;
-        try (InputStream stream = LibUtils.class.getResourceAsStream(libPath)) {
+        String libPath = "jnilib/" + classifier + "/cpu/" + name;
+        try (InputStream is = ClassLoaderUtils.getResourceAsStream(libPath)) {
             logger.info("Extracting {} to cache ...", libPath);
-            if (stream == null) {
-                throw new IllegalStateException("Paddle jni not found: " + libPath);
-            }
             tmp = Files.createTempFile(nativeDir, "jni", "tmp");
-            Files.copy(stream, tmp, StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(is, tmp, StandardCopyOption.REPLACE_EXISTING);
             Utils.moveQuietly(tmp, path);
             return path.toAbsolutePath().toString();
         } catch (IOException e) {
@@ -191,17 +189,17 @@ public final class LibUtils {
             Files.createDirectories(cacheFolder);
             tmp = Files.createTempDirectory(cacheFolder, "tmp");
             for (String file : platform.getLibraries()) {
-                String libPath = "/native/lib/" + file;
+                String libPath = "native/lib/" + file;
                 logger.info("Extracting {} to cache ...", file);
                 if (file.endsWith(".gz")) {
                     // FIXME: temporary workaround for paddlepaddle-native-cu102:2.0.2
                     String f = file.substring(0, file.length() - 3);
                     try (InputStream is =
-                            new GZIPInputStream(LibUtils.class.getResourceAsStream(libPath))) {
+                            new GZIPInputStream(ClassLoaderUtils.getResourceAsStream(libPath))) {
                         Files.copy(is, tmp.resolve(f), StandardCopyOption.REPLACE_EXISTING);
                     }
                 } else {
-                    try (InputStream is = LibUtils.class.getResourceAsStream(libPath)) {
+                    try (InputStream is = ClassLoaderUtils.getResourceAsStream(libPath)) {
                         Files.copy(is, tmp.resolve(file), StandardCopyOption.REPLACE_EXISTING);
                     }
                 }

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/javacpp/LibUtils.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/javacpp/LibUtils.java
@@ -13,6 +13,7 @@
 
 package ai.djl.tensorflow.engine.javacpp;
 
+import ai.djl.util.ClassLoaderUtils;
 import ai.djl.util.Platform;
 import ai.djl.util.Utils;
 import java.io.File;
@@ -104,12 +105,9 @@ public final class LibUtils {
             Files.createDirectories(cacheFolder);
             tmp = Files.createTempDirectory(cacheFolder, "tmp");
             for (String file : platform.getLibraries()) {
-                String libPath = "/native/lib/" + file;
+                String libPath = "native/lib/" + file;
                 logger.info("Extracting {} to cache ...", libPath);
-                try (InputStream is = LibUtils.class.getResourceAsStream(libPath)) {
-                    if (is == null) {
-                        throw new IllegalStateException("Tensorflow library not found: " + libPath);
-                    }
+                try (InputStream is = ClassLoaderUtils.getResourceAsStream(libPath)) {
                     Files.copy(is, tmp.resolve(file), StandardCopyOption.REPLACE_EXISTING);
                 }
             }

--- a/engines/tensorrt/src/main/java/ai/djl/tensorrt/jni/LibUtils.java
+++ b/engines/tensorrt/src/main/java/ai/djl/tensorrt/jni/LibUtils.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.tensorrt.jni;
 
+import ai.djl.util.ClassLoaderUtils;
 import ai.djl.util.Platform;
 import ai.djl.util.Utils;
 import java.io.IOException;
@@ -63,13 +64,10 @@ public final class LibUtils {
         Path tmp = null;
         String libPath = "/jnilib/" + classifier + "/" + name;
         logger.info("Extracting {} to cache ...", libPath);
-        try (InputStream stream = LibUtils.class.getResourceAsStream(libPath)) {
-            if (stream == null) {
-                throw new IllegalStateException("TensorRT library not found: " + libPath);
-            }
+        try (InputStream is = ClassLoaderUtils.getResourceAsStream(libPath)) {
             Files.createDirectories(dir);
             tmp = Files.createTempFile(cacheDir, "jni", "tmp");
-            Files.copy(stream, tmp, StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(is, tmp, StandardCopyOption.REPLACE_EXISTING);
             Utils.moveQuietly(tmp, path);
             return path.toAbsolutePath().toString();
         } catch (IOException e) {

--- a/engines/tflite/tflite-engine/src/main/java/ai/djl/tflite/engine/LibUtils.java
+++ b/engines/tflite/tflite-engine/src/main/java/ai/djl/tflite/engine/LibUtils.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.tflite.engine;
 
+import ai.djl.util.ClassLoaderUtils;
 import ai.djl.util.Platform;
 import ai.djl.util.Utils;
 import java.io.IOException;
@@ -80,12 +81,9 @@ public final class LibUtils {
             Files.createDirectories(cacheFolder);
             tmp = Files.createTempDirectory(cacheFolder, "tmp");
             for (String file : platform.getLibraries()) {
-                String libPath = "/native/lib/" + file;
+                String libPath = "native/lib/" + file;
                 logger.info("Extracting {} to cache ...", libPath);
-                try (InputStream is = LibUtils.class.getResourceAsStream(libPath)) {
-                    if (is == null) {
-                        throw new IllegalStateException("TFLite library not found: " + libPath);
-                    }
+                try (InputStream is = ClassLoaderUtils.getResourceAsStream(libPath)) {
                     Files.copy(is, tmp.resolve(file), StandardCopyOption.REPLACE_EXISTING);
                 }
             }

--- a/extensions/aws-ai/src/main/java/ai/djl/aws/sagemaker/SageMaker.java
+++ b/extensions/aws-ai/src/main/java/ai/djl/aws/sagemaker/SageMaker.java
@@ -28,6 +28,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Objects;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
@@ -302,7 +303,7 @@ public final class SageMaker {
 
     private void addToTar(Path root, Path file, TarArchiveOutputStream tos) throws IOException {
         Path relative = root.relativize(file);
-        String name = modelName + '/' + relative.toString();
+        String name = modelName + '/' + relative;
         if (Files.isDirectory(file)) {
             File[] files = file.toFile().listFiles();
             if (files != null) {
@@ -433,7 +434,7 @@ public final class SageMaker {
     }
 
     private static String readPolicyDocument(String path) {
-        try (InputStream is = SageMaker.class.getResourceAsStream(path)) {
+        try (InputStream is = Objects.requireNonNull(SageMaker.class.getResourceAsStream(path))) {
             return Utils.toString(is);
         } catch (IOException e) {
             throw new AssertionError("Failed to read " + path, e);

--- a/extensions/fasttext/src/main/java/ai/djl/fasttext/jni/LibUtils.java
+++ b/extensions/fasttext/src/main/java/ai/djl/fasttext/jni/LibUtils.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.fasttext.jni;
 
+import ai.djl.util.ClassLoaderUtils;
 import ai.djl.util.Platform;
 import ai.djl.util.Utils;
 import java.io.IOException;
@@ -63,14 +64,11 @@ public final class LibUtils {
             return path.toAbsolutePath().toString();
         }
         Path tmp = null;
-        String libPath = "/native/lib/" + classifier + "/" + name;
-        try (InputStream stream = LibUtils.class.getResourceAsStream(libPath)) {
-            if (stream == null) {
-                throw new IllegalStateException("fastText library not found: " + libPath);
-            }
+        String libPath = "native/lib/" + classifier + "/" + name;
+        try (InputStream is = ClassLoaderUtils.getResourceAsStream(libPath)) {
             Files.createDirectories(nativeDir.resolve(version));
             tmp = Files.createTempFile(nativeDir, "jni", "tmp");
-            Files.copy(stream, tmp, StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(is, tmp, StandardCopyOption.REPLACE_EXISTING);
             Utils.moveQuietly(tmp, path);
             return path.toAbsolutePath().toString();
         } catch (IOException e) {

--- a/extensions/sentencepiece/src/main/java/ai/djl/sentencepiece/jni/LibUtils.java
+++ b/extensions/sentencepiece/src/main/java/ai/djl/sentencepiece/jni/LibUtils.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.sentencepiece.jni;
 
+import ai.djl.util.ClassLoaderUtils;
 import ai.djl.util.Platform;
 import ai.djl.util.Utils;
 import java.io.IOException;
@@ -59,15 +60,12 @@ public final class LibUtils {
             return path.toAbsolutePath().toString();
         }
         Path tmp = null;
-        String libPath = "/native/lib/" + classifier + "/" + name;
+        String libPath = "native/lib/" + classifier + "/" + name;
         logger.info("Extracting {} to cache ...", libPath);
-        try (InputStream stream = LibUtils.class.getResourceAsStream(libPath)) {
-            if (stream == null) {
-                throw new IllegalStateException("SentencePiece library not found: " + libPath);
-            }
+        try (InputStream is = ClassLoaderUtils.getResourceAsStream(libPath)) {
             Files.createDirectories(nativeDir.resolve(version));
             tmp = Files.createTempFile(nativeDir, "jni", "tmp");
-            Files.copy(stream, tmp, StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(is, tmp, StandardCopyOption.REPLACE_EXISTING);
             Utils.moveQuietly(tmp, path);
             return path.toAbsolutePath().toString();
         } catch (IOException e) {

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/LibUtils.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/LibUtils.java
@@ -13,6 +13,7 @@
 package ai.djl.huggingface.tokenizers.jni;
 
 import ai.djl.engine.EngineException;
+import ai.djl.util.ClassLoaderUtils;
 import ai.djl.util.Platform;
 import ai.djl.util.Utils;
 import java.io.IOException;
@@ -86,12 +87,9 @@ public final class LibUtils {
             tmp = Files.createTempDirectory(cacheDir, "tmp");
 
             for (String libName : libs) {
-                String libPath = "/native/lib/" + classifier + "/" + libName;
+                String libPath = "native/lib/" + classifier + "/" + libName;
                 logger.info("Extracting {} to cache ...", libPath);
-                try (InputStream is = LibUtils.class.getResourceAsStream(libPath)) {
-                    if (is == null) {
-                        throw new IllegalStateException("tokenizers library not found: " + libPath);
-                    }
+                try (InputStream is = ClassLoaderUtils.getResourceAsStream(libPath)) {
                     Path target = tmp.resolve(libName);
                     Files.copy(is, target, StandardCopyOption.REPLACE_EXISTING);
                 }


### PR DESCRIPTION
Class.getResourceAsStream() can only load resource from the same module.
Use ClassLoader.getResource() to search the module path.

Change-Id: I380044b949e3ce76824382be6c489d45b9fae05a

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
