### PR TITLE
Adding Movielens 100k tabular dataset to basicdatasets

### DIFF
--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/MovieLens100k.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/MovieLens100k.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.basicdataset.tabular;
+
+import ai.djl.Application;
+import ai.djl.basicdataset.BasicDatasets;
+import ai.djl.repository.Artifact;
+import ai.djl.repository.MRL;
+import ai.djl.repository.Repository;
+import ai.djl.util.Progress;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+
+/** Movielens 100k movie reviews dataset from https://grouplens.org/datasets/movielens/100k/. */
+public final class MovieLens100k extends CsvDataset {
+
+    private static final String ARTIFACT_ID = "movielens-100k";
+    private static final String VERSION = "1.0";
+
+    private static final String[] USER_FEATURES = {
+        "user_id", "user_age", "user_gender", "user_occupation", "user_zipcode"
+    };
+    private static final String[] MOVIE_FEATURES = {
+        "movie_id",
+        "movie_title",
+        "movie_release_date",
+        "movie_video_release_date",
+        "imdb_url",
+        "unknown",
+        "action",
+        "adventure",
+        "animation",
+        "childrens",
+        "comedy",
+        "crime",
+        "documentary",
+        "drama",
+        "fantasy",
+        "film-noir",
+        "horror",
+        "musical",
+        "mystery",
+        "romance",
+        "sci-fi",
+        "thriller",
+        "war",
+        "western"
+    };
+
+    enum HeaderEnum {
+        user_id,
+        movie_id,
+        rating,
+        timestamp
+    }
+
+    private Usage usage;
+    private MRL mrl;
+    private boolean prepared;
+    private Map<String, Map<String, String>> userFeaturesMap;
+    private Map<String, Map<String, String>> movieFeaturesMap;
+
+    MovieLens100k(Builder builder) {
+        super(builder);
+        usage = builder.usage;
+        mrl = builder.getMrl();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected String getCell(long rowIndex, String featureName) {
+        CSVRecord record = csvRecords.get(Math.toIntExact(rowIndex));
+        if (HeaderEnum.rating.toString().equals(featureName)) {
+            return record.get(HeaderEnum.rating);
+        }
+        if (featureName.startsWith("user")) {
+            String userId = record.get(HeaderEnum.user_id);
+            return userFeaturesMap.get(userId).get(featureName);
+        }
+        String movieId = record.get(HeaderEnum.movie_id);
+        return movieFeaturesMap.get(movieId).get(featureName);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void prepare(Progress progress) throws IOException {
+        if (prepared) {
+            return;
+        }
+
+        Artifact artifact = mrl.getDefaultArtifact();
+        mrl.prepare(artifact, progress);
+
+        Path dir = mrl.getRepository().getResourceDirectory(artifact);
+        Path root = dir.resolve("ml-100k/ml-100k");
+
+        // The actual feature values to use for training/testing are stored in separate files
+        Path userFeaturesFile = root.resolve("u.user");
+        userFeaturesMap = prepareFeaturesMap(userFeaturesFile, USER_FEATURES);
+        Path movieFeaturesFile = root.resolve("u.item");
+        movieFeaturesMap = prepareFeaturesMap(movieFeaturesFile, MOVIE_FEATURES);
+
+        Path csvFile;
+        switch (usage) {
+            case TRAIN:
+                csvFile = root.resolve("ua.base");
+                break;
+            case TEST:
+                csvFile = root.resolve("ua.test");
+                break;
+            case VALIDATION:
+            default:
+                throw new UnsupportedOperationException("Validation data not available");
+        }
+
+        csvUrl = csvFile.toUri().toURL();
+        super.prepare(progress);
+        prepared = true;
+    }
+
+    private Map<String, Map<String, String>> prepareFeaturesMap(
+            Path featureFile, String[] featureNames) throws IOException {
+        URL featureFileUrl = featureFile.toUri().toURL();
+        CSVFormat format = CSVFormat.Builder.create(CSVFormat.newFormat('|')).build();
+        Reader reader =
+                new InputStreamReader(
+                        new BufferedInputStream(featureFileUrl.openStream()),
+                        StandardCharsets.UTF_8);
+        CSVParser csvParser = new CSVParser(reader, format);
+        List<CSVRecord> featureRecords = csvParser.getRecords();
+
+        Map<String, Map<String, String>> featuresMap = new ConcurrentHashMap<>();
+        for (CSVRecord record : featureRecords) {
+            Map<String, String> featureValues = new ConcurrentHashMap<>();
+            for (int i = 0; i < featureNames.length; i++) {
+                featureValues.put(featureNames[i], record.get(i));
+            }
+            featuresMap.put(record.get(0), featureValues);
+        }
+        return featuresMap;
+    }
+
+    /**
+     * Creates a builder to build a {@link MovieLens100k}.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** A builder to construct a {@link MovieLens100k}. */
+    public static final class Builder extends CsvBuilder<Builder> {
+
+        Repository repository;
+        String groupId;
+        String artifactId;
+        Usage usage;
+        List<String> featureArray =
+                new ArrayList<>(
+                        Arrays.asList(
+                                "user_age",
+                                "user_gender",
+                                "user_occupation",
+                                "user_zipcode",
+                                "movie_title",
+                                "movie_genres"));
+
+        List<String> movieGenres =
+                new ArrayList<>(
+                        Arrays.asList(
+                                "unknown",
+                                "action",
+                                "adventure",
+                                "animation",
+                                "childrens",
+                                "comedy",
+                                "crime",
+                                "documentary",
+                                "drama",
+                                "fantasy",
+                                "film-noir",
+                                "horror",
+                                "musical",
+                                "mystery",
+                                "romance",
+                                "sci-fi",
+                                "thriller",
+                                "war",
+                                "western"));
+
+        /** Constructs a new builder. */
+        Builder() {
+            repository = BasicDatasets.REPOSITORY;
+            groupId = BasicDatasets.GROUP_ID;
+            artifactId = ARTIFACT_ID;
+            usage = Usage.TRAIN;
+            csvFormat = CSVFormat.TDF.builder().setHeader(HeaderEnum.class).setQuote(null).build();
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public Builder self() {
+            return this;
+        }
+
+        /**
+         * Sets the optional usage.
+         *
+         * @param usage the new usage
+         * @return this builder
+         */
+        public Builder optUsage(Usage usage) {
+            this.usage = usage;
+            return self();
+        }
+
+        /**
+         * Sets the optional repository.
+         *
+         * @param repository the repository
+         * @return this builder
+         */
+        public Builder optRepository(Repository repository) {
+            this.repository = repository;
+            return self();
+        }
+
+        /**
+         * Sets optional groupId.
+         *
+         * @param groupId the groupId}
+         * @return this builder
+         */
+        public Builder optGroupId(String groupId) {
+            this.groupId = groupId;
+            return self();
+        }
+
+        /**
+         * Sets the optional artifactId.
+         *
+         * @param artifactId the artifactId
+         * @return this builder
+         */
+        public Builder optArtifactId(String artifactId) {
+            if (artifactId.contains(":")) {
+                String[] tokens = artifactId.split(":");
+                groupId = tokens[0];
+                this.artifactId = tokens[1];
+            } else {
+                this.artifactId = artifactId;
+            }
+            return self();
+        }
+
+        /**
+         * Returns the available features of this dataset.
+         *
+         * @return a list of feature names
+         */
+        public List<String> getAvailableFeatures() {
+            return featureArray;
+        }
+
+        /**
+         * Adds a feature to the features set.
+         *
+         * @param name the name of the feature
+         * @return this builder
+         */
+        public Builder addFeature(String name) {
+            if (getAvailableFeatures().contains(name)) {
+                switch (name) {
+                    case "user_age":
+                        addNumericFeature(name);
+                        break;
+                    case "user_gender":
+                    case "user_occupation":
+                        addCategoricalFeature(name, true);
+                        break;
+                    case "user_zipcode":
+                    case "movie_title":
+                        addCategoricalFeature(name, false);
+                        break;
+                    case "movie_genres":
+                        movieGenres.forEach(genre -> addNumericFeature(genre));
+                        break;
+                    default:
+                        break;
+                }
+            } else {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Provided feature %s is not valid. Valid features are: %s",
+                                name, featureArray));
+            }
+            return self();
+        }
+
+        /**
+         * Builds the new {@link MovieLens100k}.
+         *
+         * @return the new {@link MovieLens100k}
+         */
+        @Override
+        public MovieLens100k build() {
+            if (features.isEmpty()) {
+                featureArray.forEach(feature -> addFeature(feature));
+            }
+            if (labels.isEmpty()) {
+                addNumericLabel("rating");
+            }
+            return new MovieLens100k(this);
+        }
+
+        MRL getMrl() {
+            return repository.dataset(Application.Tabular.ANY, groupId, artifactId, VERSION);
+        }
+    }
+}

--- a/basicdataset/src/test/java/ai/djl/basicdataset/MovieLens100kTest.java
+++ b/basicdataset/src/test/java/ai/djl/basicdataset/MovieLens100kTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.basicdataset;
+
+import ai.djl.Model;
+import ai.djl.basicdataset.tabular.MovieLens100k;
+import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.NDManager;
+import ai.djl.nn.Blocks;
+import ai.djl.nn.Parameter;
+import ai.djl.repository.Repository;
+import ai.djl.training.DefaultTrainingConfig;
+import ai.djl.training.Trainer;
+import ai.djl.training.TrainingConfig;
+import ai.djl.training.dataset.Batch;
+import ai.djl.training.dataset.Dataset;
+import ai.djl.training.dataset.Record;
+import ai.djl.training.initializer.Initializer;
+import ai.djl.training.loss.Loss;
+import ai.djl.translate.TranslateException;
+import java.io.IOException;
+import java.nio.file.Paths;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class MovieLens100kTest {
+
+    @Test
+    public void testMovieLens100kRemote() throws IOException, TranslateException {
+        TrainingConfig config =
+                new DefaultTrainingConfig(Loss.l2Loss())
+                        .optInitializer(Initializer.ONES, Parameter.Type.WEIGHT);
+
+        try (Model model = Model.newInstance("model")) {
+            model.setBlock(Blocks.identityBlock());
+
+            NDManager manager = model.getNDManager();
+
+            Repository repository =
+                    Repository.newInstance(
+                            "testrepo",
+                            Paths.get(
+                                    "/Users/siddhave/workplace/DeepJavaLibraryCore/djl/basicdataset/src/test/resources/mlrepo"));
+
+            MovieLens100k movieLens100k =
+                    MovieLens100k.builder()
+                            .optUsage(Dataset.Usage.TEST)
+                            .optRepository(repository)
+                            .addFeature("user_age")
+                            .addFeature("user_gender")
+                            .addFeature("user_occupation")
+                            .addFeature("movie_genres")
+                            .setSampling(32, true)
+                            .build();
+
+            movieLens100k.prepare();
+
+            long size = movieLens100k.size();
+            Assert.assertEquals(size, 9430);
+
+            Record record = movieLens100k.get(manager, 23);
+            NDList data = record.getData();
+            NDList labels = record.getLabels();
+
+            Assert.assertEquals(
+                    data.head().toFloatArray(),
+                    new float[] {
+                        23.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+                        0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+                        0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+                        0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f,
+                    });
+            Assert.assertEquals(labels.head().toFloatArray(), new float[] {5.0f});
+
+            try (Trainer trainer = model.newTrainer(config)) {
+                Batch batch = trainer.iterateDataset(movieLens100k).iterator().next();
+                Assert.assertEquals(batch.getData().size(), 1);
+                Assert.assertEquals(batch.getLabels().size(), 1);
+                batch.close();
+            }
+        }
+    }
+}

--- a/basicdataset/src/test/resources/mlrepo/dataset/tabular/ai/djl/basicdataset/movielens-100k/metadata.json
+++ b/basicdataset/src/test/resources/mlrepo/dataset/tabular/ai/djl/basicdataset/movielens-100k/metadata.json
@@ -1,0 +1,29 @@
+{
+  "metadataVersion": "0.2",
+  "resourceType": "dataset",
+  "application": "tabular",
+  "groupId": "ai.djl.basicdataset",
+  "artifactId": "movielens-100k",
+  "name": "movielens-100k",
+  "description": "Movie Ratings from 1000 Users on 1700 movies",
+  "website": "https://grouplens.org/datasets/movielens/100k/",
+  "licenses": {
+    "license": {
+      "name": "N/A",
+      "url": "https://files.grouplens.org/datasets/movielens/ml-100k-README.txt"
+    }
+  },
+  "artifacts": [
+    {
+      "version": "1.0",
+      "snapshot": false,
+      "files": {
+        "ml-100k": {
+          "uri": "https://files.grouplens.org/datasets/movielens/ml-100k.zip",
+          "sha1Hash": "cd4dcac4241c8a4ad7badc7ca635da8a69dddb83",
+          "size": "4924029"
+        }
+      }
+    }
+  ]
+}

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -71,6 +71,7 @@ This module contains the following datasets:
 
 - [Airfoil Self-Noise](https://javadoc.io/doc/ai.djl/basicdataset/latest/ai/djl/basicdataset/tabular/AirfoilRandomAccess.html) - A 6 feature dataset from NASA tests of airfoils
 - [Ames House Pricing](https://javadoc.io/doc/ai.djl/basicdataset/latest/ai/djl/basicdataset/tabular/AmesRandomAccess.html) - A 80 feature dataset to predict house prices
+- [Movielens 100k](https://javadoc.io/doc/ai.djl/basicdataset/latest/ai/djl/basicdataset/tabular/MovieLens100k.html) - A 6 feature dataset of movie ratings on 1682 movies from 943 users
 
 ### Time Series
 


### PR DESCRIPTION
## Description ##

Adding the Movielens 100k dataset to the tabular datasets. This dataset can be used to train regression models, collaborative filtering models, Graph Neural Networks, and a host of other recommendation system models. 

https://grouplens.org/datasets/movielens/100k/

## Note ##
The tests right now are using a local instace of the repo since the metadata hasn't been published to S3. I'll update the tests accordingly once the metadata.json has been pushed to S3 and I can verify using the remote bucket works.
