### PR TITLE
Enable better textual description of neural net

### DIFF
--- a/api/src/main/java/ai/djl/nn/AbstractBaseBlock.java
+++ b/api/src/main/java/ai/djl/nn/AbstractBaseBlock.java
@@ -21,7 +21,6 @@ import ai.djl.training.ParameterStore;
 import ai.djl.training.initializer.Initializer;
 import ai.djl.util.Pair;
 import ai.djl.util.PairList;
-import ai.djl.util.Utils;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -357,7 +356,7 @@ public abstract class AbstractBaseBlock implements Block {
     /** {@inheritDoc} */
     @Override
     public String toString() {
-        return Utils.describe(this, null, 0);
+        return Blocks.describe(this, null, 0);
     }
 
     /** {@inheritDoc} */

--- a/api/src/main/java/ai/djl/nn/AbstractBaseBlock.java
+++ b/api/src/main/java/ai/djl/nn/AbstractBaseBlock.java
@@ -21,6 +21,7 @@ import ai.djl.training.ParameterStore;
 import ai.djl.training.initializer.Initializer;
 import ai.djl.util.Pair;
 import ai.djl.util.PairList;
+import ai.djl.util.Utils;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -356,25 +357,7 @@ public abstract class AbstractBaseBlock implements Block {
     /** {@inheritDoc} */
     @Override
     public String toString() {
-        // FIXME: This is a quick hack for display in jupyter notebook.
-        StringBuilder sb = new StringBuilder(200);
-        String className = getClass().getSimpleName();
-        if (className.endsWith("Block")) {
-            className = className.substring(0, className.length() - 5);
-        }
-        sb.append(className).append('(');
-        if (isInitialized()) {
-            PairList<String, Shape> inputShapeDescription = describeInput();
-            appendShape(sb, inputShapeDescription.values().toArray(new Shape[0]));
-            sb.append(" -> ");
-            Shape[] outputShapes =
-                    getOutputShapes(inputShapeDescription.values().toArray(new Shape[0]));
-            appendShape(sb, outputShapes);
-        } else {
-            sb.append("Uninitialized");
-        }
-        sb.append(')');
-        return sb.toString();
+        return Utils.describe(this, null, 0);
     }
 
     private void appendShape(StringBuilder sb, Shape[] shapes) {
@@ -412,5 +395,15 @@ public abstract class AbstractBaseBlock implements Block {
                 }
             }
         }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Shape[] getInputShapes() {
+        if (!isInitialized()) {
+            throw new IllegalStateException(
+                    "getInputShapes() can only be called after the initialization process");
+        }
+        return inputShapes;
     }
 }

--- a/api/src/main/java/ai/djl/nn/AbstractBaseBlock.java
+++ b/api/src/main/java/ai/djl/nn/AbstractBaseBlock.java
@@ -360,43 +360,6 @@ public abstract class AbstractBaseBlock implements Block {
         return Utils.describe(this, null, 0);
     }
 
-    private void appendShape(StringBuilder sb, Shape[] shapes) {
-        boolean first = true;
-        for (Shape shape : shapes) {
-            if (first) {
-                first = false;
-            } else {
-                sb.append(", ");
-            }
-            long[] sh = shape.getShape();
-            int length = sh.length;
-            if (length == 0) {
-                sb.append("()");
-            } else {
-                int index = 0;
-                if (sh[0] == -1) {
-                    --length;
-                    index = 1;
-                }
-
-                if (length == 0) {
-                    sb.append("()");
-                } else if (length == 1) {
-                    sb.append(sh[index]);
-                } else {
-                    sb.append('(');
-                    for (int i = index; i < sh.length; ++i) {
-                        if (i > index) {
-                            sb.append(", ");
-                        }
-                        sb.append(sh[i]);
-                    }
-                    sb.append(')');
-                }
-            }
-        }
-    }
-
     /** {@inheritDoc} */
     @Override
     public Shape[] getInputShapes() {

--- a/api/src/main/java/ai/djl/nn/AbstractBlock.java
+++ b/api/src/main/java/ai/djl/nn/AbstractBlock.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.nn;
 
+import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.types.DataType;
@@ -23,6 +24,7 @@ import ai.djl.util.PairList;
 import java.io.DataOutputStream;
 import java.util.LinkedHashMap;
 import java.util.Locale;
+import java.util.function.Function;
 
 /**
  * {@code AbstractBlock} is an abstract implementation of {@link Block}.
@@ -93,17 +95,39 @@ public abstract class AbstractBlock extends AbstractBaseBlock {
     /**
      * Use this to add a child block to this block.
      *
-     * @param name Name of the block, must be unique or otherwise existing children with this name
-     *     are removed, must not be null.
+     * @param name Name of the block, must not be null.
      * @param block The block, must not be null.
      * @param <B> The type of block
      * @return the block given as a parameter - that way the block can be created and reassigned to
      *     a member variable more easily.
      */
-    protected final <B extends Block> B addChildBlock(String name, B block) {
+    public final <B extends Block> B addChildBlock(String name, B block) {
         int childNumber = children.size() + 1;
         children.add(String.format(Locale.ROOT, "%02d%s", childNumber, name), block);
         return block;
+    }
+
+    /**
+     * Adds a {@link LambdaBlock} as a child block to this block.
+     *
+     * @param name Name of the block, must not be null.
+     * @param f the function forms the {@link LambdaBlock}
+     * @return the child block
+     */
+    public LambdaBlock addChildBlock(String name, Function<NDList, NDList> f) {
+        return addChildBlock(name, new LambdaBlock(f));
+    }
+
+    /**
+     * Adds a {@link LambdaBlock#singleton(Function)} as a child block to this block.
+     *
+     * @param name Name of the block, must not be null.
+     * @param f the function forms the {@link LambdaBlock}
+     * @return the child block
+     * @see LambdaBlock#singleton(Function)
+     */
+    public final LambdaBlock addChildBlockSingleton(String name, Function<NDArray, NDArray> f) {
+        return addChildBlock(name, LambdaBlock.singleton(f));
     }
 
     /**

--- a/api/src/main/java/ai/djl/nn/AbstractBlock.java
+++ b/api/src/main/java/ai/djl/nn/AbstractBlock.java
@@ -101,7 +101,7 @@ public abstract class AbstractBlock extends AbstractBaseBlock {
      * @return the block given as a parameter - that way the block can be created and reassigned to
      *     a member variable more easily.
      */
-    public final <B extends Block> B addChildBlock(String name, B block) {
+    protected final <B extends Block> B addChildBlock(String name, B block) {
         int childNumber = children.size() + 1;
         children.add(String.format(Locale.ROOT, "%02d%s", childNumber, name), block);
         return block;
@@ -114,8 +114,8 @@ public abstract class AbstractBlock extends AbstractBaseBlock {
      * @param f the function forms the {@link LambdaBlock}
      * @return the child block
      */
-    public LambdaBlock addChildBlock(String name, Function<NDList, NDList> f) {
-        return addChildBlock(name, new LambdaBlock(f));
+    protected LambdaBlock addChildBlock(String name, Function<NDList, NDList> f) {
+        return addChildBlock(name, new LambdaBlock(f, name));
     }
 
     /**
@@ -126,8 +126,8 @@ public abstract class AbstractBlock extends AbstractBaseBlock {
      * @return the child block
      * @see LambdaBlock#singleton(Function)
      */
-    public final LambdaBlock addChildBlockSingleton(String name, Function<NDArray, NDArray> f) {
-        return addChildBlock(name, LambdaBlock.singleton(f));
+    protected final LambdaBlock addChildBlockSingleton(String name, Function<NDArray, NDArray> f) {
+        return addChildBlock(name, LambdaBlock.singleton(f, name));
     }
 
     /**

--- a/api/src/main/java/ai/djl/nn/Block.java
+++ b/api/src/main/java/ai/djl/nn/Block.java
@@ -251,6 +251,14 @@ public interface Block {
     Shape[] getOutputShapes(Shape[] inputShapes);
 
     /**
+     * Returns the input shapes of the block. The input shapes are only available after the block is
+     * initialized, otherwise an {@link IllegalStateException} is thrown.
+     *
+     * @return the input shapes of the block
+     */
+    Shape[] getInputShapes();
+
+    /**
      * Writes the parameters of the block to the given outputStream.
      *
      * @param os the outputstream to save the parameters to

--- a/api/src/main/java/ai/djl/nn/Blocks.java
+++ b/api/src/main/java/ai/djl/nn/Blocks.java
@@ -14,6 +14,11 @@ package ai.djl.nn;
 
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.types.Shape;
+import ai.djl.util.Pair;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /** Utility class that provides some useful blocks. */
 public final class Blocks {
@@ -80,5 +85,52 @@ public final class Blocks {
      */
     public static Block identityBlock() {
         return new LambdaBlock(x -> x, "identity");
+    }
+
+    /**
+     * Returns a string representation of the passed {@link Block} describing the input axes, output
+     * axes, and the block's children.
+     *
+     * @param block the block to describe
+     * @param blockName the name to be used for the passed block, or <code>null</code> if its class
+     *     name is to be used
+     * @param beginAxis skips all axes before this axis; use <code>0</code> to print all axes and
+     *     <code>1</code> to skip the batch axis.
+     * @return the string representation
+     */
+    public static String describe(Block block, String blockName, int beginAxis) {
+        Shape[] inputShapes = block.isInitialized() ? block.getInputShapes() : null;
+        Shape[] outputShapes = inputShapes != null ? block.getOutputShapes(inputShapes) : null;
+        StringBuilder sb = new StringBuilder(200);
+        if (block instanceof LambdaBlock
+                && !LambdaBlock.DEFAULT_NAME.equals(((LambdaBlock) block).getName())) {
+            sb.append(((LambdaBlock) block).getName());
+        } else if (blockName != null) {
+            sb.append(blockName);
+        } else {
+            sb.append(block.getClass().getSimpleName());
+        }
+        if (inputShapes != null) {
+            sb.append(
+                    Stream.of(inputShapes)
+                            .map(shape -> shape.slice(beginAxis).toString())
+                            .collect(Collectors.joining("+")));
+        }
+        if (!block.getChildren().isEmpty()) {
+            sb.append(" {\n");
+            for (Pair<String, Block> pair : block.getChildren()) {
+                String child = describe(pair.getValue(), pair.getKey().substring(2), beginAxis);
+                sb.append(child.replaceAll("(?m)^", "\t")).append('\n');
+            }
+            sb.append('}');
+        }
+        if (outputShapes != null) {
+            sb.append(" -> ");
+            sb.append(
+                    Stream.of(outputShapes)
+                            .map(shape -> shape.slice(beginAxis).toString())
+                            .collect(Collectors.joining("+")));
+        }
+        return sb.toString();
     }
 }

--- a/api/src/main/java/ai/djl/nn/LambdaBlock.java
+++ b/api/src/main/java/ai/djl/nn/LambdaBlock.java
@@ -34,6 +34,8 @@ import java.util.function.Function;
  */
 public class LambdaBlock extends AbstractBlock {
 
+    public static final String DEFAULT_NAME = "anonymous";
+
     private static final byte VERSION = 2;
 
     private Function<NDList, NDList> lambda;
@@ -45,7 +47,7 @@ public class LambdaBlock extends AbstractBlock {
      * @param lambda the function to apply
      */
     public LambdaBlock(Function<NDList, NDList> lambda) {
-        this(lambda, "anonymous");
+        this(lambda, DEFAULT_NAME);
     }
 
     /**
@@ -131,11 +133,5 @@ public class LambdaBlock extends AbstractBlock {
         } else if (version != 1) {
             throw new MalformedModelException("Unsupported encoding version: " + version);
         }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public String toString() {
-        return "Lambda::" + name + "()";
     }
 }

--- a/api/src/main/java/ai/djl/nn/ParallelBlock.java
+++ b/api/src/main/java/ai/djl/nn/ParallelBlock.java
@@ -13,6 +13,7 @@
 package ai.djl.nn;
 
 import ai.djl.MalformedModelException;
+import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.types.DataType;
@@ -110,6 +111,43 @@ public class ParallelBlock extends AbstractBlock {
      */
     public final ParallelBlock add(Function<NDList, NDList> f) {
         return add(new LambdaBlock(f));
+    }
+
+    /**
+     * Adds a {@link LambdaBlock}, that applies the given function, to the list of parallel
+     * branches.
+     *
+     * @param f the function forms the {@link LambdaBlock}
+     * @param name the function name
+     * @return this block
+     */
+    public ParallelBlock add(Function<NDList, NDList> f, String name) {
+        return add(new LambdaBlock(f, name));
+    }
+
+    /**
+     * Adds a {@link LambdaBlock#singleton(Function)}, that applies the given function, to the list
+     * of parallel branches.
+     *
+     * @param f the function forms the {@link LambdaBlock}
+     * @return this block
+     * @see LambdaBlock#singleton(Function)
+     */
+    public ParallelBlock addSingleton(Function<NDArray, NDArray> f) {
+        return add(LambdaBlock.singleton(f));
+    }
+
+    /**
+     * Adds a {@link LambdaBlock#singleton(Function)}, that applies the given function, to the list
+     * of parallel branches.
+     *
+     * @param f the function forms the {@link LambdaBlock}
+     * @param name the function name
+     * @return this block
+     * @see LambdaBlock#singleton(Function)
+     */
+    public ParallelBlock addSingleton(Function<NDArray, NDArray> f, String name) {
+        return add(LambdaBlock.singleton(f, name));
     }
 
     /** {@inheritDoc} */

--- a/api/src/main/java/ai/djl/nn/ParallelBlock.java
+++ b/api/src/main/java/ai/djl/nn/ParallelBlock.java
@@ -180,17 +180,4 @@ public class ParallelBlock extends AbstractBlock {
             throw new MalformedModelException("Unsupported encoding version: " + loadVersion);
         }
     }
-
-    /** {@inheritDoc} */
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder(200);
-        sb.append("Parallel(\n");
-        for (Block block : children.values()) {
-            String blockString = block.toString().replaceAll("(?m)^", "\t");
-            sb.append(blockString).append('\n');
-        }
-        sb.append(')');
-        return sb.toString();
-    }
 }

--- a/api/src/main/java/ai/djl/nn/SequentialBlock.java
+++ b/api/src/main/java/ai/djl/nn/SequentialBlock.java
@@ -209,17 +209,4 @@ public class SequentialBlock extends AbstractBlock {
             throw new MalformedModelException("Unsupported encoding version: " + loadVersion);
         }
     }
-
-    /** {@inheritDoc} */
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder(200);
-        sb.append("Sequential(\n");
-        for (Block block : children.values()) {
-            String blockString = block.toString().replaceAll("(?m)^", "\t");
-            sb.append(blockString).append('\n');
-        }
-        sb.append(')');
-        return sb.toString();
-    }
 }

--- a/api/src/main/java/ai/djl/nn/norm/Dropout.java
+++ b/api/src/main/java/ai/djl/nn/norm/Dropout.java
@@ -91,12 +91,6 @@ public class Dropout extends AbstractBlock {
         }
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public String toString() {
-        return "Dropout()";
-    }
-
     /**
      * Applies Dropout to the input.
      *

--- a/api/src/main/java/ai/djl/util/Utils.java
+++ b/api/src/main/java/ai/djl/util/Utils.java
@@ -373,7 +373,8 @@ public final class Utils {
         Shape[] inputShapes = block.isInitialized() ? block.getInputShapes() : null;
         Shape[] outputShapes = inputShapes != null ? block.getOutputShapes(inputShapes) : null;
         StringBuilder sb = new StringBuilder(200);
-        if (block instanceof LambdaBlock && !"anonymous".equals(((LambdaBlock) block).getName())) {
+        if (block instanceof LambdaBlock
+                && !LambdaBlock.DEFAULT_NAME.equals(((LambdaBlock) block).getName())) {
             sb.append(((LambdaBlock) block).getName());
         } else if (blockName != null) {
             sb.append(blockName);

--- a/api/src/main/java/ai/djl/util/Utils.java
+++ b/api/src/main/java/ai/djl/util/Utils.java
@@ -13,9 +13,6 @@
 package ai.djl.util;
 
 import ai.djl.ndarray.NDArray;
-import ai.djl.ndarray.types.Shape;
-import ai.djl.nn.Block;
-import ai.djl.nn.LambdaBlock;
 import ai.djl.nn.Parameter;
 
 import org.slf4j.Logger;
@@ -39,7 +36,6 @@ import java.util.Scanner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /** A class containing utility methods. */
 public final class Utils {
@@ -356,52 +352,5 @@ public final class Utils {
             }
         }
         return Paths.get(cacheDir);
-    }
-
-    /**
-     * Returns a string representation of the passed {@link Block} describing the input axes, output
-     * axes, and the block's children.
-     *
-     * @param block the block to describe
-     * @param blockName the name to be used for the passed block, or <code>null</code> if its class
-     *     name is to be used
-     * @param beginAxis skips all axes before this axis; use <code>0</code> to print all axes and
-     *     <code>1</code> to skip the batch axis.
-     * @return the string representation
-     */
-    public static String describe(Block block, String blockName, int beginAxis) {
-        Shape[] inputShapes = block.isInitialized() ? block.getInputShapes() : null;
-        Shape[] outputShapes = inputShapes != null ? block.getOutputShapes(inputShapes) : null;
-        StringBuilder sb = new StringBuilder(200);
-        if (block instanceof LambdaBlock
-                && !LambdaBlock.DEFAULT_NAME.equals(((LambdaBlock) block).getName())) {
-            sb.append(((LambdaBlock) block).getName());
-        } else if (blockName != null) {
-            sb.append(blockName);
-        } else {
-            sb.append(block.getClass().getSimpleName());
-        }
-        if (inputShapes != null) {
-            sb.append(
-                    Stream.of(inputShapes)
-                            .map(shape -> shape.slice(beginAxis).toString())
-                            .collect(Collectors.joining("+")));
-        }
-        if (!block.getChildren().isEmpty()) {
-            sb.append(" {\n");
-            for (Pair<String, Block> pair : block.getChildren()) {
-                String child = describe(pair.getValue(), pair.getKey().substring(2), beginAxis);
-                sb.append(child.replaceAll("(?m)^", "\t")).append('\n');
-            }
-            sb.append('}');
-        }
-        if (outputShapes != null) {
-            sb.append(" -> ");
-            sb.append(
-                    Stream.of(outputShapes)
-                            .map(shape -> shape.slice(beginAxis).toString())
-                            .collect(Collectors.joining("+")));
-        }
-        return sb.toString();
     }
 }


### PR DESCRIPTION
This feature adds Utils.decribe() which describes the created neural net based on the block naming used in AbstractBlock.addChildBlock()

For the TrainMnist example, we can get now a nicer textual description:
```

Mlp(1, 784) {
	Flatten(1, 784) -> (1, 784)
	Linear(1, 784) -> (1, 128)
	Relu(1, 128) -> (1, 128)
	Linear(1, 128) -> (1, 64)
	Relu(1, 64) -> (1, 64)
	Linear(1, 64) -> (1, 10)
} -> (1, 10)

```
that is much easier to read than Block.toString() :

```
Sequential(
	Lambda()
	Linear(1 -> 128)
	Lambda()
	Linear(1 -> 64)
	Lambda()
	Linear(1 -> 10)
)
```

by following code in Mlp.java:

```

        addChildBlock("Flatten", Blocks.batchFlattenBlock(input));
        for (int hiddenSize : hidden) {
            add(Linear.builder().setUnits(hiddenSize).build());
            addChildBlock("Relu", activation);
        }

        add(Linear.builder().setUnits(output).build());



```