### PR TITLE
Support of take from pytorch

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/NDArray.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArray.java
@@ -514,6 +514,21 @@ public interface NDArray extends NDResource, BytesSupplier {
     /**
      * Returns a partial {@code NDArray}.
      *
+     * @param index the boolean or int {@code NDArray} that indicates what to get
+     * @return the partial {@code NDArray}
+     */
+    default NDArray get(NDArray index) {
+        DataType indexType = index.getDataType();
+        if (indexType == DataType.BOOLEAN) {
+            return get(new NDIndex().addBooleanIndex(index));
+        } else {
+            return take(index);
+        }
+    }
+
+    /**
+     * Returns a partial {@code NDArray}.
+     *
      * @param indices the indices used to indicate what to get
      * @param args arguments to replace the varaible "{}" in the indices string. Can be an integer,
      *     long, boolean {@link NDArray}, or integer {@link NDArray}.
@@ -533,16 +548,6 @@ public interface NDArray extends NDResource, BytesSupplier {
      */
     default NDArray get(long... indices) {
         return get(new NDIndex(indices));
-    }
-
-    /**
-     * Returns a partial {@code NDArray}.
-     *
-     * @param index the boolean {@code NDArray} that indicates what to get
-     * @return the partial {@code NDArray}
-     */
-    default NDArray get(NDArray index) {
-        return get(new NDIndex().addBooleanIndex(index));
     }
 
     /**

--- a/api/src/main/java/ai/djl/ndarray/NDArray.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArray.java
@@ -518,8 +518,7 @@ public interface NDArray extends NDResource, BytesSupplier {
      * @return the partial {@code NDArray}
      */
     default NDArray get(NDArray index) {
-        DataType indexType = index.getDataType();
-        if (indexType == DataType.BOOLEAN) {
+        if (index.getDataType() == DataType.BOOLEAN) {
             return get(new NDIndex().addBooleanIndex(index));
         } else {
             return take(index);

--- a/api/src/main/java/ai/djl/ndarray/NDArray.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArray.java
@@ -557,6 +557,14 @@ public interface NDArray extends NDResource, BytesSupplier {
     NDArray gather(NDArray index, int axis);
 
     /**
+     * Returns a partial {@code NDArray} pointed by the indexed array, according to linear indexing.
+     *
+     * @param index picks the elements of an NDArray to the same position as index
+     * @return the partial {@code NDArray} of the same shape as index
+     */
+    NDArray take(NDArray index);
+
+    /**
      * Returns a scalar {@code NDArray} corresponding to a single element.
      *
      * @param indices the indices of the scalar to return. Must return only a single element

--- a/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
@@ -184,6 +184,12 @@ public abstract class NDArrayAdapter implements NDArray {
 
     /** {@inheritDoc} */
     @Override
+    public NDArray take(NDArray index) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MSG);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void set(Buffer data) {
         NDArray array = manager.create(data, getShape(), getDataType());
         intern(array);

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
@@ -314,6 +314,12 @@ public class MxNDArray extends NativeResource<Pointer> implements LazyNDArray {
 
     /** {@inheritDoc} */
     @Override
+    public NDArray take(NDArray index) {
+        throw new UnsupportedOperationException("Not implemented yet.");
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void copyTo(NDArray ndArray) {
         if (!(ndArray instanceof MxNDArray)) {
             throw new IllegalArgumentException("Only MxNDArray is supported.");

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -250,6 +250,15 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
 
     /** {@inheritDoc} */
     @Override
+    public NDArray take(NDArray index) {
+        if (!(index instanceof PtNDArray)) {
+            throw new IllegalArgumentException("Only PtNDArray is supported.");
+        }
+        return JniUtils.take(this, (PtNDArray) index);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void copyTo(NDArray array) {
         throw new UnsupportedOperationException("Not implemented");
     }

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
@@ -352,6 +352,12 @@ public final class JniUtils {
                 PyTorchLibrary.LIB.torchGather(ndArray.getHandle(), index.getHandle(), dim, false));
     }
 
+    public static PtNDArray take(PtNDArray ndArray, PtNDArray index) {
+        return new PtNDArray(
+                ndArray.getManager(),
+                PyTorchLibrary.LIB.torchTake(ndArray.getHandle(), index.getHandle()));
+    }
+
     public static PtNDArray pick(PtNDArray ndArray, PtNDArray index, long dim) {
         Shape indexShape = index.getShape();
         Shape ndShape = ndArray.getShape();

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
@@ -347,12 +347,18 @@ public final class JniUtils {
     }
 
     public static PtNDArray gather(PtNDArray ndArray, PtNDArray index, long dim) {
+        if (index.getDataType() != DataType.INT64) {
+            index = index.toType(DataType.INT64, true);
+        }
         return new PtNDArray(
                 ndArray.getManager(),
                 PyTorchLibrary.LIB.torchGather(ndArray.getHandle(), index.getHandle(), dim, false));
     }
 
     public static PtNDArray take(PtNDArray ndArray, PtNDArray index) {
+        if (index.getDataType() != DataType.INT64) {
+            index = index.toType(DataType.INT64, true);
+        }
         return new PtNDArray(
                 ndArray.getManager(),
                 PyTorchLibrary.LIB.torchTake(ndArray.getHandle(), index.getHandle()));

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
@@ -198,6 +198,8 @@ final class PyTorchLibrary {
 
     native long torchGather(long handle, long index, long dim, boolean sparseGrad);
 
+    native long torchTake(long handle, long index);
+
     native long torchMaskedSelect(long handle, long maskHandle);
 
     native void torchMaskedPut(long handle, long valueHandle, long maskHandle);

--- a/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_tensor.cc
+++ b/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_tensor.cc
@@ -176,6 +176,16 @@ JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchGather(
   API_END_RETURN()
 }
 
+JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchTake(
+    JNIEnv* env, jobject jthis, jlong jhandle, jlong jindex_handle) {
+  API_BEGIN()
+  const auto* tensor_ptr = reinterpret_cast<torch::Tensor*>(jhandle);
+  const auto* index_ptr = reinterpret_cast<torch::Tensor*>(jindex_handle);
+  const auto* result_ptr = new torch::Tensor(tensor_ptr->take(*index_ptr));
+  return reinterpret_cast<uintptr_t>(result_ptr);
+  API_END_RETURN()  
+}
+
 JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchMaskedSelect(
     JNIEnv* env, jobject jthis, jlong jhandle, jlong jmasked_handle) {
   API_BEGIN()

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
@@ -214,6 +214,12 @@ public class TfNDArray extends NativeResource<TFE_TensorHandle> implements NDArr
 
     /** {@inheritDoc} */
     @Override
+    public NDArray take(NDArray index) {
+        throw new UnsupportedOperationException("Not implemented yet.");
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void attach(NDManager manager) {
         detach();
         this.manager = (TfNDManager) manager;

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
@@ -12,7 +12,6 @@
  */
 package ai.djl.integration.tests.ndarray;
 
-import ai.djl.engine.Engine;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.index.NDIndex;
@@ -56,13 +55,12 @@ public class NDIndexTest {
 
     @Test
     public void testGather() {
-        // Currently in windows gradle cannot find all the engines.
+        // Currently in windows gradle cannot find all the engines to fill in -classpath, except for
+        // MXNet.
         // In the dependencies, changing runtimeOnly to api however will remedy the problem.
         // TODO: remove this when gradle problem is fixed.
         TestRequirements.notWindows();
-        Engine engine = Engine.getEngine("PyTorch");
-        try (NDManager manager = engine.newBaseManager()) {
-//        try (NDManager manager = NDManager.newBaseManager()) {
+        try (NDManager manager = NDManager.newBaseManager()) {
             NDArray arr = manager.arange(20f).reshape(-1, 4);
             NDArray index = manager.create(new long[] {0, 0, 2, 1, 1, 2}, new Shape(3, 2));
             NDArray actual = arr.gather(index, 1);
@@ -73,9 +71,10 @@ public class NDIndexTest {
 
     @Test
     public void testTake() {
-        Engine engine = Engine.getEngine("PyTorch");
-        try (NDManager manager = engine.newBaseManager()) {
-            NDArray arr = manager.arange(1,7f).reshape(-1, 3);
+        // TODO: remove this when gradle problem in windows shown above is fixed.
+        TestRequirements.notWindows();
+        try (NDManager manager = NDManager.newBaseManager()) {
+            NDArray arr = manager.arange(1, 7f).reshape(-1, 3);
             NDArray index = manager.create(new long[] {0, 4, 1, 2}, new Shape(2, 2));
             NDArray actual = arr.take(index);
             NDArray expected = manager.create(new float[] {1, 5, 2, 3}, new Shape(2, 2));

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
@@ -12,11 +12,11 @@
  */
 package ai.djl.integration.tests.ndarray;
 
+import ai.djl.engine.Engine;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.index.NDIndex;
 import ai.djl.ndarray.types.Shape;
-import ai.djl.testing.TestRequirements;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -55,11 +55,6 @@ public class NDIndexTest {
 
     @Test
     public void testGather() {
-        // Currently in windows gradle cannot find all the engines to fill in -classpath, except for
-        // MXNet.
-        // In the dependencies, changing runtimeOnly to api however will remedy the problem.
-        // TODO: remove this when gradle problem is fixed.
-        TestRequirements.notWindows();
         try (NDManager manager = NDManager.newBaseManager()) {
             NDArray arr = manager.arange(20f).reshape(-1, 4);
             NDArray index = manager.create(new long[] {0, 0, 2, 1, 1, 2}, new Shape(3, 2));
@@ -71,8 +66,6 @@ public class NDIndexTest {
 
     @Test
     public void testTake() {
-        // TODO: remove this when gradle problem in windows shown above is fixed.
-        TestRequirements.notWindows();
         try (NDManager manager = NDManager.newBaseManager()) {
             NDArray arr = manager.arange(1, 7f).reshape(-1, 3);
             NDArray index = manager.create(new long[] {0, 4, 1, 2}, new Shape(2, 2));

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
@@ -12,7 +12,6 @@
  */
 package ai.djl.integration.tests.ndarray;
 
-import ai.djl.engine.Engine;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.index.NDIndex;

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
@@ -69,10 +69,8 @@ public class NDIndexTest {
             NDArray arr = manager.arange(1, 7f).reshape(-1, 3);
             NDArray index = manager.create(new long[] {0, 4, 1, 2}, new Shape(2, 2));
             NDArray actual = arr.take(index);
-            NDArray actual2 = arr.get(index);
             NDArray expected = manager.create(new float[] {1, 5, 2, 3}, new Shape(2, 2));
             Assert.assertEquals(actual, expected);
-            Assert.assertEquals(actual2, expected);
         }
     }
 
@@ -119,6 +117,13 @@ public class NDIndexTest {
             NDArray bool = manager.create(new boolean[] {true, false});
             expected = manager.arange(5).reshape(1, 5);
             Assert.assertEquals(original.get(bool), expected);
+
+            // get from int array
+            original = manager.arange(1, 7f).reshape(-1, 3);
+            NDArray index = manager.create(new long[] {0, 4, 1, 2}, new Shape(2, 2));
+            NDArray actual = original.take(index);
+            expected = manager.create(new float[] {1, 5, 2, 3}, new Shape(2, 2));
+            Assert.assertEquals(actual, expected);
         }
     }
 

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.integration.tests.ndarray;
 
+import ai.djl.engine.Engine;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.index.NDIndex;
@@ -61,10 +62,21 @@ public class NDIndexTest {
         TestRequirements.notWindows();
         try (NDManager manager = NDManager.newBaseManager()) {
             NDArray arr = manager.arange(20f).reshape(-1, 4);
-            long[] idx = {0, 0, 2, 1, 1, 2};
-            NDArray index = manager.create(idx, new Shape(3, 2));
+            NDArray index = manager.create(new long[] {0, 0, 2, 1, 1, 2}, new Shape(3, 2));
             NDArray actual = arr.gather(index, 1);
             NDArray expected = manager.create(new float[] {0, 0, 6, 5, 9, 10}, new Shape(3, 2));
+            Assert.assertEquals(actual, expected);
+        }
+    }
+
+    @Test
+    public void testTake() {
+        Engine engine = Engine.getEngine("PyTorch");
+        try (NDManager manager = engine.newBaseManager()) {
+            NDArray arr = manager.arange(6f).reshape(-1, 3);
+            NDArray index = manager.create(new long[] {0, 4, 1, 2}, new Shape(2, 2));
+            NDArray actual = arr.take(index);
+            NDArray expected = manager.create(new float[] {1, 5, 2, 3}, new Shape(2, 2));
             Assert.assertEquals(actual, expected);
         }
     }

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
@@ -60,7 +60,9 @@ public class NDIndexTest {
         // In the dependencies, changing runtimeOnly to api however will remedy the problem.
         // TODO: remove this when gradle problem is fixed.
         TestRequirements.notWindows();
-        try (NDManager manager = NDManager.newBaseManager()) {
+        Engine engine = Engine.getEngine("PyTorch");
+        try (NDManager manager = engine.newBaseManager()) {
+//        try (NDManager manager = NDManager.newBaseManager()) {
             NDArray arr = manager.arange(20f).reshape(-1, 4);
             NDArray index = manager.create(new long[] {0, 0, 2, 1, 1, 2}, new Shape(3, 2));
             NDArray actual = arr.gather(index, 1);
@@ -73,7 +75,7 @@ public class NDIndexTest {
     public void testTake() {
         Engine engine = Engine.getEngine("PyTorch");
         try (NDManager manager = engine.newBaseManager()) {
-            NDArray arr = manager.arange(6f).reshape(-1, 3);
+            NDArray arr = manager.arange(1,7f).reshape(-1, 3);
             NDArray index = manager.create(new long[] {0, 4, 1, 2}, new Shape(2, 2));
             NDArray actual = arr.take(index);
             NDArray expected = manager.create(new float[] {1, 5, 2, 3}, new Shape(2, 2));

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
@@ -121,7 +121,7 @@ public class NDIndexTest {
             // get from int array
             original = manager.arange(1, 7f).reshape(-1, 3);
             NDArray index = manager.create(new long[] {0, 4, 1, 2}, new Shape(2, 2));
-            NDArray actual = original.take(index);
+            NDArray actual = original.get(index);
             expected = manager.create(new float[] {1, 5, 2, 3}, new Shape(2, 2));
             Assert.assertEquals(actual, expected);
         }

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
@@ -69,8 +69,10 @@ public class NDIndexTest {
             NDArray arr = manager.arange(1, 7f).reshape(-1, 3);
             NDArray index = manager.create(new long[] {0, 4, 1, 2}, new Shape(2, 2));
             NDArray actual = arr.take(index);
+            NDArray actual2 = arr.get(index);
             NDArray expected = manager.create(new float[] {1, 5, 2, 3}, new Shape(2, 2));
             Assert.assertEquals(actual, expected);
+            Assert.assertEquals(actual2, expected);
         }
     }
 


### PR DESCRIPTION
## Description ##

This is a follow-up on PR https://github.com/deepjavalibrary/djl/pull/1622. The `take` feature will enable more advanced indexing.

It's the same as `take` in [numpy ](https://numpy.org/doc/stable/reference/generated/numpy.take.html#numpy.take) and [ pytorch](https://pytorch.org/docs/1.11/generated/torch.take.html?highlight=take#torch.take).

Defination of `NDArray take(NDArray index)`:
Returns a partial pointed by the index array, according to row-major-ordering linear indexing.
The shape of the output is decided by that of `index`.
