### PR TITLE
Fix errors in "getIoU" function

### DIFF
--- a/api/src/main/java/ai/djl/modality/cv/output/Rectangle.java
+++ b/api/src/main/java/ai/djl/modality/cv/output/Rectangle.java
@@ -89,7 +89,7 @@ public class Rectangle implements BoundingBox {
         Rectangle rec = (Rectangle) box;
         // caculate intesection lrtb
         double left = Math.max(getX(), rec.getX());
-        double top = Math.min(getY(), rec.getY());
+        double top = Math.max(getY(), rec.getY());
         double right = Math.min(getX() + getWidth(), rec.getX() + rec.getWidth());
         double bottom = Math.min(getY() + getHeight(), rec.getY() + rec.getHeight());
         double intersection = (right - left) * (bottom - top);


### PR DESCRIPTION
The value of top should be the maximum Y of both Rectangles, not the minimum. This will result in the incorrect calculation of the iOU values of the two Rectangles in the upper and lower positions.

## Description ##
in function getloU, the value of var top is the lesser Y value of two rectangel, which will lead to wrong value while two rectangle with up-down relationship, for example: 
new Rectangle(0,10,10,10).getIoU(new Rectangle(0,20,10,10) 
will get 1.0,  but the right value of top is the bigger Y.