### PR TITLE
Add rpath fix to Native Publish PyTorch

### DIFF
--- a/.github/workflows/native_publish_pytorch.yml
+++ b/.github/workflows/native_publish_pytorch.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/engines/pytorch/pytorch-native/build.gradle
+++ b/engines/pytorch/pytorch-native/build.gradle
@@ -109,10 +109,10 @@ def prepareNativeLib(String binaryRoot, String ver) {
 
 
     exec {
-        commandLine 'install_name_tool', '-add_rpath', '"@loader_path"', "${binaryRoot}/cpu/osx-x86_64/native/lib/libtorch_cpu.dylib"
+        commandLine 'install_name_tool', '-add_rpath', '@loader_path', "${binaryRoot}/cpu/osx-x86_64/native/lib/libtorch_cpu.dylib"
     }
     exec {
-        commandLine 'install_name_tool', '-add_rpath', '"@loader_path"', "${binaryRoot}/cpu/osx-x86_64/native/lib/libtorch.dylib"
+        commandLine 'install_name_tool', '-add_rpath', '@loader_path', "${binaryRoot}/cpu/osx-x86_64/native/lib/libtorch.dylib"
     }
 }
 

--- a/engines/pytorch/pytorch-native/build.gradle
+++ b/engines/pytorch/pytorch-native/build.gradle
@@ -76,6 +76,10 @@ def downloadBuildAndroid(String ver) {
 }
 
 def prepareNativeLib(String binaryRoot, String ver) {
+    if (!System.properties['os.name'].toLowerCase(Locale.ROOT).contains("mac")) {
+        throw new GradleException("This command must be run from osx")
+    }
+
     def officialPytorchUrl = "https://download.pytorch.org/libtorch"
     def aarch64PytorchUrl = "https://djl-ai.s3.amazonaws.com/publish/pytorch"
     String cu11
@@ -102,6 +106,14 @@ def prepareNativeLib(String binaryRoot, String ver) {
 
     copyNativeLibToOutputDir(files, binaryRoot, officialPytorchUrl)
     copyNativeLibToOutputDir(aarch64Files, binaryRoot, aarch64PytorchUrl)
+
+
+    exec {
+        commandLine 'install_name_tool', '-add_rpath', '"@loader_path"', "${binaryRoot}/cpu/osx-x86_64/native/lib/libtorch_cpu.dylib"
+    }
+    exec {
+        commandLine 'install_name_tool', '-add_rpath', '"@loader_path"', "${binaryRoot}/cpu/osx-x86_64/native/lib/libtorch.dylib"
+    }
 }
 
 def copyNativeLibToOutputDir(Map<String, String> fileStoreMap, String binaryRoot, String url) {


### PR DESCRIPTION
This adds the install name tool rpath fix to downloading the pytorch native libraries.
It also updates the gradle script that runs the publish to run on osx which has
the fixer tool instead of osx.

It does have a minor breaking aspect as now the publish must be run from osx. I
did add an early error in case it is run from a different os.