### PR TITLE
Criteria.toBuilder()

### DIFF
--- a/api/src/main/java/ai/djl/repository/zoo/Criteria.java
+++ b/api/src/main/java/ai/djl/repository/zoo/Criteria.java
@@ -354,6 +354,29 @@ public class Criteria<I, O> {
     }
 
     /**
+     * Creates a new {@link Builder} which starts with the values of this {@link Criteria}.
+     *
+     * @return a new {@link Builder}
+     */
+    public Builder<I, O> toBuilder() {
+        return Criteria.builder()
+                .setTypes(inputClass, outputClass)
+                .optApplication(application)
+                .optEngine(engine)
+                .optDevice(device)
+                .optGroupId(groupId)
+                .optArtifactId(artifactId)
+                .optModelZoo(modelZoo)
+                .optFilters(filters)
+                .optArguments(arguments)
+                .optOptions(options)
+                .optTranslatorFactory(factory)
+                .optBlock(block)
+                .optModelName(modelName)
+                .optProgress(progress);
+    }
+
+    /**
      * Creates a builder to build a {@code Criteria}.
      *
      * <p>The methods start with {@code set} are required fields, and {@code opt} for optional
@@ -626,6 +649,7 @@ public class Criteria<I, O> {
          * @return this {@code Builder}
          */
         public Builder<I, O> optTranslator(Translator<I, O> translator) {
+            this.factory = null;
             this.translator = translator;
             return this;
         }
@@ -637,6 +661,7 @@ public class Criteria<I, O> {
          * @return this {@code Builder}
          */
         public Builder<I, O> optTranslatorFactory(TranslatorFactory factory) {
+            this.translator = null;
             this.factory = factory;
             return this;
         }

--- a/api/src/test/java/ai/djl/repository/ZooTest.java
+++ b/api/src/test/java/ai/djl/repository/ZooTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.repository;
+
+import ai.djl.modality.Input;
+import ai.djl.modality.Output;
+import ai.djl.repository.zoo.Criteria;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ZooTest {
+
+    @Test
+    public void testCriteriaToBuilder() {
+        Criteria<Input, Output> criteria1 =
+                Criteria.builder()
+                        .setTypes(Input.class, Output.class)
+                        .optEngine("testEngine1")
+                        .optModelName("testModelName")
+                        .build();
+
+        Criteria<Input, Output> criteria2 = criteria1.toBuilder().optEngine("testEngine2").build();
+
+        Assert.assertEquals("testEngine1", criteria1.getEngine());
+        Assert.assertEquals("testEngine2", criteria2.getEngine());
+        Assert.assertEquals("testModelName", criteria1.getModelName());
+        Assert.assertEquals("testModelName", criteria2.getModelName());
+    }
+}


### PR DESCRIPTION
Creates a new method Criteria.toBuilder() to go from a working criteria to a Criteria builder to modify that criteria. It is intended for use for a new method in the DJL Serving WLM `new ModelInfo(String id, Criteria criteria)` which can be used for non-serving usages of the WLM.