### PR TITLE
[TabNet/WIP] Implement GhostBatchNorm

### DIFF
--- a/api/src/main/java/ai/djl/nn/norm/BatchNorm.java
+++ b/api/src/main/java/ai/djl/nn/norm/BatchNorm.java
@@ -10,6 +10,7 @@
  * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
+
 package ai.djl.nn.norm;
 
 import ai.djl.Device;
@@ -282,34 +283,22 @@ public class BatchNorm extends AbstractBlock {
 
     /** The Builder to construct a {@link BatchNorm}. */
     public static class Builder extends BaseBuilder<Builder> {
-        /**
-         * Builds a {@link BatchNorm} block.
-         *
-         * @return the {@link BatchNorm} block
-         */
         Builder() {}
 
-        /**
-         * Builds the new {@link BatchNorm}.
-         *
-         * @return the new {@link BatchNorm}
-         */
+        /** {@inheritDoc} */
         @Override
         public BatchNorm build() {
             return new BatchNorm(this);
         }
 
-        /**
-         * Returns this {code Builder} object.
-         *
-         * @return this {@code BaseBuilder}
-         */
+        /** {@inheritDoc} */
         @Override
         public Builder self() {
             return this;
         }
     }
 
+    /** The Builder to construct a {@link BatchNorm} type of {@link ai.djl.nn.Block}. */
     public abstract static class BaseBuilder<T extends BaseBuilder<T>> {
 
         protected int axis = 1;
@@ -318,7 +307,7 @@ public class BatchNorm extends AbstractBlock {
         protected boolean center = true;
         protected boolean scale = true;
 
-        public BaseBuilder() {}
+        protected BaseBuilder() {}
 
         /**
          * Set the axis in which channel is specified. Defaults to 1.
@@ -375,10 +364,18 @@ public class BatchNorm extends AbstractBlock {
             return self();
         }
 
-        /** {@inheritDoc} */
+        /**
+         * Builds the new {@link BatchNorm}.
+         *
+         * @return the new {@link BatchNorm}
+         */
         public abstract BatchNorm build();
 
-        /** {@inheritDoc} */
+        /**
+         * Returns this {code Builder} object.
+         *
+         * @return this {@code BaseBuilder}
+         */
         public abstract T self();
     }
 }

--- a/api/src/main/java/ai/djl/nn/norm/BatchNorm.java
+++ b/api/src/main/java/ai/djl/nn/norm/BatchNorm.java
@@ -77,7 +77,7 @@ public class BatchNorm extends AbstractBlock {
     private Parameter runningMean;
     private Parameter runningVar;
 
-    BatchNorm(Builder builder) {
+    BatchNorm(BaseBuilder<?> builder) {
         super(VERSION);
         axis = builder.axis;
         epsilon = builder.epsilon;
@@ -276,20 +276,49 @@ public class BatchNorm extends AbstractBlock {
      *
      * @return a new builder
      */
-    public static Builder builder() {
+    public static BaseBuilder<?> builder() {
         return new Builder();
     }
 
     /** The Builder to construct a {@link BatchNorm}. */
-    public static class Builder {
-
-        private int axis = 1;
-        private float epsilon = 1E-5f;
-        private float momentum = .9f;
-        private boolean center = true;
-        private boolean scale = true;
-
+    public static class Builder extends BaseBuilder<Builder> {
+        /**
+         * Builds a {@link BatchNorm} block.
+         *
+         * @return the {@link BatchNorm} block
+         */
         Builder() {}
+
+        /**
+         * Builds the new {@link BatchNorm}.
+         *
+         * @return the new {@link BatchNorm}
+         */
+        @Override
+        public BatchNorm build() {
+            return new BatchNorm(this);
+        }
+
+        /**
+         * Returns this {code Builder} object.
+         *
+         * @return this {@code BaseBuilder}
+         */
+        @Override
+        public Builder self() {
+            return this;
+        }
+    }
+
+    public abstract static class BaseBuilder<T extends BaseBuilder<T>> {
+
+        protected int axis = 1;
+        protected float epsilon = 1E-5f;
+        protected float momentum = .9f;
+        protected boolean center = true;
+        protected boolean scale = true;
+
+        public BaseBuilder() {}
 
         /**
          * Set the axis in which channel is specified. Defaults to 1.
@@ -297,9 +326,9 @@ public class BatchNorm extends AbstractBlock {
          * @param axis the axis in which channel is specified
          * @return this Builder
          */
-        public Builder optAxis(int axis) {
+        public T optAxis(int axis) {
             this.axis = axis;
-            return this;
+            return self();
         }
 
         /**
@@ -308,9 +337,9 @@ public class BatchNorm extends AbstractBlock {
          * @param val True or False on whether to add and train offset value
          * @return this Builder
          */
-        public Builder optCenter(boolean val) {
+        public T optCenter(boolean val) {
             center = val;
-            return this;
+            return self();
         }
 
         /**
@@ -319,9 +348,9 @@ public class BatchNorm extends AbstractBlock {
          * @param val True or False on whether to add and train scale value
          * @return this Builder
          */
-        public Builder optScale(boolean val) {
+        public T optScale(boolean val) {
             scale = val;
-            return this;
+            return self();
         }
 
         /**
@@ -330,9 +359,9 @@ public class BatchNorm extends AbstractBlock {
          * @param val the epsilon value
          * @return this Builder
          */
-        public Builder optEpsilon(float val) {
+        public T optEpsilon(float val) {
             epsilon = val;
-            return this;
+            return self();
         }
 
         /**
@@ -341,18 +370,15 @@ public class BatchNorm extends AbstractBlock {
          * @param val the momentum for moving average
          * @return this Builder
          */
-        public Builder optMomentum(float val) {
+        public T optMomentum(float val) {
             momentum = val;
-            return this;
+            return self();
         }
 
-        /**
-         * Builds a {@link BatchNorm} block.
-         *
-         * @return the {@link BatchNorm} block
-         */
-        public BatchNorm build() {
-            return new BatchNorm(this);
-        }
+        /** {@inheritDoc} */
+        public abstract BatchNorm build();
+
+        /** {@inheritDoc} */
+        public abstract T self();
     }
 }

--- a/api/src/main/java/ai/djl/nn/norm/BatchNorm.java
+++ b/api/src/main/java/ai/djl/nn/norm/BatchNorm.java
@@ -281,7 +281,7 @@ public class BatchNorm extends AbstractBlock {
     }
 
     /** The Builder to construct a {@link BatchNorm}. */
-    public static final class Builder {
+    public static class Builder {
 
         private int axis = 1;
         private float epsilon = 1E-5f;

--- a/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
+++ b/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
@@ -77,7 +77,7 @@ public class GhostBatchNorm extends BatchNorm {
     /**
      * Converts an array of {@link NDList} into an NDList using {@link StackBatchifier} and squeezes
      * the first dimension created by it. This makes the final {@link NDArray} same size as the
-     * splitted one
+     * splitted one.
      *
      * @param subBatches the input array of {@link NDList}
      * @return the batchified {@link NDList}

--- a/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
+++ b/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
@@ -12,7 +12,7 @@ import ai.djl.util.PairList;
  * 0 and variance of 1 and finally concatenate them again to a single batch. Each of the
  * mini-batches contains a virtualBatchSize samples.
  *
- * @see <a href="https://arxiv.org/abs/1705.08741">Ghost Batch Normalization Paper</a>
+ * @see <a href="https://arxiv.org/abs/1705.08741">Ghost Normalization Paper</a>
  */
 public class GhostBatchNorm extends BatchNorm {
 
@@ -86,9 +86,9 @@ public class GhostBatchNorm extends BatchNorm {
         }
 
         /**
-         * Builds the new {@link BatchNorm}.
+         * Builds the new {@link GhostBatchNorm}.
          *
-         * @return the new {@link BatchNorm}
+         * @return the new {@link GhostBatchNorm}
          */
         public GhostBatchNorm build() {
             return new GhostBatchNorm(this);

--- a/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
+++ b/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
 package ai.djl.nn.norm;
 
 import ai.djl.ndarray.NDList;
@@ -35,9 +48,9 @@ public class GhostBatchNorm extends BatchNorm {
             PairList<String, Object> params) {
 
         NDList[] subBatches = split(inputs);
-        for (NDList batch : subBatches)
+        for (NDList batch : subBatches) {
             super.forwardInternal(parameterStore, batch, training, params);
-
+        }
         return batchifier.batchify(subBatches);
     }
 
@@ -60,7 +73,7 @@ public class GhostBatchNorm extends BatchNorm {
     }
 
     /**
-     * Creates a builder to build a {@code GhostBatchNorm.}
+     * Creates a builder to build a {@code GhostBatchNorm}.
      *
      * @return a new builder
      */
@@ -68,7 +81,7 @@ public class GhostBatchNorm extends BatchNorm {
         return new Builder();
     }
 
-    /** The Builder to construct a {@link GhostBatchNorm} */
+    /** The Builder to construct a {@link GhostBatchNorm}. */
     public static class Builder extends BatchNorm.BaseBuilder<Builder> {
         private int virtualBatchSize = 128;
 
@@ -77,7 +90,7 @@ public class GhostBatchNorm extends BatchNorm {
         /**
          * Set the size of virtual batches in which to use when sub-batching. Defaults to 128.
          *
-         * @param virtualBatchSize
+         * @param virtualBatchSize the virtual batch size
          * @return this Builder
          */
         public Builder optVirtualBatchSize(int virtualBatchSize) {

--- a/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
+++ b/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
@@ -48,9 +48,11 @@ public class GhostBatchNorm extends BatchNorm {
             PairList<String, Object> params) {
 
         NDList[] subBatches = split(inputs);
-        for (NDList batch : subBatches) {
-            super.forwardInternal(parameterStore, batch, training, params);
+
+        for (int i = 0; i < subBatches.length; i++) {
+            subBatches[i] = super.forwardInternal(parameterStore, subBatches[i], training, params);
         }
+
         return batchify(subBatches);
     }
 

--- a/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
+++ b/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
@@ -11,6 +11,8 @@ import ai.djl.util.PairList;
  * smaller sub-batches aka <em>ghost batches</em>, and normalize them individually to have a mean of
  * 0 and variance of 1 and finally concatenate them again to a single batch. Each of the
  * mini-batches contains a virtualBatchSize samples.
+ *
+ * @see <a href="https://arxiv.org/abs/1705.08741">Ghost Batch Normalization Paper</a>
  */
 public class GhostBatchNorm extends BatchNorm {
 

--- a/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
+++ b/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
@@ -1,0 +1,121 @@
+package ai.djl.nn.norm;
+
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDList;
+import ai.djl.training.ParameterStore;
+import ai.djl.translate.Batchifier;
+import ai.djl.translate.StackBatchifier;
+import ai.djl.util.PairList;
+
+/**
+ * {@link GhostBatchNorm} is similar to {@link BatchNorm} except that it splits a batch into a
+ * smaller sub-batches aka <em>ghost batches</em>, and normalize them individually to have a mean of
+ * 0 and variance of 1 and finally concatenate them again to a single batch. Each of the
+ * mini-batches contains a virtualBatchSize samples.
+ */
+public class GhostBatchNorm extends BatchNorm {
+
+    private int virtualBatchSize;
+    private Batchifier batchifier;
+
+    GhostBatchNorm(Builder builder) {
+        super(new BatchNorm.Builder());
+
+        this.virtualBatchSize = builder.virtualBatchSize;
+        this.batchifier = new StackBatchifier();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected NDList forwardInternal(
+            ParameterStore parameterStore,
+            NDList inputs,
+            boolean training,
+            PairList<String, Object> params) {
+
+        NDList[] subBatches = split(inputs);
+        for (NDList batch : subBatches)
+            super.forwardInternal(parameterStore, batch, training, params);
+
+        return batchifier.batchify(subBatches);
+    }
+
+    /**
+     * Splits an {@link NDList} into the given <b>size</b> of sub-batch.
+     *
+     * <p>This function unbatchifies the input {@link NDList} into mini-batches, each with the size
+     * of virtualBatchSize. If the batch size is divisible by the virtual batch size, all returned
+     * sub-batches will be the same size. If the batch size is not divisible by virtual batch size,
+     * all returned sub-batches will be the same size, except the last one.
+     *
+     * @param list the {@link NDList} that needs to be split
+     * @return an array of {@link NDList} that contains all the mini-batches
+     */
+    protected NDList[] split(NDList list) {
+        double batchSize = list.head().size(0);
+        int countBatches = (int) Math.ceil(batchSize / virtualBatchSize);
+
+        return batchifier.split(list, countBatches, true);
+    }
+
+    /**
+     * Creates a builder to build a {@code GhostBatchNorm.}
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** The Builder to construct a {@link GhostBatchNorm} */
+    public static class Builder extends BatchNorm.Builder {
+        private int virtualBatchSize = 128;
+
+        Builder() {}
+
+        /** {@inheritDoc} */
+        public Builder optVirtualBatchSize(int virtualBatchSize) {
+            this.virtualBatchSize = virtualBatchSize;
+            return this;
+        }
+
+        public GhostBatchNorm build() {
+            return new GhostBatchNorm(this);
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public Builder optAxis(int axis) {
+            super.optAxis(axis);
+            return this;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public Builder optCenter(boolean val) {
+            super.optCenter(val);
+            return this;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public Builder optScale(boolean val) {
+            super.optScale(val);
+            return this;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public Builder optEpsilon(float val) {
+            super.optEpsilon(val);
+            return this;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public Builder optMomentum(float val) {
+            super.optMomentum(val);
+            return this;
+        }
+    }
+}

--- a/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
+++ b/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
@@ -73,13 +73,27 @@ public class GhostBatchNorm extends BatchNorm {
         return batchifier.split(list, countBatches, true);
     }
 
+    /**
+     * Converts an array of {@link NDList} into an NDList using {@link StackBatchifier} and squeezes
+     * the first dimension created by it. This makes the final {@link NDArray} same size as the
+     * splitted one
+     *
+     * @param subBatches the input array of {@link NDList}
+     * @return the batchified {@link NDList}
+     */
     protected NDList batchify(NDList[] subBatches) {
         NDList batch = batchifier.batchify(subBatches);
 
         return squeezeExtraDimensions(batch);
     }
 
-    protected NDList squeezeExtraDimensions(NDList batch){
+    /**
+     * Squeezes first axes of {@link NDList}
+     *
+     * @param batch input array of {@link NDList}
+     * @return the squeezed {@link NDList}
+     */
+    protected NDList squeezeExtraDimensions(NDList batch) {
         NDArray array = batch.singletonOrThrow().squeeze(0);
         batch.set(0, array);
 

--- a/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
+++ b/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
@@ -13,6 +13,7 @@
 
 package ai.djl.nn.norm;
 
+import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDList;
 import ai.djl.training.ParameterStore;
 import ai.djl.translate.Batchifier;
@@ -51,7 +52,7 @@ public class GhostBatchNorm extends BatchNorm {
         for (NDList batch : subBatches) {
             super.forwardInternal(parameterStore, batch, training, params);
         }
-        return batchifier.batchify(subBatches);
+        return batchify(subBatches);
     }
 
     /**
@@ -70,6 +71,19 @@ public class GhostBatchNorm extends BatchNorm {
         int countBatches = (int) Math.ceil(batchSize / virtualBatchSize);
 
         return batchifier.split(list, countBatches, true);
+    }
+
+    protected NDList batchify(NDList[] subBatches) {
+        NDList batch = batchifier.batchify(subBatches);
+
+        return squeezeExtraDimensions(batch);
+    }
+
+    protected NDList squeezeExtraDimensions(NDList batch){
+        NDArray array = batch.singletonOrThrow().squeeze(0);
+        batch.set(0, array);
+
+        return batch;
     }
 
     /**

--- a/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
+++ b/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
@@ -1,6 +1,5 @@
 package ai.djl.nn.norm;
 
-import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDList;
 import ai.djl.training.ParameterStore;
 import ai.djl.translate.Batchifier;
@@ -18,8 +17,8 @@ public class GhostBatchNorm extends BatchNorm {
     private int virtualBatchSize;
     private Batchifier batchifier;
 
-    GhostBatchNorm(Builder builder) {
-        super(new BatchNorm.Builder());
+    protected GhostBatchNorm(Builder builder) {
+        super(builder);
 
         this.virtualBatchSize = builder.virtualBatchSize;
         this.batchifier = new StackBatchifier();
@@ -68,53 +67,34 @@ public class GhostBatchNorm extends BatchNorm {
     }
 
     /** The Builder to construct a {@link GhostBatchNorm} */
-    public static class Builder extends BatchNorm.Builder {
+    public static class Builder extends BatchNorm.BaseBuilder<Builder> {
         private int virtualBatchSize = 128;
 
         Builder() {}
 
-        /** {@inheritDoc} */
+        /**
+         * Set the size of virtual batches in which to use when sub-batching. Defaults to 128.
+         *
+         * @param virtualBatchSize
+         * @return this Builder
+         */
         public Builder optVirtualBatchSize(int virtualBatchSize) {
             this.virtualBatchSize = virtualBatchSize;
             return this;
         }
 
+        /**
+         * Builds the new {@link BatchNorm}.
+         *
+         * @return the new {@link BatchNorm}
+         */
         public GhostBatchNorm build() {
             return new GhostBatchNorm(this);
         }
 
         /** {@inheritDoc} */
         @Override
-        public Builder optAxis(int axis) {
-            super.optAxis(axis);
-            return this;
-        }
-
-        /** {@inheritDoc} */
-        @Override
-        public Builder optCenter(boolean val) {
-            super.optCenter(val);
-            return this;
-        }
-
-        /** {@inheritDoc} */
-        @Override
-        public Builder optScale(boolean val) {
-            super.optScale(val);
-            return this;
-        }
-
-        /** {@inheritDoc} */
-        @Override
-        public Builder optEpsilon(float val) {
-            super.optEpsilon(val);
-            return this;
-        }
-
-        /** {@inheritDoc} */
-        @Override
-        public Builder optMomentum(float val) {
-            super.optMomentum(val);
+        public Builder self() {
             return this;
         }
     }

--- a/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
+++ b/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
@@ -89,7 +89,7 @@ public class GhostBatchNorm extends BatchNorm {
     }
 
     /**
-     * Squeezes first axes of {@link NDList}
+     * Squeezes first axes of {@link NDList}.
      *
      * @param batch input array of {@link NDList}
      * @return the squeezed {@link NDList}

--- a/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
+++ b/api/src/main/java/ai/djl/nn/norm/GhostBatchNorm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
  * with the License. A copy of the License is located at
@@ -35,7 +35,6 @@ public class GhostBatchNorm extends BatchNorm {
 
     protected GhostBatchNorm(Builder builder) {
         super(builder);
-
         this.virtualBatchSize = builder.virtualBatchSize;
         this.batchifier = new StackBatchifier();
     }
@@ -111,12 +110,13 @@ public class GhostBatchNorm extends BatchNorm {
 
     /** The Builder to construct a {@link GhostBatchNorm}. */
     public static class Builder extends BatchNorm.BaseBuilder<Builder> {
+
         private int virtualBatchSize = 128;
 
         Builder() {}
 
         /**
-         * Set the size of virtual batches in which to use when sub-batching. Defaults to 128.
+         * Sets the size of virtual batches in which to use when sub-batching. Defaults to 128.
          *
          * @param virtualBatchSize the virtual batch size
          * @return this Builder
@@ -131,6 +131,7 @@ public class GhostBatchNorm extends BatchNorm {
          *
          * @return the new {@link GhostBatchNorm}
          */
+        @Override
         public GhostBatchNorm build() {
             return new GhostBatchNorm(this);
         }

--- a/api/src/test/java/ai/djl/nn/norm/GhostBatchNormTest.java
+++ b/api/src/test/java/ai/djl/nn/norm/GhostBatchNormTest.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 package ai.djl.nn.norm;
 
 import ai.djl.ndarray.NDArray;
@@ -5,12 +17,24 @@ import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.types.Shape;
 import org.testng.Assert;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 public class GhostBatchNormTest {
 
-    private GhostBatchNorm gbn;
+    @Test
+    public void originalBatchOfSizeOneSubBatchIntoOneVbsListOfLengthOne() {
+        testSubBatchingShapeSize(new Shape(1, 1, 10), 1, 1);
+    }
+
+    @Test
+    public void originalBatchOfSizeSixSubBatchIntoTwoVbsListOfLengthThree() {
+        testSubBatchingShapeSize(new Shape(6, 1, 10), 2, 3);
+    }
+
+    @Test
+    public void originalBatchOfSize60SubBatchInto64VbsListOfLengthOne() {
+        testSubBatchingShapeSize(new Shape(60, 10), 64, 1);
+    }
 
     private void testSubBatchingShapeSize(Shape shape, int vbs, int expectedSize) {
         NDList[] zeroSubList = generateZerosArrayAndSubBatch(shape, vbs);
@@ -19,24 +43,10 @@ public class GhostBatchNormTest {
 
     private NDList[] generateZerosArrayAndSubBatch(Shape shape, int vbs) {
         try (NDManager manager = NDManager.newBaseManager()) {
-            this.gbn = new GhostBatchNorm(GhostBatchNorm.builder().optVirtualBatchSize(vbs));
+            GhostBatchNorm gbn =
+                    new GhostBatchNorm(GhostBatchNorm.builder().optVirtualBatchSize(vbs));
             NDArray zerosInput = manager.zeros(shape);
             return gbn.split(new NDList(zerosInput));
         }
-    }
-
-    @Test
-    public void originalBatchOfSizeOne_subBatchIntoOneVBS_listOfLengthOne() {
-        testSubBatchingShapeSize(new Shape(1, 1, 10), 1, 1);
-    }
-
-    @Test
-    public void originalBatchOfSizeSix_subBatchIntoTwoVBS_listOfLengthThree() {
-        testSubBatchingShapeSize(new Shape(6, 1, 10), 2, 3);
-    }
-
-    @Test
-    public void originalBatchOfSize60_subBatchInto64VBS_listOfLengthOne() {
-        testSubBatchingShapeSize(new Shape(60, 10), 64, 1);
     }
 }

--- a/api/src/test/java/ai/djl/nn/norm/GhostBatchNormTest.java
+++ b/api/src/test/java/ai/djl/nn/norm/GhostBatchNormTest.java
@@ -1,0 +1,46 @@
+package ai.djl.nn.norm;
+
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.NDManager;
+import ai.djl.ndarray.types.Shape;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+public class GhostBatchNormTest {
+
+    private GhostBatchNorm gbn;
+    private NDManager manager;
+
+    @BeforeTest
+    void initialize() {
+        this.manager = NDManager.newBaseManager();
+    }
+
+    private void testSubBatchingShapeSize(Shape shape, int vbs, int expectedSize) {
+        NDList[] zeroSubList = generateZerosArrayAndSubBatch(shape, vbs);
+        Assert.assertEquals(expectedSize, zeroSubList.length);
+    }
+
+    private NDList[] generateZerosArrayAndSubBatch(Shape shape, int vbs) {
+        this.gbn = new GhostBatchNorm(GhostBatchNorm.builder().optVirtualBatchSize(vbs));
+        NDArray zerosInput = manager.zeros(shape);
+        return gbn.split(new NDList(zerosInput));
+    }
+
+    @Test
+    public void originalBatchOfSizeOne_subBatchIntoOneVBS_listOfLengthOne() {
+        testSubBatchingShapeSize(new Shape(1, 1, 10), 1, 1);
+    }
+
+    @Test
+    public void originalBatchOfSizeSix_subBatchIntoTwoVBS_listOfLengthThree() {
+        testSubBatchingShapeSize(new Shape(6, 1, 10), 2, 3);
+    }
+
+    @Test
+    public void originalBatchOfSize60_subBatchInto64VBS_listOfLengthOne() {
+        testSubBatchingShapeSize(new Shape(60, 10), 64, 1);
+    }
+}

--- a/api/src/test/java/ai/djl/nn/norm/GhostBatchNormTest.java
+++ b/api/src/test/java/ai/djl/nn/norm/GhostBatchNormTest.java
@@ -11,12 +11,6 @@ import org.testng.annotations.Test;
 public class GhostBatchNormTest {
 
     private GhostBatchNorm gbn;
-    private NDManager manager;
-
-    @BeforeTest
-    void initialize() {
-        this.manager = NDManager.newBaseManager();
-    }
 
     private void testSubBatchingShapeSize(Shape shape, int vbs, int expectedSize) {
         NDList[] zeroSubList = generateZerosArrayAndSubBatch(shape, vbs);
@@ -24,9 +18,11 @@ public class GhostBatchNormTest {
     }
 
     private NDList[] generateZerosArrayAndSubBatch(Shape shape, int vbs) {
-        this.gbn = new GhostBatchNorm(GhostBatchNorm.builder().optVirtualBatchSize(vbs));
-        NDArray zerosInput = manager.zeros(shape);
-        return gbn.split(new NDList(zerosInput));
+        try (NDManager manager = NDManager.newBaseManager()) {
+            this.gbn = new GhostBatchNorm(GhostBatchNorm.builder().optVirtualBatchSize(vbs));
+            NDArray zerosInput = manager.zeros(shape);
+            return gbn.split(new NDList(zerosInput));
+        }
     }
 
     @Test

--- a/api/src/test/java/ai/djl/nn/norm/package-info.java
+++ b/api/src/test/java/ai/djl/nn/norm/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+/** Contains tests for {@link ai.djl.nn.norm}. */
+package ai.djl.nn.norm;


### PR DESCRIPTION
## Description ##

`GhostBatchNormalization` is one of the components that build up TabNet. It works similar to `BatchNorm` except that it splits each batch into smaller mini-batches and each of them is normalized separately.

Changes:
* **BatchNorm**: remove the final notation from the builder class as GhostBatchNormalization extends BatchNorm and the builder is required to be extended with it for usage.
*  **GhostBatchNorm**: Extends BatchNorm and overrides `internalForward()` such that it splits the batch into mini-batches using `StackBatchifier` before applying batch normalization. `split()` divides the size of the original batch and ceil it so if the original batch size isn't divisible by the virtual batch size, the remaining samples will be placed in the last mini-batch (this behaviour is inspired from PyTorch chunk). Builder methods are duplicated from BatchNorm due to return type, this can be resolved using generics if needed.
* **GhostBatchNormTest**: tests the splitting behavior in GhostBatchNorm. I will add more for `forwardInternal` in later commits.
