### PR TITLE
allow empty batch data

### DIFF
--- a/api/src/main/java/ai/djl/nn/Blocks.java
+++ b/api/src/main/java/ai/djl/nn/Blocks.java
@@ -29,6 +29,10 @@ public final class Blocks {
      */
     public static NDArray batchFlatten(NDArray array) {
         long batch = array.size(0);
+		if (batch == 0) {
+			// calculate the size of second dimension manually as using -1 would not work here
+			return array.reshape(batch, array.getShape().slice(1).size());
+		}
         return array.reshape(batch, -1);
     }
 


### PR DESCRIPTION
## Description ##

This fix handles the edge case of flattening a batch of zero size. It is a good  quality metric for a software function to be able to handle zero data input even if the calling function could detect this case and create a fake expected output (that was my work-around before). 

Before this fix, this exception would have been thrown:

Caused by: ai.djl.engine.EngineException: cannot reshape tensor of 0 elements into shape [0, -1] because the unspecified dimension size -1 can be any value and is ambiguous
	at ai.djl.pytorch.jni.PyTorchLibrary.torchReshape(Native Method)
