### PR TITLE
Resizing the image after running model

### DIFF
--- a/api/src/main/java/ai/djl/modality/cv/translator/SemanticSegmentationTranslator.java
+++ b/api/src/main/java/ai/djl/modality/cv/translator/SemanticSegmentationTranslator.java
@@ -74,10 +74,9 @@ public class SemanticSegmentationTranslator extends BaseImageTranslator<Image> {
     public Image processOutput(TranslatorContext ctx, NDList list) {
         // scores contains the probabilities of each pixel being a certain object
         float[] scores = list.get(1).toFloatArray();
-
-        // get dimensions of image
-        int width = (int) ctx.getAttachment("originalWidth");
-        int height = (int) ctx.getAttachment("originalHeight");
+        Shape shape = list.get(1).getShape();
+        int width = (int) shape.get(2);
+        int height = (int) shape.get(1);
 
         // build image array
         try (NDManager manager = NDManager.newBaseManager()) {

--- a/examples/src/main/java/ai/djl/examples/inference/SemanticSegmentation.java
+++ b/examples/src/main/java/ai/djl/examples/inference/SemanticSegmentation.java
@@ -62,9 +62,6 @@ public final class SemanticSegmentation {
         Map<String, String> arguments = new ConcurrentHashMap<>();
         arguments.put("toTensor", "true");
         arguments.put("normalize", "true");
-        arguments.put("resize", "true");
-        arguments.put("width", String.valueOf(width));
-        arguments.put("height", String.valueOf(height));
         SemanticSegmentationTranslator translator =
                 SemanticSegmentationTranslator.builder(arguments).build();
 
@@ -79,17 +76,20 @@ public final class SemanticSegmentation {
         try (ZooModel<Image, Image> model = criteria.loadModel()) {
             try (Predictor<Image, Image> predictor = model.newPredictor()) {
                 Image semanticImage = predictor.predict(img);
-                saveSemanticImage(semanticImage);
+                saveSemanticImage(semanticImage, width, height);
             }
         }
     }
 
-    private static void saveSemanticImage(Image img) throws IOException {
+    private static void saveSemanticImage(Image img, int width, int height) throws IOException {
         Path outputDir = Paths.get("build/output");
         Files.createDirectories(outputDir);
 
         Path imagePath = outputDir.resolve("semantic_instances.png");
-        img.save(Files.newOutputStream(imagePath), "png");
+
+        // reduce image down to original size
+        Image resized = img.getSubImage(0, 0, width, height);
+        resized.save(Files.newOutputStream(imagePath), "png");
         logger.info("Segmentation result image has been saved in: {}", imagePath);
     }
 }


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- Change image resize to after the model has run so that if we want to run inference on several images of different sizes, we can do it after loading the model just once instead of each time
