### PR TITLE
Support freeze parameters

### DIFF
--- a/api/src/main/java/ai/djl/nn/Block.java
+++ b/api/src/main/java/ai/djl/nn/Block.java
@@ -272,9 +272,9 @@ public interface Block {
      * Freezes or unfreezes all parameters inside the block for training.
      *
      * @param freeze true if the parameter should be frozen
-     * @see Parameter#freeze(Boolean)
+     * @see Parameter#freeze(boolean)
      */
-    default void freezeParameters(Boolean freeze) {
+    default void freezeParameters(boolean freeze) {
         for (Parameter parameter : getParameters().values()) {
             parameter.freeze(freeze);
         }

--- a/api/src/main/java/ai/djl/nn/Block.java
+++ b/api/src/main/java/ai/djl/nn/Block.java
@@ -269,6 +269,18 @@ public interface Block {
             throws IOException, MalformedModelException;
 
     /**
+     * Freezes or unfreezes all parameters inside the block for training.
+     *
+     * @param freeze true if the parameter should be frozen
+     * @see Parameter#freeze(Boolean)
+     */
+    default void freezeParameters(Boolean freeze) {
+        for (Parameter parameter : getParameters().values()) {
+            parameter.freeze(freeze);
+        }
+    }
+
+    /**
      * Validates that actual layout matches the expected layout.
      *
      * @param expectedLayout the expected layout

--- a/api/src/main/java/ai/djl/nn/Parameter.java
+++ b/api/src/main/java/ai/djl/nn/Parameter.java
@@ -144,7 +144,7 @@ public class Parameter implements AutoCloseable {
      *
      * @param freeze true if the parameter should be frozen ({@code freeze == !requiresGradient()})
      */
-    public void freeze(Boolean freeze) {
+    public void freeze(boolean freeze) {
         requiresGrad = !freeze;
         array.setRequiresGradient(requiresGrad);
     }

--- a/api/src/main/java/ai/djl/nn/Parameter.java
+++ b/api/src/main/java/ai/djl/nn/Parameter.java
@@ -134,6 +134,22 @@ public class Parameter implements AutoCloseable {
     }
 
     /**
+     * Freezes or unfreezes the parameter for training.
+     *
+     * <p>Sometimes during training, especially during transfer learning, it is typical to train
+     * only part of the model. For this, the freeze can be used to prevent certain parts from being
+     * trained.
+     *
+     * <p>This modifies the {@link #requiresGradient()} of the parameter.
+     *
+     * @param freeze true if the parameter should be frozen ({@code freeze == !requiresGradient()})
+     */
+    public void freeze(Boolean freeze) {
+        requiresGrad = !freeze;
+        array.setRequiresGradient(requiresGrad);
+    }
+
+    /**
      * Checks if this {@code Parameter} is initialized.
      *
      * @return {@code true} if this {@code Parameter} is initialized


### PR DESCRIPTION
This adds a method to support freezing and unfreezing a parameter for transfer
learning. There is also a helper to (un)freeze all paremters in a block, but
without filtering. For more advanced use cases of (un)freezing part of the
parameters in a block, it should be implemented using block.getChildren(),
block.getDirectParameters() and/or block.getParameters().

fixes #392
fixes #1494