### PR TITLE
[api] Improves ServingTranslator output handling

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/NDList.java
+++ b/api/src/main/java/ai/djl/ndarray/NDList.java
@@ -292,8 +292,18 @@ public class NDList extends ArrayList<NDArray> implements NDResource, BytesSuppl
      * @return the byte array
      */
     public byte[] encode() {
+        return encode(false);
+    }
+
+    /**
+     * Encodes the NDList to byte array.
+     *
+     * @param numpy encode in npz format if true
+     * @return the byte array
+     */
+    public byte[] encode(boolean numpy) {
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-            encode(baos);
+            encode(baos, numpy);
             return baos.toByteArray();
         } catch (IOException e) {
             throw new AssertionError("NDList is not writable", e);

--- a/api/src/test/java/ai/djl/translate/BatchifierTest.java
+++ b/api/src/test/java/ai/djl/translate/BatchifierTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.translate;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class BatchifierTest {
+
+    @Test
+    public void testBatchifier() {
+        Batchifier batchifier = Batchifier.fromString("stack");
+        Assert.assertEquals(batchifier, Batchifier.STACK);
+
+        Assert.assertThrows(() -> Batchifier.fromString("invalid"));
+    }
+}

--- a/api/src/test/java/ai/djl/translate/ServingTranslatorTest.java
+++ b/api/src/test/java/ai/djl/translate/ServingTranslatorTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.translate;
+
+import ai.djl.Model;
+import ai.djl.ModelException;
+import ai.djl.inference.Predictor;
+import ai.djl.modality.Input;
+import ai.djl.modality.Output;
+import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.NDManager;
+import ai.djl.ndarray.types.DataType;
+import ai.djl.ndarray.types.Shape;
+import ai.djl.nn.Block;
+import ai.djl.nn.Blocks;
+import ai.djl.repository.zoo.Criteria;
+import ai.djl.repository.zoo.ZooModel;
+import ai.djl.util.Utils;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+public class ServingTranslatorTest {
+
+    @AfterClass
+    public void tierDown() {
+        Utils.deleteQuietly(Paths.get("build/model"));
+    }
+
+    @Test
+    public void testNumpy() throws IOException, TranslateException, ModelException {
+        Path path = Paths.get("build/model");
+        Files.createDirectories(path);
+        Input input = new Input();
+
+        try (NDManager manager = NDManager.newBaseManager()) {
+            Block block = Blocks.identityBlock();
+            block.initialize(manager, DataType.FLOAT32, new Shape(1));
+            Model model = Model.newInstance("identity");
+            model.setBlock(block);
+            model.save(path, null);
+            model.close();
+            NDList list = new NDList();
+            list.add(manager.create(10f));
+            input.add(list.encode(true));
+            input.add("Content-Type", "tensor/npz");
+        }
+
+        Criteria<Input, Output> criteria =
+                Criteria.builder()
+                        .setTypes(Input.class, Output.class)
+                        .optModelPath(path)
+                        .optModelName("identity")
+                        .optBlock(Blocks.identityBlock())
+                        .build();
+
+        try (ZooModel<Input, Output> model = criteria.loadModel();
+                Predictor<Input, Output> predictor = model.newPredictor()) {
+            Output output = predictor.predict(input);
+            try (NDManager manager = NDManager.newBaseManager()) {
+                NDList list = output.getDataAsNDList(manager);
+                Assert.assertEquals(list.size(), 1);
+                Assert.assertEquals(list.get(0).toFloatArray()[0], 10f);
+            }
+            Input invalid = new Input();
+            invalid.add("String");
+            Assert.assertThrows(TranslateException.class, () -> predictor.predict(invalid));
+        }
+    }
+}

--- a/api/src/test/java/ai/djl/translate/package-info.java
+++ b/api/src/test/java/ai/djl/translate/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+/** Contains tests for {@link ai.djl.translate}. */
+package ai.djl.translate;


### PR DESCRIPTION
The output content-type will match the input content-type.

Change-Id: I06d864449b89e8e416371f2e2b32b91406ee4883

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
