### PR TITLE
Normalized Numeric Featurizer

### DIFF
--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/AmesRandomAccess.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/AmesRandomAccess.java
@@ -200,7 +200,7 @@ public class AmesRandomAccess extends CsvDataset {
             if (af.categorical.contains(name)) {
                 Map<String, Integer> map = af.featureToMap.get(name);
                 if (map == null) {
-                    return addCategoricalFeature(name);
+                    return addCategoricalFeature(name, onehotEncode);
                 }
                 return addCategoricalFeature(name, map, onehotEncode);
             }

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularDataset.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularDataset.java
@@ -14,6 +14,7 @@ package ai.djl.basicdataset.tabular;
 
 import ai.djl.basicdataset.tabular.utils.DynamicBuffer;
 import ai.djl.basicdataset.tabular.utils.Feature;
+import ai.djl.basicdataset.tabular.utils.Featurizers;
 import ai.djl.basicdataset.tabular.utils.PreparedFeaturizer;
 import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.NDManager;
@@ -87,7 +88,7 @@ public abstract class TabularDataset extends RandomAccessDataset {
         for (Feature feature : featuresToPrepare) {
             if (feature.getFeaturizer() instanceof PreparedFeaturizer) {
                 PreparedFeaturizer featurizer = (PreparedFeaturizer) feature.getFeaturizer();
-                List<String> inputs = new ArrayList<>(Math.toIntExact(availableSize()));
+                List<String> inputs = new ArrayList<>(Math.toIntExact(availableSize));
                 for (int i = 0; i < availableSize; i++) {
                     inputs.add(getCell(i, feature.getName()));
                 }
@@ -144,6 +145,18 @@ public abstract class TabularDataset extends RandomAccessDataset {
         }
 
         /**
+         * Adds a numeric feature to the feature set.
+         *
+         * @param name the feature name
+         * @param normalize true to normalize the column
+         * @return this builder
+         */
+        public T addNumericFeature(String name, boolean normalize) {
+            features.add(new Feature(name, Featurizers.getNumericFeaturizer(normalize)));
+            return self();
+        }
+
+        /**
          * Adds a categorical feature to the feature set.
          *
          * @param name the feature name
@@ -155,11 +168,23 @@ public abstract class TabularDataset extends RandomAccessDataset {
         }
 
         /**
+         * Adds a categorical feature to the feature set.
+         *
+         * @param name the feature name
+         * @param onehotEncode true to use onehot encode
+         * @return this builder
+         */
+        public T addCategoricalFeature(String name, boolean onehotEncode) {
+            features.add(new Feature(name, Featurizers.getStringFeaturizer(onehotEncode)));
+            return self();
+        }
+
+        /**
          * Adds a categorical feature to the feature set with specified mapping.
          *
          * @param name the feature name
          * @param map a map contains categorical value maps to index
-         * @param onehotEncode true if use onehot encode
+         * @param onehotEncode true to use onehot encode
          * @return this builder
          */
         public T addCategoricalFeature(
@@ -191,13 +216,37 @@ public abstract class TabularDataset extends RandomAccessDataset {
         }
 
         /**
+         * Adds a number feature to the label set.
+         *
+         * @param name the label name
+         * @param normalize true to normalize the column
+         * @return this builder
+         */
+        public T addNumericLabel(String name, boolean normalize) {
+            labels.add(new Feature(name, Featurizers.getNumericFeaturizer(normalize)));
+            return self();
+        }
+
+        /**
          * Adds a categorical feature to the label set.
          *
          * @param name the feature name
          * @return this builder
          */
         public T addCategoricalLabel(String name) {
-            labels.add(new Feature(name, true));
+            labels.add(new Feature(name, false));
+            return self();
+        }
+
+        /**
+         * Adds a categorical feature to the label set.
+         *
+         * @param name the feature name
+         * @param onehotEncode true if use onehot encode
+         * @return this builder
+         */
+        public T addCategoricalLabel(String name, boolean onehotEncode) {
+            labels.add(new Feature(name, Featurizers.getStringFeaturizer(onehotEncode)));
             return self();
         }
 

--- a/basicdataset/src/test/java/ai/djl/basicdataset/AirfoilRandomAccessTest.java
+++ b/basicdataset/src/test/java/ai/djl/basicdataset/AirfoilRandomAccessTest.java
@@ -100,8 +100,8 @@ public class AirfoilRandomAccessTest {
 
         float epsilon = (float) 1e-4;
 
-        float[] expected = {-0.6603f, -1.1448f, 1.797f, 1.3109f, -0.6443f};
+        float[] expected = {-0.6620f, -1.1464f, 1.7993f, 1.3129f, -0.6448f};
         Assert.assertEquals(data.head().toFloatArray(), expected, epsilon);
-        Assert.assertEquals(labels.head().toFloatArray(), new float[] {0.1937f}, epsilon);
+        Assert.assertEquals(labels.head().toFloatArray(), new float[] {0.1979f}, epsilon);
     }
 }


### PR DESCRIPTION
Earlier, the AirfoilRandomAccess had to use custom code to add normalizing
functionality and couldn't rely on the featurizers. This creates a new
normalizing featurizer using the new PreparedFeaturizer and brings it into line
with the standard tabular dataset.

The changes in testAirfoilRemotePreprocessing come from an update to the
normalization. Before, it was normalized by calculating using the size (limited
to top 1500 elements in the dataset for the test). Instead, it normalizes using
the full dataset availableSize(). I feel like this would make more sense to not
have your data preprocessing be different between a limited dataset and the full
one and would be unexpected for users if it were.
