### PR TITLE
Issue fix 1773 and 1774

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/NDArray.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArray.java
@@ -484,11 +484,11 @@ public interface NDArray extends NDResource, BytesSupplier {
     /**
      * Sets the {@code NDArray} by boolean mask.
      *
-     * @param index the boolean {@code NDArray} that indicates what to get
+     * @param index the boolean or integer {@code NDArray} that indicates what to get
      * @param value the value to replace with
      */
     default void set(NDArray index, Number value) {
-        set(new NDIndex().addBooleanIndex(index), value);
+        set(new NDIndex("{}", index), value);
     }
 
     /**
@@ -526,7 +526,7 @@ public interface NDArray extends NDResource, BytesSupplier {
     /**
      * Returns a partial {@code NDArray}.
      *
-     * @param index the boolean or int {@code NDArray} that indicates what to get
+     * @param index the boolean or integer {@code NDArray} that indicates what to get
      * @return the partial {@code NDArray}
      */
     default NDArray get(NDArray index) {

--- a/api/src/main/java/ai/djl/ndarray/NDArray.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArray.java
@@ -482,7 +482,7 @@ public interface NDArray extends NDResource, BytesSupplier {
     }
 
     /**
-     * Sets the {@code NDArray} by boolean mask.
+     * Sets the {@code NDArray} by boolean mask or integer index.
      *
      * @param index the boolean or integer {@code NDArray} that indicates what to get
      * @param value the value to replace with

--- a/docs/get.md
+++ b/docs/get.md
@@ -96,10 +96,10 @@ If you have another project and want to use a custom version of DJL in it, you c
 
 ```groovy
 dependencies {
-    implementation platform("ai.djl:bom:0.19.0-SNAPSHOT")
+    implementation platform("ai.djl:bom:<UPCOMING VERSION>-SNAPSHOT")
 }
 ```
-
+Currently, the `<UPCOMING VERSION> = 0.19.0`.
 This snapshot version is the same as the custom DJL repository. 
 
 You also need to change directory to `djl/bom`. Then build and publish it to maven local same as what was done in `djl`.

--- a/docs/get.md
+++ b/docs/get.md
@@ -96,13 +96,13 @@ If you have another project and want to use a custom version of DJL in it, you c
 
 ```groovy
 dependencies {
-    implementation platform("ai.djl:bom:0.17.0-SNAPSHOT")
+    implementation platform("ai.djl:bom:<THE NEXT TO-PUBLISH VERSION>-SNAPSHOT")
 }
 ```
 
 This snapshot version is the same as the custom DJL repository. 
 
-You also need to change directory to `djl/bom`. Then build and publish it to maven local same as was done in `djl`.
+You also need to change directory to `djl/bom`. Then build and publish it to maven local same as what was done in `djl`.
 
 From there, you may have to update the Maven or Gradle build of the project importing DJL to also look at the local maven repository cache for your locally published versions of DJL. For Maven, no changes are necessary. If you are using Gradle, you will have to add the maven local repository such as this [example](https://github.com/deepjavalibrary/djl-demo/blob/135c969d66d98d1672852e53a37e52ca1da3e325/pneumonia-detection/build.gradle#L11):
 

--- a/docs/get.md
+++ b/docs/get.md
@@ -96,7 +96,7 @@ If you have another project and want to use a custom version of DJL in it, you c
 
 ```groovy
 dependencies {
-    implementation platform("ai.djl:bom:<THE NEXT TO-PUBLISH VERSION>-SNAPSHOT")
+    implementation platform("ai.djl:bom:<UPCOMING VERSION>-SNAPSHOT")
 }
 ```
 

--- a/docs/get.md
+++ b/docs/get.md
@@ -96,7 +96,7 @@ If you have another project and want to use a custom version of DJL in it, you c
 
 ```groovy
 dependencies {
-    implementation platform("ai.djl:bom:<UPCOMING VERSION>-SNAPSHOT")
+    implementation platform("ai.djl:bom:0.19.0-SNAPSHOT")
 }
 ```
 

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
@@ -205,6 +205,13 @@ public class NDIndexTest {
             expected =
                     manager.create(new int[] {666, 666, 3, 666, 666, 6, 7, 8, 9}, new Shape(3, 3));
             Assert.assertEquals(original, expected);
+
+            original = manager.arange(1, 10).reshape(3, 3);
+            original.set(index, 666);
+            expected =
+                    manager.create(
+                            new int[] {666, 666, 666, 666, 666, 666, 7, 8, 9}, new Shape(3, 3));
+            Assert.assertEquals(original, expected);
         }
     }
 


### PR DESCRIPTION
1. Fix [issue 1773](https://github.com/deepjavalibrary/djl/issues/1773) and [issue 1774](https://github.com/deepjavalibrary/djl/issues/1774)

In `NDArray.set(NDArray index, Number value)` add the feature of setting array values with integer indices, as shown in the use case https://github.com/deepjavalibrary/djl/issues/1773 as well as https://github.com/deepjavalibrary/djl/issues/1774.

This is similar to [pr#1755](https://github.com/deepjavalibrary/djl/pull/1755) and is based on the advanced indexing [pr#1719](https://github.com/deepjavalibrary/djl/pull/1719).

2. Fix an issue in the document of built-from-source