### PR TITLE
[api] Avoid NPE in Metric.toString()

### DIFF
--- a/api/src/main/java/ai/djl/metric/Metric.java
+++ b/api/src/main/java/ai/djl/metric/Metric.java
@@ -192,6 +192,9 @@ public class Metric {
         if (dimensions != null) {
             boolean first = true;
             for (Dimension dimension : dimensions) {
+                if (dimension == null) {
+                    continue;
+                }
                 if (first) {
                     sb.append("|#");
                     first = false;


### PR DESCRIPTION
Change-Id: I5dae8088aff74f5d77558ab30aa5e8d0fb96926b

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
