### PR TITLE
HF Tokenizer: get charspans 

### DIFF
--- a/extensions/tokenizers/rust/src/lib.rs
+++ b/extensions/tokenizers/rust/src/lib.rs
@@ -14,14 +14,15 @@
 
 extern crate tokenizers as tk;
 
-use std::borrow::Borrow;
 use std::str::FromStr;
 use tk::tokenizer::{EncodeInput, Encoding};
-use tk::{FromPretrainedParameters, Offsets};
 use tk::Tokenizer;
+use tk::{FromPretrainedParameters, Offsets};
 
 use jni::objects::{JClass, JMethodID, JObject, JString, JValue};
-use jni::sys::{jboolean, jlong, jlongArray, jobjectArray, jsize, JNI_TRUE, jintArray, jint, jvalue};
+use jni::sys::{
+    jboolean, jint, jlong, jlongArray, jobjectArray, jsize, JNI_TRUE,
+};
 use jni::JNIEnv;
 
 #[no_mangle]
@@ -257,7 +258,8 @@ pub extern "system" fn Java_ai_djl_huggingface_tokenizers_jni_TokenizersLibrary_
         .unwrap();
     for (i, token) in tokens.iter().enumerate() {
         let item: JString = env.new_string(&token).unwrap();
-        env.set_object_array_element(array, i as jsize, item).unwrap();
+        env.set_object_array_element(array, i as jsize, item)
+            .unwrap();
     }
     array
 }
@@ -311,37 +313,34 @@ pub extern "system" fn Java_ai_djl_huggingface_tokenizers_jni_TokenizersLibrary_
     let len = tokens.len() as jsize;
 
     let array: jobjectArray = env
-        .new_object_array(len, "ai/djl/huggingface/tokenizers/jni/CharSpan", JObject::null())
+        .new_object_array(
+            len,
+            "ai/djl/huggingface/tokenizers/jni/CharSpan",
+            JObject::null(),
+        )
         .unwrap();
     for (i, _) in tokens.iter().enumerate() {
         let opt_offsets: Option<(usize, Offsets)> = encoding.token_to_chars(i);
-        //let spans: Option<(usize, Offsets)> = encoding.token_to_chars(i);
-        //maybe check if rust has something like getOrElse?
         match &opt_offsets {
             Some((_, offsets)) => {
-                println!("char spans: {:?}", offsets);
-               // offsets_vec.push((*offsets).0 as jint);
-               // offsets_vec.push((*offsets).1 as jint);
-                let classId = "ai/djl/huggingface/tokenizers/CharSpan";
-                let methodId = "<init>";
+                let class_id = "ai/djl/huggingface/tokenizers/jni/CharSpan";
+                let method_id = "<init>";
                 let params = "(II)V";
-                let cls: JClass = env.find_class(classId).unwrap();
-                let constructor: JMethodID = env.get_method_id(cls, methodId, params).unwrap();
-                let offsets_vec: Vec<JValue> = vec![JValue::Int((*offsets).0 as jint), JValue::Int((*offsets).0 as jint) ];
-                let obj = env.new_object_unchecked(cls, constructor, &offsets_vec[..] ).unwrap();
-                env.set_object_array_element(array, i as jsize, obj).unwrap();
+                let cls: JClass = env.find_class(class_id).unwrap();
+                let constructor: JMethodID = env.get_method_id(cls, method_id, params).unwrap();
+                let offsets_vec: Vec<JValue> = vec![
+                    JValue::Int((*offsets).0 as jint),
+                    JValue::Int((*offsets).1 as jint),
+                ];
+                let obj = env
+                    .new_object_unchecked(cls, constructor, &offsets_vec[..])
+                    .unwrap();
+                env.set_object_array_element(array, i as jsize, obj)
+                    .unwrap();
             }
-            None => {
-                //set Object null here
-                println!("no char spans!");
-                //no spans, set as empty array
-                // let item: jintArray = env.new_int_array(0).unwrap();
-                // env.set_int_array_region(item, 0, &offsets_vec).unwrap();
-                // env.set_object_array_element(array, i as jsize, item).unwrap();
-            }
+            None => {}
         }
-
-        }
+    }
     array
 }
 

--- a/extensions/tokenizers/rust/src/lib.rs
+++ b/extensions/tokenizers/rust/src/lib.rs
@@ -311,7 +311,7 @@ pub extern "system" fn Java_ai_djl_huggingface_tokenizers_jni_TokenizersLibrary_
     let len = tokens.len() as jsize;
 
     let array: jobjectArray = env
-        .new_object_array(len, "ai/djl/huggingface/tokenizers/CharSpan", JObject::null())
+        .new_object_array(len, "ai/djl/huggingface/tokenizers/jni/CharSpan", JObject::null())
         .unwrap();
     for (i, _) in tokens.iter().enumerate() {
         let opt_offsets: Option<(usize, Offsets)> = encoding.token_to_chars(i);
@@ -332,6 +332,7 @@ pub extern "system" fn Java_ai_djl_huggingface_tokenizers_jni_TokenizersLibrary_
                 env.set_object_array_element(array, i as jsize, obj).unwrap();
             }
             None => {
+                //set Object null here
                 println!("no char spans!");
                 //no spans, set as empty array
                 // let item: jintArray = env.new_int_array(0).unwrap();

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/CharSpan.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/CharSpan.java
@@ -1,0 +1,13 @@
+package ai.djl.huggingface.tokenizers;
+
+
+public static class CharSpan {
+    private double start;
+    private double end;
+
+    public CharSpan(int start, int end) {
+        this.start = start;
+        this.end = end;
+    }
+
+}

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/Encoding.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/Encoding.java
@@ -12,6 +12,8 @@
  */
 package ai.djl.huggingface.tokenizers;
 
+import ai.djl.huggingface.tokenizers.jni.CharSpan;
+
 /** A class holds token encoding information. */
 public class Encoding {
 
@@ -21,7 +23,7 @@ public class Encoding {
     private long[] wordIds;
     private long[] attentionMask;
     private long[] specialTokenMask;
-    private int[][] charTokenSpans;
+    private CharSpan[] charTokenSpans;
 
     Encoding(
             long[] ids,
@@ -30,7 +32,7 @@ public class Encoding {
             long[] wordIds,
             long[] attentionMask,
             long[] specialTokenMask,
-            int[][] charTokenSpans) {
+            CharSpan[] charTokenSpans) {
         this.ids = ids;
         this.typeIds = typeIds;
         this.tokens = tokens;

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/Encoding.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/Encoding.java
@@ -21,6 +21,7 @@ public class Encoding {
     private long[] wordIds;
     private long[] attentionMask;
     private long[] specialTokenMask;
+    private int[][] charTokenSpans;
 
     Encoding(
             long[] ids,
@@ -28,13 +29,15 @@ public class Encoding {
             String[] tokens,
             long[] wordIds,
             long[] attentionMask,
-            long[] specialTokenMask) {
+            long[] specialTokenMask,
+            int[][] charTokenSpans) {
         this.ids = ids;
         this.typeIds = typeIds;
         this.tokens = tokens;
         this.wordIds = wordIds;
         this.attentionMask = attentionMask;
         this.specialTokenMask = specialTokenMask;
+        this.charTokenSpans = charTokenSpans;
     }
 
     /**
@@ -90,4 +93,15 @@ public class Encoding {
     public long[] getSpecialTokenMask() {
         return specialTokenMask;
     }
+
+    /**
+     * Returns char token spans.
+     *
+     * @return char token spans
+     */
+    public CharSpan[] getCharTokenSpans() {
+        return charTokenSpans;
+    }
+
 }
+

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/Encoding.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/Encoding.java
@@ -104,6 +104,4 @@ public class Encoding {
     public CharSpan[] getCharTokenSpans() {
         return charTokenSpans;
     }
-
 }
-

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizer.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizer.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.huggingface.tokenizers;
 
+import ai.djl.huggingface.tokenizers.jni.CharSpan;
 import ai.djl.huggingface.tokenizers.jni.LibUtils;
 import ai.djl.huggingface.tokenizers.jni.TokenizersLibrary;
 import ai.djl.modality.nlp.preprocess.Tokenizer;

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizer.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizer.java
@@ -200,8 +200,9 @@ public final class HuggingFaceTokenizer extends NativeResource<Long> implements 
         long[] wordIds = TokenizersLibrary.LIB.getWordIds(encoding);
         long[] attentionMask = TokenizersLibrary.LIB.getAttentionMask(encoding);
         long[] specialTokenMask = TokenizersLibrary.LIB.getSpecialTokenMask(encoding);
+        CharSpan[] charSpans = TokenizersLibrary.LIB.getTokenCharSpans(encoding);
 
         TokenizersLibrary.LIB.deleteEncoding(encoding);
-        return new Encoding(ids, typeIds, tokens, wordIds, attentionMask, specialTokenMask);
+        return new Encoding(ids, typeIds, tokens, wordIds, attentionMask, specialTokenMask, charSpans);
     }
 }

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizer.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizer.java
@@ -204,6 +204,7 @@ public final class HuggingFaceTokenizer extends NativeResource<Long> implements 
         CharSpan[] charSpans = TokenizersLibrary.LIB.getTokenCharSpans(encoding);
 
         TokenizersLibrary.LIB.deleteEncoding(encoding);
-        return new Encoding(ids, typeIds, tokens, wordIds, attentionMask, specialTokenMask, charSpans);
+        return new Encoding(
+                ids, typeIds, tokens, wordIds, attentionMask, specialTokenMask, charSpans);
     }
 }

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/CharSpan.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/CharSpan.java
@@ -1,7 +1,7 @@
-package ai.djl.huggingface.tokenizers;
+package ai.djl.huggingface.tokenizers.jni;
 
 
-public static class CharSpan {
+public class CharSpan {
     private double start;
     private double end;
 

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/CharSpan.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/CharSpan.java
@@ -1,13 +1,19 @@
 package ai.djl.huggingface.tokenizers.jni;
 
-
 public class CharSpan {
-    private double start;
-    private double end;
+    private final int start;
+    private final int end;
 
     public CharSpan(int start, int end) {
         this.start = start;
         this.end = end;
     }
 
+    public double getStart() {
+        return start;
+    }
+
+    public double getEnd() {
+        return end;
+    }
 }

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/CharSpan.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/CharSpan.java
@@ -14,7 +14,9 @@
 /** A class holds character span information. */
 package ai.djl.huggingface.tokenizers.jni;
 
+/** A class holds character span information. */
 public class CharSpan {
+
     private final int start;
     private final int end;
 

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/CharSpan.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/CharSpan.java
@@ -1,19 +1,49 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+/** A class holds character span information. */
 package ai.djl.huggingface.tokenizers.jni;
 
 public class CharSpan {
     private final int start;
     private final int end;
 
+    /**
+     * Constructs a new {@code CharSpan} instance.
+     *
+     * @param start the start position
+     * @param end the end position
+     */
     public CharSpan(int start, int end) {
         this.start = start;
         this.end = end;
     }
 
-    public double getStart() {
+    /**
+     * Returns the start position.
+     *
+     * @return the start position
+     */
+    public int getStart() {
         return start;
     }
 
-    public double getEnd() {
+    /**
+     * Returns the end position.
+     *
+     * @return the end position
+     */
+    public int getEnd() {
         return end;
     }
 }

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/TokenizersLibrary.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/TokenizersLibrary.java
@@ -47,5 +47,4 @@ public final class TokenizersLibrary {
     public native long[] getSpecialTokenMask(long encoding);
 
     public native CharSpan[] getTokenCharSpans(long encoding);
-
 }

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/TokenizersLibrary.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/TokenizersLibrary.java
@@ -45,4 +45,7 @@ public final class TokenizersLibrary {
     public native long[] getAttentionMask(long encoding);
 
     public native long[] getSpecialTokenMask(long encoding);
+
+    public native CharSpan[] getTokenCharSpans(long encoding);
+
 }

--- a/extensions/tokenizers/src/test/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizerTest.java
+++ b/extensions/tokenizers/src/test/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizerTest.java
@@ -13,6 +13,7 @@
 
 package ai.djl.huggingface.tokenizers;
 
+import ai.djl.huggingface.tokenizers.jni.CharSpan;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -48,8 +49,34 @@ public class HuggingFaceTokenizerTest {
             Assert.assertEquals(wordIds, encoding.getWordIds());
             Assert.assertEquals(attentionMask, encoding.getAttentionMask());
             Assert.assertEquals(specialTokenMask, encoding.getSpecialTokenMask());
-           // Assert.assertEquals(null, encoding.getCharTokenSpans());
 
+            CharSpan[] charSpansExpected = {
+                null,
+                new CharSpan(0, 5),
+                new CharSpan(5, 6),
+                new CharSpan(7, 8),
+                new CharSpan(8, 9),
+                new CharSpan(9, 12),
+                new CharSpan(12, 13),
+                new CharSpan(14, 17),
+                new CharSpan(18, 21),
+                new CharSpan(22, 25),
+                new CharSpan(26, 30),
+                new CharSpan(31, 32),
+                null
+            };
+            int expectedLength = charSpansExpected.length;
+            CharSpan[] charSpansResult = encoding.getCharTokenSpans();
+
+            Assert.assertEquals(expectedLength, charSpansResult.length);
+            Assert.assertEquals(charSpansExpected[0], charSpansResult[0]);
+            Assert.assertEquals(
+                    charSpansExpected[expectedLength - 1], charSpansResult[expectedLength - 1]);
+
+            for (int i = 1; i < expectedLength - 1; i++) {
+                Assert.assertEquals(charSpansExpected[i].getStart(), charSpansResult[i].getStart());
+                Assert.assertEquals(charSpansExpected[i].getEnd(), charSpansResult[i].getEnd());
+            }
 
             Encoding[] encodings = tokenizer.batchEncode(Arrays.asList(inputs));
             Assert.assertEquals(encodings.length, 2);

--- a/extensions/tokenizers/src/test/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizerTest.java
+++ b/extensions/tokenizers/src/test/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizerTest.java
@@ -48,6 +48,8 @@ public class HuggingFaceTokenizerTest {
             Assert.assertEquals(wordIds, encoding.getWordIds());
             Assert.assertEquals(attentionMask, encoding.getAttentionMask());
             Assert.assertEquals(specialTokenMask, encoding.getSpecialTokenMask());
+            Assert.assertEquals(null, encoding.getCharTokenSpans());
+
 
             Encoding[] encodings = tokenizer.batchEncode(Arrays.asList(inputs));
             Assert.assertEquals(encodings.length, 2);

--- a/extensions/tokenizers/src/test/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizerTest.java
+++ b/extensions/tokenizers/src/test/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizerTest.java
@@ -48,7 +48,7 @@ public class HuggingFaceTokenizerTest {
             Assert.assertEquals(wordIds, encoding.getWordIds());
             Assert.assertEquals(attentionMask, encoding.getAttentionMask());
             Assert.assertEquals(specialTokenMask, encoding.getSpecialTokenMask());
-            Assert.assertEquals(null, encoding.getCharTokenSpans());
+           // Assert.assertEquals(null, encoding.getCharTokenSpans());
 
 
             Encoding[] encodings = tokenizer.batchEncode(Arrays.asList(inputs));


### PR DESCRIPTION
## Description ##

This PR extends the hugging face Java/Rust interface. I added a method to return the original char spans for each token result, together with the encoding object. 

This function is useful in Named Entity Recognition tasks (NER), specifically to reconstruct entities together, since the tokens retrieved from the tokenization lose whitespace information.