### PR TITLE
[ci] Use cuda 11.3.1 to build pytorch jni

### DIFF
--- a/.github/workflows/native_jni_s3_pytorch.yml
+++ b/.github/workflows/native_jni_s3_pytorch.yml
@@ -50,7 +50,7 @@ jobs:
   build-pytorch-jni-linux:
     if: github.repository == 'deepjavalibrary/djl'
     runs-on: ubuntu-latest
-    container: nvidia/cuda:11.1-cudnn8-devel-ubuntu18.04
+    container: nvidia/cuda:11.3.1-cudnn8-devel-ubuntu18.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
@@ -102,7 +102,7 @@ jobs:
   build-pytorch-jni-precxx11:
     if: github.repository == 'deepjavalibrary/djl'
     runs-on: ubuntu-latest
-    container: nvidia/cuda:11.1-cudnn8-devel-centos7
+    container: nvidia/cuda:11.3.1-cudnn8-devel-centos7
     steps:
       - name: Install Environment
         run: |


### PR DESCRIPTION
Change-Id: I3301525131a3d0e4c1637fe7d625c677f1258516

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
