### PR TITLE
Add tensor setter feature with advanced indexing on PyTorch engine

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/NDArray.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArray.java
@@ -595,7 +595,7 @@ public interface NDArray extends NDResource, BytesSupplier {
      *
      * @param index select the entries of an {@code NDArray}
      * @param data numbers to assign to the indexed entries
-     * @return The NDArray with updated values
+     * @return the NDArray with updated values
      */
     NDArray put(NDArray index, NDArray data);
 

--- a/api/src/main/java/ai/djl/ndarray/index/NDIndex.java
+++ b/api/src/main/java/ai/djl/ndarray/index/NDIndex.java
@@ -73,43 +73,48 @@ public class NDIndex {
      * <pre>
      *     NDArray a = manager.ones(new Shape(5, 4, 3));
      *
-     *     // Gets a subsection of the NDArray in the first axis.
+     *     // Get a subsection of the NDArray in the first axis.
      *     assertEquals(a.get(new NDIndex("2")).getShape(), new Shape(4, 3));
      *
-     *     // Gets a subsection of the NDArray indexing from the end (-i == length - i).
+     *     // Get a subsection of the NDArray indexing from the end (-i == length - i).
      *     assertEquals(a.get(new NDIndex("-1")).getShape(), new Shape(4, 3));
      *
-     *     // Gets everything in the first axis and a subsection in the second axis.
+     *     // Get everything in the first axis and a subsection in the second axis.
      *     // You can use either : or * to represent everything
      *     assertEquals(a.get(new NDIndex(":, 2")).getShape(), new Shape(5, 3));
      *     assertEquals(a.get(new NDIndex("*, 2")).getShape(), new Shape(5, 3));
      *
-     *     // Gets a range of values along the second axis that is inclusive on the bottom and exclusive on the top.
+     *     // Get a range of values along the second axis that is inclusive on the bottom and exclusive on the top.
      *     assertEquals(a.get(new NDIndex(":, 1:3")).getShape(), new Shape(5, 2, 3));
      *
-     *     // Excludes either the min or the max of the range to go all the way to the beginning or end.
+     *     // Exclude either the min or the max of the range to go all the way to the beginning or end.
      *     assertEquals(a.get(new NDIndex(":, :3")).getShape(), new Shape(5, 3, 3));
      *     assertEquals(a.get(new NDIndex(":, 1:")).getShape(), new Shape(5, 4, 3));
      *
-     *     // Uses the value after the second colon in a slicing range, the step, to get every other result.
+     *     // Use the value after the second colon in a slicing range, the step, to get every other result.
      *     assertEquals(a.get(new NDIndex(":, 1::2")).getShape(), new Shape(5, 2, 3));
      *
-     *     // Uses a negative step to reverse along the dimension.
+     *     // Use a negative step to reverse along the dimension.
      *     assertEquals(a.get(new NDIndex("-1")).getShape(), new Shape(5, 4, 3));
      *
-     *     // Uses a variable argument to the index
+     *     // Use a variable argument to the index
      *     // It can replace any number in any of these formats with {} and then the value of {}
      *     // is specified in an argument following the indices string.
      *     assertEquals(a.get(new NDIndex("{}, {}:{}", 0, 1, 3)).getShape(), new Shape(2, 3));
      *
-     *     // Uses ellipsis to insert many full slices
+     *     // Use ellipsis to insert many full slices
      *     assertEquals(a.get(new NDIndex("...")).getShape(), new Shape(5, 4, 3));
      *
-     *     // Uses ellipsis to select all the dimensions except for last axis where we only get a subsection.
+     *     // Use ellipsis to select all the dimensions except for last axis where we only get a subsection.
      *     assertEquals(a.get(new NDIndex("..., 2")).getShape(), new Shape(5, 4));
      *
-     *     // Uses null to add an extra axis to the output array
+     *     // Use null to add an extra axis to the output array
      *     assertEquals(a.get(new NDIndex(":2, null, 0, :2")).getShape(), new Shape(2, 1, 2));
+     *
+     *     // Get entries of an NDArray with mixed index
+     *     index1 = manager.create(new long[] {0, 1, 1}, new Shape(2));
+     *     bool1 = manager.create(new boolean[] {true, false, true});
+     *     assertEquals(a.get(new NDIndex(":{}, {}, {}, {}" 2, index1, bool1, null).getShape(), new Shape(2, 2, 1));
      *
      * </pre>
      *

--- a/api/src/main/java/ai/djl/ndarray/index/NDIndex.java
+++ b/api/src/main/java/ai/djl/ndarray/index/NDIndex.java
@@ -73,45 +73,45 @@ public class NDIndex {
      * <pre>
      *     NDArray a = manager.ones(new Shape(5, 4, 3));
      *
-     *     // Get a subsection of the NDArray in the first axis.
+     *     // Gets a subsection of the NDArray in the first axis.
      *     assertEquals(a.get(new NDIndex("2")).getShape(), new Shape(4, 3));
      *
-     *     // Get a subsection of the NDArray indexing from the end (-i == length - i).
+     *     // Gets a subsection of the NDArray indexing from the end (-i == length - i).
      *     assertEquals(a.get(new NDIndex("-1")).getShape(), new Shape(4, 3));
      *
-     *     // Get everything in the first axis and a subsection in the second axis.
+     *     // Gets everything in the first axis and a subsection in the second axis.
      *     // You can use either : or * to represent everything
      *     assertEquals(a.get(new NDIndex(":, 2")).getShape(), new Shape(5, 3));
      *     assertEquals(a.get(new NDIndex("*, 2")).getShape(), new Shape(5, 3));
      *
-     *     // Get a range of values along the second axis that is inclusive on the bottom and exclusive on the top.
+     *     // Gets a range of values along the second axis that is inclusive on the bottom and exclusive on the top.
      *     assertEquals(a.get(new NDIndex(":, 1:3")).getShape(), new Shape(5, 2, 3));
      *
-     *     // Exclude either the min or the max of the range to go all the way to the beginning or end.
+     *     // Excludes either the min or the max of the range to go all the way to the beginning or end.
      *     assertEquals(a.get(new NDIndex(":, :3")).getShape(), new Shape(5, 3, 3));
      *     assertEquals(a.get(new NDIndex(":, 1:")).getShape(), new Shape(5, 4, 3));
      *
-     *     // Use the value after the second colon in a slicing range, the step, to get every other result.
+     *     // Uses the value after the second colon in a slicing range, the step, to get every other result.
      *     assertEquals(a.get(new NDIndex(":, 1::2")).getShape(), new Shape(5, 2, 3));
      *
-     *     // Use a negative step to reverse along the dimension.
+     *     // Uses a negative step to reverse along the dimension.
      *     assertEquals(a.get(new NDIndex("-1")).getShape(), new Shape(5, 4, 3));
      *
-     *     // Use a variable argument to the index
+     *     // Uses a variable argument to the index
      *     // It can replace any number in any of these formats with {} and then the value of {}
      *     // is specified in an argument following the indices string.
      *     assertEquals(a.get(new NDIndex("{}, {}:{}", 0, 1, 3)).getShape(), new Shape(2, 3));
      *
-     *     // Use ellipsis to insert many full slices
+     *     // Uses ellipsis to insert many full slices
      *     assertEquals(a.get(new NDIndex("...")).getShape(), new Shape(5, 4, 3));
      *
-     *     // Use ellipsis to select all the dimensions except for last axis where we only get a subsection.
+     *     // Uses ellipsis to select all the dimensions except for last axis where we only get a subsection.
      *     assertEquals(a.get(new NDIndex("..., 2")).getShape(), new Shape(5, 4));
      *
-     *     // Use null to add an extra axis to the output array
+     *     // Uses null to add an extra axis to the output array
      *     assertEquals(a.get(new NDIndex(":2, null, 0, :2")).getShape(), new Shape(2, 1, 2));
      *
-     *     // Get entries of an NDArray with mixed index
+     *     // Gets entries of an NDArray with mixed index
      *     index1 = manager.create(new long[] {0, 1, 1}, new Shape(2));
      *     bool1 = manager.create(new boolean[] {true, false, true});
      *     assertEquals(a.get(new NDIndex(":{}, {}, {}, {}" 2, index1, bool1, null).getShape(), new Shape(2, 2, 1));

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -258,11 +258,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
         return JniUtils.take(this, (PtNDArray) index);
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return
-     */
+    /** {@inheritDoc} */
     @Override
     public NDArray put(NDArray index, NDArray data) {
         if (!(index instanceof PtNDArray) || !(data instanceof PtNDArray)) {

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -269,15 +269,6 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
 
     /** {@inheritDoc} */
     @Override
-    public NDArray put(NDArray index, NDArray data) {
-        if (!(index instanceof PtNDArray) || !(data instanceof PtNDArray)) {
-            throw new IllegalArgumentException("Only PtNDArray is supported.");
-        }
-        return JniUtils.put(this, (PtNDArray) index, (PtNDArray) data);
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void copyTo(NDArray array) {
         throw new UnsupportedOperationException("Not implemented");
     }

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -258,6 +258,19 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
         return JniUtils.take(this, (PtNDArray) index);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @return
+     */
+    @Override
+    public NDArray put(NDArray index, NDArray data) {
+        if (!(index instanceof PtNDArray) || !(data instanceof PtNDArray)) {
+            throw new IllegalArgumentException("Only PtNDArray is supported.");
+        }
+        return JniUtils.put(this, (PtNDArray) index, (PtNDArray) data);
+    }
+
     /** {@inheritDoc} */
     @Override
     public NDArray put(NDArray index, NDArray data) {

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArrayIndexer.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArrayIndexer.java
@@ -74,6 +74,25 @@ public class PtNDArrayIndexer extends NDArrayIndexer {
 
     /** {@inheritDoc} */
     @Override
+    public void set(NDArray array, NDIndex index, Object data) {
+        PtNDArray ptArray =
+                array instanceof PtNDArray
+                        ? (PtNDArray) array
+                        : manager.create(
+                                array.toByteBuffer(), array.getShape(), array.getDataType());
+
+        if (data instanceof Number) {
+            JniUtils.indexAdvPut(ptArray, index, (PtNDArray) manager.create((Number) data));
+        } else if (data instanceof NDArray) {
+            JniUtils.indexAdvPut(ptArray, index, (PtNDArray) data);
+        } else {
+            throw new IllegalArgumentException(
+                    "The type of value to assign cannot be other than NDArray and Number.");
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void set(NDArray array, NDIndexFullSlice fullSlice, NDArray value) {
         Stack<NDArray> prepareValue = new Stack<>();
         prepareValue.add(value);

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
@@ -409,7 +409,69 @@ public final class JniUtils {
 
         return new PtNDArray(
                 ndArray.getManager(),
-                PyTorchLibrary.LIB.torchIndexReturn(ndArray.getHandle(), torchIndexHandle));
+                PyTorchLibrary.LIB.torchIndexAdvGet(ndArray.getHandle(), torchIndexHandle));
+    }
+
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    public static void indexAdvPut(PtNDArray ndArray, NDIndex index, PtNDArray data) {
+        if (ndArray == null) {
+            return;
+        }
+
+        // Index aggregation
+        List<NDIndexElement> indices = index.getIndices();
+        long torchIndexHandle = PyTorchLibrary.LIB.torchIndexInit(indices.size());
+        ListIterator<NDIndexElement> it = indices.listIterator();
+        while (it.hasNext()) {
+            if (it.nextIndex() == index.getEllipsisIndex()) {
+                PyTorchLibrary.LIB.torchIndexAppendNoneEllipsis(torchIndexHandle, true);
+            }
+
+            NDIndexElement elem = it.next();
+            if (elem instanceof NDIndexNull) {
+                PyTorchLibrary.LIB.torchIndexAppendNoneEllipsis(torchIndexHandle, false);
+            } else if (elem instanceof NDIndexSlice) {
+                Long min = ((NDIndexSlice) elem).getMin();
+                Long max = ((NDIndexSlice) elem).getMax();
+                Long step = ((NDIndexSlice) elem).getStep();
+                int nullSliceBin = (min == null ? 1 : 0) * 2 + (max == null ? 1 : 0);
+                // nullSliceBin encodes whether the slice (min, max) is null:
+                // is_null == 1, ! is_null == 0;
+                // 0b11 == 3, 0b10 = 2, ...
+                PyTorchLibrary.LIB.torchIndexAppendSlice(
+                        torchIndexHandle,
+                        min == null ? 0 : min,
+                        max == null ? 0 : max,
+                        step == null ? 1 : step,
+                        nullSliceBin);
+            } else if (elem instanceof NDIndexAll) {
+                PyTorchLibrary.LIB.torchIndexAppendSlice(torchIndexHandle, 0, 0, 1, 3);
+            } else if (elem instanceof NDIndexFixed) {
+                PyTorchLibrary.LIB.torchIndexAppendFixed(
+                        torchIndexHandle, ((NDIndexFixed) elem).getIndex());
+            } else if (elem instanceof NDIndexBooleans) {
+                PtNDArray indexArr = (PtNDArray) ((NDIndexBooleans) elem).getIndex();
+                PyTorchLibrary.LIB.torchIndexAppendArray(torchIndexHandle, indexArr.getHandle());
+            } else if (elem instanceof NDIndexTake) {
+                PtNDArray indexArr = (PtNDArray) ((NDIndexTake) elem).getIndex();
+                if (indexArr.getDataType() != DataType.INT64) {
+                    indexArr = indexArr.toType(DataType.INT64, true);
+                }
+                PyTorchLibrary.LIB.torchIndexAppendArray(torchIndexHandle, indexArr.getHandle());
+            } else if (elem instanceof NDIndexPick) {
+                // Backward compatible
+                NDIndexFullPick fullPick =
+                        NDIndexFullPick.fromIndex(index, ndArray.getShape()).get();
+                pick(ndArray, ndArray.getManager().from(fullPick.getIndices()), fullPick.getAxis());
+                return;
+            }
+        }
+        if (indices.size() == index.getEllipsisIndex()) {
+            PyTorchLibrary.LIB.torchIndexAppendNoneEllipsis(torchIndexHandle, true);
+        }
+
+        PyTorchLibrary.LIB.torchIndexAdvPut(
+                ndArray.getHandle(), torchIndexHandle, data.getHandle());
     }
 
     public static void indexSet(

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
@@ -192,6 +192,8 @@ final class PyTorchLibrary {
             long[] maxIndices,
             long[] stepIndices);
 
+    native void torchIndexAdvPut(long handle, long torchIndexHandle, long data);
+
     native void torchSet(long handle, ByteBuffer data);
 
     native long torchSlice(long handle, long dim, long start, long end, long step);
@@ -605,7 +607,7 @@ final class PyTorchLibrary {
 
     native long torchIndexInit(int size);
 
-    native long torchIndexReturn(long handle, long torchIndexHandle);
+    native long torchIndexAdvGet(long handle, long torchIndexHandle);
 
     native void torchIndexAppendNoneEllipsis(long torchIndexHandle, boolean isEllipsis);
 

--- a/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_tensor.cc
+++ b/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_tensor.cc
@@ -123,30 +123,30 @@ JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndex(JNIEnv
 
 JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexInit(JNIEnv* env, jobject jthis, jint jsize) {
   API_BEGIN()
-  std::vector<torch::indexing::TensorIndex>* index_ptr = new std::vector<torch::indexing::TensorIndex>;
+  std::vector<torch::indexing::TensorIndex> *index_ptr = new std::vector<torch::indexing::TensorIndex>;
   index_ptr->reserve(jsize);
   return reinterpret_cast<uintptr_t>(index_ptr);
   API_END_RETURN()
 }
 
-JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexReturn(
-    JNIEnv* env, jobject jthis, jlong jhandle, jlong jtorch_index_handle) {
+JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexReturn(JNIEnv* env, jobject jthis,
+    jlong jhandle, jlong jtorch_index_handle) {
   API_BEGIN()
   const auto* tensor_ptr = reinterpret_cast<torch::Tensor*>(jhandle);
-  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex>*>(jtorch_index_handle);
+  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex> *>(jtorch_index_handle);
   torch::Tensor* ret_ptr = new torch::Tensor(tensor_ptr->index(*index_ptr));
   return reinterpret_cast<uintptr_t>(ret_ptr);
   API_END_RETURN()
 }
 
-JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexAppendNoneEllipsis(
-    JNIEnv* env, jobject jthis, jlong jtorch_index_handle, jboolean jis_ellipsis) {
+JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexAppendNoneEllipsis(JNIEnv* env, jobject jthis,
+    jlong jtorch_index_handle, jboolean jis_ellipsis) {
   API_BEGIN()
-  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex>*>(jtorch_index_handle);
+  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex> *>(jtorch_index_handle);
   if (jis_ellipsis) {
-    index_ptr->emplace_back(torch::indexing::Ellipsis);
+      index_ptr->emplace_back(torch::indexing::Ellipsis);
   } else {
-    index_ptr->emplace_back(torch::indexing::None);
+      index_ptr->emplace_back(torch::indexing::None);
   }
   API_END()
 }
@@ -154,34 +154,34 @@ JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexAppendNo
 JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexAppendSlice(JNIEnv* env, jobject jthis,
     jlong jtorch_index_handle, jlong jmin, jlong jmax, jlong jstep, jint jnull_slice_binary) {
   API_BEGIN()
-  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex>*>(jtorch_index_handle);
+  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex> *>(jtorch_index_handle);
   if (jnull_slice_binary == 0) {
-    index_ptr->emplace_back(torch::indexing::Slice(jmin, jmax, jstep));
+      index_ptr->emplace_back(torch::indexing::Slice(jmin, jmax, jstep));
   } else if (jnull_slice_binary == 1) {
-    index_ptr->emplace_back(torch::indexing::Slice(jmin, torch::indexing::None, jstep));
+      index_ptr->emplace_back(torch::indexing::Slice(jmin, torch::indexing::None, jstep));
   } else if (jnull_slice_binary == 2) {
-    index_ptr->emplace_back(torch::indexing::Slice(torch::indexing::None, jmax, jstep));
+      index_ptr->emplace_back(torch::indexing::Slice(torch::indexing::None, jmax, jstep));
   } else if (jnull_slice_binary == 3) {
-    index_ptr->emplace_back(torch::indexing::Slice(torch::indexing::None, torch::indexing::None, jstep));
+      index_ptr->emplace_back(torch::indexing::Slice(torch::indexing::None, torch::indexing::None, jstep));
   }
   API_END()
 }
 
-JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexAppendFixed(
-    JNIEnv* env, jobject jthis, jlong jtorch_index_handle, jlong jidx) {
+JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexAppendFixed(JNIEnv* env, jobject jthis,
+    jlong jtorch_index_handle, jlong jidx) {
   API_BEGIN()
-  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex>*>(jtorch_index_handle);
+  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex> *>(jtorch_index_handle);
   index_ptr->emplace_back((int) jidx);
   API_END()
 }
 
-JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexAppendArray(
-    JNIEnv* env, jobject jthis, jlong jtorch_index_handle, jlong jarray) {
-  API_BEGIN()
-  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex>*>(jtorch_index_handle);
+JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexAppendArray(JNIEnv* env, jobject jthis,
+    jlong jtorch_index_handle, jlong jarray) {
+API_BEGIN()
+  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex> *>(jtorch_index_handle);
   auto* array_ptr = reinterpret_cast<torch::Tensor*>(jarray);
   index_ptr->emplace_back(*array_ptr);
-  API_END()
+API_END()
 }
 
 JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexPut(JNIEnv* env, jobject jthis, jlong jhandle,

--- a/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_tensor.cc
+++ b/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_tensor.cc
@@ -123,30 +123,30 @@ JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndex(JNIEnv
 
 JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexInit(JNIEnv* env, jobject jthis, jint jsize) {
   API_BEGIN()
-  std::vector<torch::indexing::TensorIndex> *index_ptr = new std::vector<torch::indexing::TensorIndex>;
+  std::vector<torch::indexing::TensorIndex>* index_ptr = new std::vector<torch::indexing::TensorIndex>;
   index_ptr->reserve(jsize);
   return reinterpret_cast<uintptr_t>(index_ptr);
   API_END_RETURN()
 }
 
-JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexReturn(JNIEnv* env, jobject jthis,
-    jlong jhandle, jlong jtorch_index_handle) {
+JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexAdvGet(
+    JNIEnv* env, jobject jthis, jlong jhandle, jlong jtorch_index_handle) {
   API_BEGIN()
   const auto* tensor_ptr = reinterpret_cast<torch::Tensor*>(jhandle);
-  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex> *>(jtorch_index_handle);
+  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex>*>(jtorch_index_handle);
   torch::Tensor* ret_ptr = new torch::Tensor(tensor_ptr->index(*index_ptr));
   return reinterpret_cast<uintptr_t>(ret_ptr);
   API_END_RETURN()
 }
 
-JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexAppendNoneEllipsis(JNIEnv* env, jobject jthis,
-    jlong jtorch_index_handle, jboolean jis_ellipsis) {
+JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexAppendNoneEllipsis(
+    JNIEnv* env, jobject jthis, jlong jtorch_index_handle, jboolean jis_ellipsis) {
   API_BEGIN()
-  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex> *>(jtorch_index_handle);
+  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex>*>(jtorch_index_handle);
   if (jis_ellipsis) {
-      index_ptr->emplace_back(torch::indexing::Ellipsis);
+    index_ptr->emplace_back(torch::indexing::Ellipsis);
   } else {
-      index_ptr->emplace_back(torch::indexing::None);
+    index_ptr->emplace_back(torch::indexing::None);
   }
   API_END()
 }
@@ -154,34 +154,34 @@ JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexAppendNo
 JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexAppendSlice(JNIEnv* env, jobject jthis,
     jlong jtorch_index_handle, jlong jmin, jlong jmax, jlong jstep, jint jnull_slice_binary) {
   API_BEGIN()
-  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex> *>(jtorch_index_handle);
+  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex>*>(jtorch_index_handle);
   if (jnull_slice_binary == 0) {
-      index_ptr->emplace_back(torch::indexing::Slice(jmin, jmax, jstep));
+    index_ptr->emplace_back(torch::indexing::Slice(jmin, jmax, jstep));
   } else if (jnull_slice_binary == 1) {
-      index_ptr->emplace_back(torch::indexing::Slice(jmin, torch::indexing::None, jstep));
+    index_ptr->emplace_back(torch::indexing::Slice(jmin, torch::indexing::None, jstep));
   } else if (jnull_slice_binary == 2) {
-      index_ptr->emplace_back(torch::indexing::Slice(torch::indexing::None, jmax, jstep));
+    index_ptr->emplace_back(torch::indexing::Slice(torch::indexing::None, jmax, jstep));
   } else if (jnull_slice_binary == 3) {
-      index_ptr->emplace_back(torch::indexing::Slice(torch::indexing::None, torch::indexing::None, jstep));
+    index_ptr->emplace_back(torch::indexing::Slice(torch::indexing::None, torch::indexing::None, jstep));
   }
   API_END()
 }
 
-JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexAppendFixed(JNIEnv* env, jobject jthis,
-    jlong jtorch_index_handle, jlong jidx) {
+JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexAppendFixed(
+    JNIEnv* env, jobject jthis, jlong jtorch_index_handle, jlong jidx) {
   API_BEGIN()
-  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex> *>(jtorch_index_handle);
+  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex>*>(jtorch_index_handle);
   index_ptr->emplace_back((int) jidx);
   API_END()
 }
 
-JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexAppendArray(JNIEnv* env, jobject jthis,
-    jlong jtorch_index_handle, jlong jarray) {
-API_BEGIN()
-  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex> *>(jtorch_index_handle);
+JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexAppendArray(
+    JNIEnv* env, jobject jthis, jlong jtorch_index_handle, jlong jarray) {
+  API_BEGIN()
+  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex>*>(jtorch_index_handle);
   auto* array_ptr = reinterpret_cast<torch::Tensor*>(jarray);
   index_ptr->emplace_back(*array_ptr);
-API_END()
+  API_END()
 }
 
 JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexPut(JNIEnv* env, jobject jthis, jlong jhandle,
@@ -191,6 +191,16 @@ JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexPut(JNIE
   const auto* value_ptr = reinterpret_cast<torch::Tensor*>(jvalue_handle);
   auto indices = utils::CreateTensorIndex(env, jmin_indices, jmax_indices, jstep_indices);
   tensor_ptr->index_put_(indices, *value_ptr);
+  API_END()
+}
+
+JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexAdvPut(
+    JNIEnv* env, jobject jthis, jlong jhandle, jlong jtorch_index_handle, jlong jdata_handle) {
+  API_BEGIN()
+  const auto* tensor_ptr = reinterpret_cast<torch::Tensor*>(jhandle);
+  const auto* data_ptr = reinterpret_cast<torch::Tensor*>(jdata_handle);
+  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex>*>(jtorch_index_handle);
+  ((torch::Tensor) *tensor_ptr).index_put_(*index_ptr, *data_ptr);
   API_END()
 }
 

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
@@ -157,6 +157,15 @@ public class NDIndexTest {
             expected = manager.create(new int[] {0, 1, 9, 10, 4, 5, 11, 12}, new Shape(2, 4));
             original.set(new NDIndex(":, 2:"), manager.arange(9, 13).reshape(2, 2));
             Assert.assertEquals(original, expected);
+
+            // set by index array
+            original = manager.arange(1, 10).reshape(3, 3);
+            NDArray index = manager.create(new long[] {0, 1}, new Shape(2));
+            value = manager.create(new int[] {666, 777, 888, 999}, new Shape(2, 2));
+            original.set(new NDIndex("{}, :{}", index, 2), value);
+            expected =
+                    manager.create(new int[] {666, 777, 3, 888, 999, 6, 7, 8, 9}, new Shape(3, 3));
+            Assert.assertEquals(original, expected);
         }
     }
 
@@ -187,6 +196,14 @@ public class NDIndexTest {
             original = manager.arange(4f).reshape(2, 2);
             expected = manager.create(new float[] {1, 1, 1, 3}).reshape(2, 2);
             original.set(new NDIndex("..., 0"), 1);
+            Assert.assertEquals(original, expected);
+
+            // set by index array
+            original = manager.arange(1, 10).reshape(3, 3);
+            NDArray index = manager.create(new long[] {0, 1}, new Shape(2));
+            original.set(new NDIndex("{}, :{}", index, 2), 666);
+            expected =
+                    manager.create(new int[] {666, 666, 3, 666, 666, 6, 7, 8, 9}, new Shape(3, 3));
             Assert.assertEquals(original, expected);
         }
     }


### PR DESCRIPTION
## Description ##

Add tensor setter feature with advanced indexing on PyTorch engine. This is the counterpart of  the getter feature in one previous PR. [Advanced indexing that supports all indexing features on PyTorch #1719](https://github.com/deepjavalibrary/djl/pull/1719)

This PR succeeds [Add put feature with linear indexing on PyTorch engine #1749](https://github.com/deepjavalibrary/djl/pull/1749).


The relavant preceding PRs
[Advanced indexing that supports all indexing features on PyTorch #1719](https://github.com/deepjavalibrary/djl/pull/1719)
[Add put feature with linear indexing on PyTorch engine #1749](https://github.com/deepjavalibrary/djl/pull/1749)