### PR TITLE
Create action to auto-close issues without response

### DIFF
--- a/.github/workflows/no_response.yml
+++ b/.github/workflows/no_response.yml
@@ -1,0 +1,18 @@
+name: No Response
+
+# Both `issue_comment` and `scheduled` event types are required for this Action
+# to work properly.
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # Schedule for five minutes after the hour, every hour
+    - cron: '5 0 * * *'
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lee-dohm/no-response@v0.5.0
+        with:
+          token: ${{ github.token }}

--- a/.github/workflows/no_response.yml
+++ b/.github/workflows/no_response.yml
@@ -16,3 +16,4 @@ jobs:
       - uses: lee-dohm/no-response@v0.5.0
         with:
           token: ${{ github.token }}
+          daysUntilClose: 30


### PR DESCRIPTION
This creates an action that runs daily after midnight. It will look for actions
with a given label (defaults to more-information-needed) that have not been
updated for 14 days and will close them.