### PR TITLE
Added "capped" state to NDManager

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/NDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/NDManager.java
@@ -1390,6 +1390,13 @@ public interface NDManager extends AutoCloseable {
     boolean isOpen();
 
     /**
+     * Caps this manager to prevent unintentional attachment of resources. This is useful to detect
+     * memory leaks at an early point in time. The attachment of sub managers is still allowed after
+     * this method has been called.
+     */
+    void cap();
+
+    /**
      * Returns the parent {@code NDManager}.
      *
      * @return the parent {@code NDManager}
@@ -1433,6 +1440,20 @@ public interface NDManager extends AutoCloseable {
      * @param resource the {@link AutoCloseable} resource to be attached
      */
     void attachInternal(String resourceId, AutoCloseable resource);
+
+    /**
+     * Attaches a resource to this {@code NDManager} circumventing any cap protection.
+     *
+     * <p>The attached resource will be closed when this {@code NDManager} is closed.
+     *
+     * <p>This attachment is internal. Many resources will internally track which manager they are
+     * attached to. In that case, you should call {@link NDResource#attach(NDManager)} instead and
+     * that should then call attachInternal.
+     *
+     * @param resourceId the unique resourceId
+     * @param resource the {@link AutoCloseable} resource to be attached
+     */
+    void attachUncappedInternal(String resourceId, AutoCloseable resource);
 
     /**
      * Temporarily attaches a resource to this {@code NDManager} to be returned when this is closed.

--- a/api/src/main/java/ai/djl/ndarray/NDResource.java
+++ b/api/src/main/java/ai/djl/ndarray/NDResource.java
@@ -32,6 +32,18 @@ public interface NDResource extends AutoCloseable {
     void attach(NDManager manager);
 
     /**
+     * Attaches this {@link NDResource} to the specified {@link NDManager} from which it was
+     * previously detached and temp-attached to the current manager of this resource. This is
+     * functionally equivalent to the attach method, however the cap-state disregarded when adding
+     * the resource back to the original manager.
+     *
+     * @param manager the {@link NDManager} to be attached to
+     */
+    default void returnResource(NDManager manager) {
+        attach(manager);
+    }
+
+    /**
      * Temporarily attaches this {@link NDResource} to the specified {@link NDManager}.
      *
      * <p>Attached resource will be returned to the original manager when the {@link NDManager} is

--- a/api/src/main/java/ai/djl/util/passthrough/PassthroughNDManager.java
+++ b/api/src/main/java/ai/djl/util/passthrough/PassthroughNDManager.java
@@ -178,6 +178,10 @@ public final class PassthroughNDManager implements NDManager {
 
     /** {@inheritDoc} */
     @Override
+    public void cap() {}
+
+    /** {@inheritDoc} */
+    @Override
     public NDManager getParentManager() {
         return this;
     }
@@ -203,6 +207,12 @@ public final class PassthroughNDManager implements NDManager {
     /** {@inheritDoc} */
     @Override
     public void attachInternal(String resourceId, AutoCloseable resource) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void attachUncappedInternal(String resourceId, AutoCloseable resource) {
         throw new UnsupportedOperationException(UNSUPPORTED);
     }
 

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
@@ -165,6 +165,14 @@ public class MxNDArray extends NativeResource<Pointer> implements LazyNDArray {
 
     /** {@inheritDoc} */
     @Override
+    public void returnResource(NDManager manager) {
+        detach();
+        this.manager = (MxNDManager) manager;
+        manager.attachUncappedInternal(getUid(), this);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void tempAttach(NDManager manager) {
         NDManager original = this.manager;
         detach();

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDManager.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDManager.java
@@ -277,7 +277,7 @@ public class MxNDManager extends BaseNDManager {
     @Override
     public MxNDManager newSubManager(Device dev) {
         MxNDManager manager = new MxNDManager(this, dev, version);
-        attachInternal(manager.uid, manager);
+        attachUncappedInternal(manager.uid, manager);
         return manager;
     }
 

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -273,6 +273,14 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
 
     /** {@inheritDoc} */
     @Override
+    public void returnResource(NDManager manager) {
+        detach();
+        this.manager = (PtNDManager) manager;
+        manager.attachUncappedInternal(getUid(), this);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void tempAttach(NDManager manager) {
         NDManager original = this.manager;
         detach();

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDManager.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDManager.java
@@ -160,7 +160,7 @@ public class PtNDManager extends BaseNDManager {
     @Override
     public PtNDManager newSubManager(Device device) {
         PtNDManager manager = new PtNDManager(this, device);
-        attachInternal(manager.uid, manager);
+        attachUncappedInternal(manager.uid, manager);
         return manager;
     }
 

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayAttachmentTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayAttachmentTest.java
@@ -48,4 +48,37 @@ public class NDArrayAttachmentTest {
             }
         }
     }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testCannotUseCappedManager() {
+        try (NDManager manager = NDManager.newBaseManager()) {
+            manager.cap();
+            manager.ones(new Shape(3, 4));
+        }
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testIndexationCannotUseCappedManager() {
+        try (NDManager manager = NDManager.newBaseManager()) {
+            NDArray array3x4 = manager.ones(new Shape(3, 4));
+            array3x4.setName("Test()");
+            manager.cap();
+            array3x4.get(1);
+        }
+    }
+
+    @Test
+    public void testIndexationUsesSpecificUncappedManager() {
+        try (NDManager manager = NDManager.newBaseManager()) {
+            NDArray array3x4 = manager.ones(new Shape(3, 4));
+            array3x4.setName("Test()");
+            manager.cap();
+            try (NDManager subManager = NDManager.newBaseManager()) {
+                NDArray array4sub1 = array3x4.get(subManager, 1);
+                Assert.assertEquals(array4sub1.getManager(), subManager);
+                array3x4.tempAttach(subManager);
+                Assert.assertEquals(array3x4.getManager(), subManager);
+            }
+        }
+    }
 }


### PR DESCRIPTION
This change adds the capability to "cap" a NDManager instance.
In the capped state, it is not possible to add new resources to the manager (except for submanagers).
The model developer would choose to do so when he is sure that all resources (usually NDArray) that are supposed to be attached are attached and he expects no new resources to be added in the future, thus preventing unintentional addition of resources that could go undetected otherwise and could pose memory leaks.
Sub managers are by design still allowed to be attached and have an independent "cap" status. 
