### PR TITLE
Compatibility changes for Semantic Segmentation app

### DIFF
--- a/android/core/src/main/java/ai/djl/android/core/BitmapImageFactory.java
+++ b/android/core/src/main/java/ai/djl/android/core/BitmapImageFactory.java
@@ -98,7 +98,7 @@ public class BitmapImageFactory extends ImageFactory {
                 array = array.transpose(2, 0, 1);
                 shape = array.getShape();
             } else {
-                throw new IllegalArgumentException("First and last dimension should be number of channel with value 1 or 3");
+                throw new IllegalArgumentException("First or last dimension should be number of channel with value 1 or 3");
             }
         }
         int height = (int) shape.get(1);

--- a/android/core/src/main/java/ai/djl/android/core/BitmapImageFactory.java
+++ b/android/core/src/main/java/ai/djl/android/core/BitmapImageFactory.java
@@ -93,8 +93,13 @@ public class BitmapImageFactory extends ImageFactory {
         }
         if (shape.get(0) == 1) {
             throw new UnsupportedOperationException("Grayscale image is not supported");
-        } else if (shape.get(0) != 3){
-            throw new IllegalArgumentException("First dimension should be number of channel with value 1 or 3");
+        } else if (shape.get(0) != 3) {
+            if (shape.get(2) == 3) {
+                array = array.transpose(2, 0, 1);
+                shape = array.getShape();
+            } else {
+                throw new IllegalArgumentException("First and last dimension should be number of channel with value 1 or 3");
+            }
         }
         int height = (int) shape.get(1);
         int width = (int) shape.get(2);

--- a/api/src/main/java/ai/djl/modality/cv/translator/SemanticSegmentationTranslator.java
+++ b/api/src/main/java/ai/djl/modality/cv/translator/SemanticSegmentationTranslator.java
@@ -110,10 +110,12 @@ public class SemanticSegmentationTranslator extends BaseImageTranslator<Image> {
             }
             int originW = (int) ctx.getAttachment("originalWidth");
             int originH = (int) ctx.getAttachment("originalHeight");
-            NDArray intRet = manager.create(bb, new Shape(height, width, CHANNEL), DataType.UINT8);
-            NDArray resized = NDImageUtils.resize(intRet, originW, originH);
+            NDArray fullImage =
+                    manager.create(bb, new Shape(height, width, CHANNEL), DataType.UINT8);
+            NDArray resized = NDImageUtils.resize(fullImage, originW, originH);
+            NDArray ret = resized.toType(DataType.UINT8, true);
 
-            return ImageFactory.getInstance().fromNDArray(resized);
+            return ImageFactory.getInstance().fromNDArray(ret);
         }
     }
 

--- a/api/src/main/java/ai/djl/modality/cv/translator/SemanticSegmentationTranslator.java
+++ b/api/src/main/java/ai/djl/modality/cv/translator/SemanticSegmentationTranslator.java
@@ -113,7 +113,7 @@ public class SemanticSegmentationTranslator extends BaseImageTranslator<Image> {
             NDArray fullImage =
                     manager.create(bb, new Shape(height, width, CHANNEL), DataType.UINT8);
             NDArray resized = NDImageUtils.resize(fullImage, originW, originH);
-            NDArray ret = resized.toType(DataType.UINT8, true);
+            NDArray ret = resized.toType(DataType.UINT8, false);
 
             return ImageFactory.getInstance().fromNDArray(ret);
         }


### PR DESCRIPTION
## Description ##

Adds compatibility for the DJL-Demo Semantic Segmentation app

- Transposes NDArray if dimensions matchup in BitmapImageFactory
- DataType for NDArray would change from the app due to using BitmapImageFactory and not BufferImageFactory, so added line to change DataType back to `UINT8` before returning image.
