### PR TITLE
Ensure PreparedOneHotStringFeaturizer encodes categorical mappings co…

### DIFF
--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/MovieLens100k.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/MovieLens100k.java
@@ -332,7 +332,7 @@ public final class MovieLens100k extends CsvDataset {
                 featureArray.forEach(feature -> addFeature(feature));
             }
             if (labels.isEmpty()) {
-                addNumericLabel("rating");
+                addCategoricalLabel("rating", true);
             }
             return new MovieLens100k(this);
         }

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/utils/Featurizers.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/utils/Featurizers.java
@@ -17,6 +17,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 
 /** A utility class provides helper functions to create {@link Featurizer}. */
@@ -170,7 +171,8 @@ public final class Featurizers {
         @Override
         public void prepare(List<String> inputs) {
             map = new ConcurrentHashMap<>();
-            for (String input : inputs) {
+            TreeSet<String> uniqueInputs = new TreeSet<>(inputs);
+            for (String input : uniqueInputs) {
                 if (!map.containsKey(input)) {
                     map.put(input, map.size());
                 }

--- a/basicdataset/src/test/java/ai/djl/basicdataset/MovieLens100kTest.java
+++ b/basicdataset/src/test/java/ai/djl/basicdataset/MovieLens100kTest.java
@@ -66,12 +66,13 @@ public class MovieLens100kTest {
             Assert.assertEquals(
                     data.head().toFloatArray(),
                     new float[] {
-                        23.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+                        23.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
                         0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
-                        0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+                        0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
                         0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f,
                     });
-            Assert.assertEquals(labels.head().toFloatArray(), new float[] {5.0f});
+            Assert.assertEquals(
+                    labels.head().toFloatArray(), new float[] {0.0f, 0.0f, 0.0f, 0.0f, 1.0f});
 
             try (Trainer trainer = model.newTrainer(config)) {
                 Batch batch = trainer.iterateDataset(movieLens100k).iterator().next();


### PR DESCRIPTION
Ensure PreparedOneHotStringFeaturizer encodes categorical mappings consistently across dataset usages

## Description ##

For Tabular datasets, the PreparedOneHotStringFeaturizer currently builds a list of values for a feature as we [iterate through the records](https://github.com/deepjavalibrary/djl/blob/master/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularDataset.java#L92-L94). Since we build the OHE mapping [based on the order the values are read](https://github.com/deepjavalibrary/djl/blob/master/basicdataset/src/main/java/ai/djl/basicdataset/tabular/utils/Featurizers.java#L171-L179), if the order of values read differs across datasets (train/test/val) then the OHE mappings differ across usages where the same model would be used.

To fix this, we should sort the values (how we sort doesn't matter as long as it is consistent across dataset usages) before constructing the OHE mappings. This does assume that the the values of a certain feature we want to OHE are the same and appear at least once across all dataset usages, which I think is a fair assumption to make. Featurizers should not be concerned with whether the dataset we are reading from has been constructed appropriately or not.

I updated the MovieLens100k dataset as part of this change since I noticed this issue while trying to create an example using this dataset.

## Example##

As an example, consider the following where we want to OHE the State feature:
```
--Train Data--
|row#|State|...
|1|CA|...
|2|CO|...
|3|NY|...

--Test Data--
|row#|State|...
|1|CO|...
|2|NY|...
|3|CA|...
```
The training data is prepared such that the OHE values are `CA=[1,0,0]`, `CO=[0,1,0]`, `NY=[0,0,1]` and the model we train will learn/assume those mappings apply to the test set we want to evaluate on. But in testing, we would prepare the OHE values as `CA=[0,0,1]`, `CO=[1,0,0]`, `NY=[0,1,0]` but the model wouldn't know that these mappings have changed.
