### PR TITLE
[basicdataset] Fixed out of bound limit

### DIFF
--- a/basicdataset/src/main/java/ai/djl/basicdataset/nlp/StanfordQuestionAnsweringDataset.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/nlp/StanfordQuestionAnsweringDataset.java
@@ -238,18 +238,16 @@ public class StanfordQuestionAnsweringDataset extends TextDataset implements Raw
      * @return the last index of the answer in {@code TargetTextData} that needs to be preprocessed
      */
     private int getLastAnswerIndex(int questionInfoIndex) {
-        boolean endAtHead = false;
-        QuestionInfo questionInfo = questionInfoList.get(questionInfoIndex);
-        while (questionInfo.answerIndexList.isEmpty()) {
-            if (questionInfoIndex == 0) {
-                endAtHead = true;
-                break;
+        // Go backwards through the questionInfoList until it finds one with an answer
+        for (; questionInfoIndex >= 0; questionInfoIndex--) {
+            QuestionInfo questionInfo = questionInfoList.get(questionInfoIndex);
+            if (!questionInfo.answerIndexList.isEmpty()) {
+                return questionInfo.answerIndexList.get(questionInfo.answerIndexList.size() - 1);
             }
-            questionInfo = questionInfoList.get(--questionInfoIndex);
         }
-        return endAtHead
-                ? 0
-                : questionInfo.answerIndexList.get(questionInfo.answerIndexList.size() - 1);
+
+        // Could not find a QuestionInfo with an answer
+        return 0;
     }
 
     /**

--- a/basicdataset/src/main/java/ai/djl/basicdataset/nlp/StanfordQuestionAnsweringDataset.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/nlp/StanfordQuestionAnsweringDataset.java
@@ -241,13 +241,19 @@ public class StanfordQuestionAnsweringDataset extends TextDataset implements Raw
     @Override
     protected void preprocess(List<String> newTextData, boolean source) throws EmbeddingException {
         TextData textData = source ? sourceTextData : targetTextData;
-        QuestionInfo questionInfo = questionInfoList.get(Math.toIntExact(this.limit) - 1);
-        int lastIndex =
-                source
-                        ? questionInfo.questionIndex
-                        : questionInfo.answerIndexList.get(questionInfo.answerIndexList.size() - 1);
-        textData.preprocess(
-                manager, newTextData.subList(0, Math.min(lastIndex + 1, newTextData.size())));
+        int limit;
+        if (this.limit < questionInfoList.size()) {
+            QuestionInfo questionInfo = questionInfoList.get(Math.toIntExact(this.limit) - 1);
+            limit =
+                    (source
+                                    ? questionInfo.questionIndex
+                                    : questionInfo.answerIndexList.get(
+                                            questionInfo.answerIndexList.size() - 1))
+                            + 1;
+        } else {
+            limit = newTextData.size();
+        }
+        textData.preprocess(manager, newTextData.subList(0, limit));
     }
 
     /** A builder for a {@link StanfordQuestionAnsweringDataset}. */

--- a/basicdataset/src/test/java/ai/djl/basicdataset/StanfordQuestionAnsweringDatasetTest.java
+++ b/basicdataset/src/test/java/ai/djl/basicdataset/StanfordQuestionAnsweringDatasetTest.java
@@ -122,13 +122,12 @@ public class StanfordQuestionAnsweringDatasetTest {
                                                     TestUtils.getTextEmbedding(
                                                             manager, EMBEDDING_SIZE)))
                             .setSampling(32, true)
-                            .optLimit(350)
                             .optUsage(Dataset.Usage.TEST)
                             .build();
 
             stanfordQuestionAnsweringDataset.prepare();
             stanfordQuestionAnsweringDataset.prepare();
-            Assert.assertEquals(stanfordQuestionAnsweringDataset.size(), 350);
+            Assert.assertEquals(stanfordQuestionAnsweringDataset.size(), 11873);
 
             Record record0 = stanfordQuestionAnsweringDataset.get(manager, 0);
             Record record6 = stanfordQuestionAnsweringDataset.get(manager, 6);


### PR DESCRIPTION
## Description ##

In Stanford Question Answering Dataset the limit is specially handled, and there exists a severe bug that if the limit is too large (or the limit is set as default) it will cause an `IndexOutOfBoundException`.

This PR fixed this bug and changed the test cases into a more strict one so that this bug will be detected.

