### PR TITLE
Backward compatible with MXNet indexing.

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullPick.java
+++ b/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullPick.java
@@ -52,22 +52,26 @@ public final class NDIndexFullPick {
         for (NDIndexElement el : index.getIndices()) {
             if (el instanceof NDIndexAll) {
                 axis++;
-            } else if (el instanceof NDIndexPick || el instanceof NDIndexTake) {
-                if (fullPick == null) {
-                    NDArray indexElem =
-                            el instanceof NDIndexPick
-                                    ? ((NDIndexPick) el).getIndex()
-                                    : ((NDIndexTake) el).getIndex();
-                    if (el instanceof NDIndexTake && !indexElem.getShape().isRankOne()) {
-                        throw new UnsupportedOperationException(
-                                "Only rank-1 indexing array is supported for pick");
-                    }
-                    fullPick = new NDIndexFullPick(indexElem, axis);
-                } else {
+            } else if (el instanceof NDIndexPick) {
+                if (fullPick != null) {
                     // Don't support multiple picks
                     throw new UnsupportedOperationException(
                             "Only one pick per get is currently supported");
                 }
+                NDArray indexElem = ((NDIndexPick) el).getIndex();
+                fullPick = new NDIndexFullPick(indexElem, axis);
+            } else if (el instanceof NDIndexTake) {
+                if (fullPick != null) {
+                    // Don't support multiple picks
+                    throw new UnsupportedOperationException(
+                            "Only one pick per get is currently supported");
+                }
+                NDArray indexElem = ((NDIndexTake) el).getIndex();
+                if (!indexElem.getShape().isRankOne()) {
+                    throw new UnsupportedOperationException(
+                            "Only rank-1 indexing array is supported for pick");
+                }
+                fullPick = new NDIndexFullPick(indexElem, axis);
             } else {
                 // Invalid dim for fullPick
                 return Optional.empty();

--- a/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullPick.java
+++ b/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullPick.java
@@ -58,7 +58,7 @@ public final class NDIndexFullPick {
                             el instanceof NDIndexPick
                                     ? ((NDIndexPick) el).getIndex()
                                     : ((NDIndexTake) el).getIndex();
-                    if (!indexElem.getShape().isRankOne()) {
+                    if (el instanceof NDIndexTake && !indexElem.getShape().isRankOne()) {
                         throw new UnsupportedOperationException(
                                 "Only rank-1 indexing array is supported for pick");
                     }

--- a/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullPick.java
+++ b/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullPick.java
@@ -17,6 +17,7 @@ import ai.djl.ndarray.index.NDIndex;
 import ai.djl.ndarray.index.dim.NDIndexAll;
 import ai.djl.ndarray.index.dim.NDIndexElement;
 import ai.djl.ndarray.index.dim.NDIndexPick;
+import ai.djl.ndarray.index.dim.NDIndexTake;
 import ai.djl.ndarray.types.Shape;
 
 import java.util.Optional;
@@ -51,9 +52,13 @@ public final class NDIndexFullPick {
         for (NDIndexElement el : index.getIndices()) {
             if (el instanceof NDIndexAll) {
                 axis++;
-            } else if (el instanceof NDIndexPick) {
+            } else if (el instanceof NDIndexPick || el instanceof NDIndexTake) {
                 if (fullPick == null) {
-                    fullPick = new NDIndexFullPick(((NDIndexPick) el).getIndex(), axis);
+                    NDArray indexElem =
+                            el instanceof NDIndexPick
+                                    ? ((NDIndexPick) el).getIndex()
+                                    : ((NDIndexTake) el).getIndex();
+                    fullPick = new NDIndexFullPick(indexElem, axis);
                 } else {
                     // Don't support multiple picks
                     throw new UnsupportedOperationException(

--- a/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullPick.java
+++ b/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullPick.java
@@ -60,7 +60,7 @@ public final class NDIndexFullPick {
                                     : ((NDIndexTake) el).getIndex();
                     if (!indexElem.getShape().isRankOne()) {
                         throw new UnsupportedOperationException(
-                                "Only one pick per get is currently supported");
+                                "Only rank-1 indexing array is supported for pick");
                     }
                     fullPick = new NDIndexFullPick(indexElem, axis);
                 } else {

--- a/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullPick.java
+++ b/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullPick.java
@@ -58,6 +58,10 @@ public final class NDIndexFullPick {
                             el instanceof NDIndexPick
                                     ? ((NDIndexPick) el).getIndex()
                                     : ((NDIndexTake) el).getIndex();
+                    if (!indexElem.getShape().isRankOne()) {
+                        throw new UnsupportedOperationException(
+                                "Only one pick per get is currently supported");
+                    }
                     fullPick = new NDIndexFullPick(indexElem, axis);
                 } else {
                     // Don't support multiple picks

--- a/api/src/main/java/ai/djl/ndarray/types/Shape.java
+++ b/api/src/main/java/ai/djl/ndarray/types/Shape.java
@@ -489,9 +489,8 @@ public class Shape {
     public boolean isRankOne() {
         int max = 1;
         int ans = 1;
-        for (long s : shape) {
-            int size =  Math.toIntExact(s);
-            max = Math.max(max, size);
+        for (long size : shape) {
+            max = (int) Math.max(max, size);
             ans *= size;
             if (ans < 0) {
                 return false;

--- a/api/src/main/java/ai/djl/ndarray/types/Shape.java
+++ b/api/src/main/java/ai/djl/ndarray/types/Shape.java
@@ -489,8 +489,9 @@ public class Shape {
     public boolean isRankOne() {
         int max = 1;
         int ans = 1;
-        for (long size : shape) {
-            max = (int) Math.max(max, size);
+        for (long s : shape) {
+            int size = Math.toIntExact(s);
+            max = Math.max(max, size);
             ans *= size;
             if (ans < 0) {
                 return false;

--- a/api/src/main/java/ai/djl/ndarray/types/Shape.java
+++ b/api/src/main/java/ai/djl/ndarray/types/Shape.java
@@ -492,7 +492,7 @@ public class Shape {
         for (long s : shape) {
             int size =  Math.toIntExact(s);
             max = Math.max(max, size);
-            ans *= s;
+            ans *= size;
             if (ans < 0) {
                 return false;
             }

--- a/api/src/main/java/ai/djl/ndarray/types/Shape.java
+++ b/api/src/main/java/ai/djl/ndarray/types/Shape.java
@@ -477,4 +477,24 @@ public class Shape {
         }
         return new Shape(shapeValue, new String(layout));
     }
+
+    /**
+     * Returns if the array is rank-1 which is inferred from the shape.
+     *
+     * <p>For example, an array with shape [1, 10, 1] returns true. Array with indeterminate size -1
+     * returns false.
+     *
+     * @return if the array is rank-1
+     */
+    public boolean isRankOne() {
+        int max = 1, ans = 1;
+        for (long s : shape) {
+            max = Math.max(max, Math.toIntExact(s));
+            ans *= s;
+            if (ans < 0) {
+                return false;
+            }
+        }
+        return max == ans;
+    }
 }

--- a/api/src/main/java/ai/djl/ndarray/types/Shape.java
+++ b/api/src/main/java/ai/djl/ndarray/types/Shape.java
@@ -487,7 +487,8 @@ public class Shape {
      * @return if the array is rank-1
      */
     public boolean isRankOne() {
-        int max = 1, ans = 1;
+        int max = 1;
+        int ans = 1;
         for (long s : shape) {
             int size =  Math.toIntExact(s);
             max = Math.max(max, size);

--- a/api/src/main/java/ai/djl/ndarray/types/Shape.java
+++ b/api/src/main/java/ai/djl/ndarray/types/Shape.java
@@ -489,7 +489,8 @@ public class Shape {
     public boolean isRankOne() {
         int max = 1, ans = 1;
         for (long s : shape) {
-            max = Math.max(max, Math.toIntExact(s));
+            int size =  Math.toIntExact(s);
+            max = Math.max(max, size);
             ans *= s;
             if (ans < 0) {
                 return false;


### PR DESCRIPTION
This solves the bug reported in [issue](https://github.com/deepjavalibrary/djl/issues/1800). 

The new feature of indexing is not completely backward compatible, since `NDIndexPick` has been replaced by `NDIndexTake`. Now this problem is solved.

However, this is a temporary solution, only to make it backward compatible. `NDIndexPick` does not have the same definition as `NDIndexTake` when used to index array elements. For example, `NDIndexPick` cannot support larger-than-1-rank indexing array, while `NDIndexTake` can. So, as NDIndexElement,  `NDIndexPick` should be deprecated in the future.
