### PR TITLE
store indices with batch

### DIFF
--- a/api/src/main/java/ai/djl/training/dataset/DataIterable.java
+++ b/api/src/main/java/ai/djl/training/dataset/DataIterable.java
@@ -199,7 +199,8 @@ public class DataIterable implements Iterable<Batch>, Iterator<Batch> {
                 dataBatchifier,
                 labelBatchifier,
                 progress,
-                dataset.size());
+                dataset.size(),
+                indices);
     }
 
     private void preFetch() {


### PR DESCRIPTION
Stores the indices that are used to extract a batch from a dataset in the batch itself.
This enables to pinpoint the predictions in `BatchData`  passed into
`TrainingListenerAdapter/onTrainingBatch  `and `TrainingListenerAdapter/onValidationBatch `
within the source dataset and thus can make better use of them.  