### PR TITLE
[pytorch] use precxx11 for aarch64

### DIFF
--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
@@ -363,7 +363,8 @@ public final class LibUtils {
         String classifier = platform.getClassifier();
         String precxx11;
         if (Boolean.getBoolean("PYTORCH_PRECXX11")
-                || Boolean.parseBoolean(System.getenv("PYTORCH_PRECXX11"))) {
+                || Boolean.parseBoolean(System.getenv("PYTORCH_PRECXX11"))
+                || "aarch64".equals(platform.getOsArch())) {
             precxx11 = "-precxx11";
         } else {
             precxx11 = "";


### PR DESCRIPTION
Change-Id: I4a3e4705037b75855f5c0227ecf39657fbb21fa9

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
