### PR TITLE
[android] Bumpup android version to 0.19.0-SNAPSHOT

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -17,5 +17,5 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
-djl_version=0.18.0
+djl_version=0.19.0
 pytorch_version=1.11.0


### PR DESCRIPTION
Change-Id: I03d27ba222755c292b04a59fb6bf59864f8767b0

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
