### PR TITLE
Fixes resize return DataType mismatch bug

### DIFF
--- a/api/src/main/java/ai/djl/modality/cv/translator/SemanticSegmentationTranslator.java
+++ b/api/src/main/java/ai/djl/modality/cv/translator/SemanticSegmentationTranslator.java
@@ -113,9 +113,8 @@ public class SemanticSegmentationTranslator extends BaseImageTranslator<Image> {
             NDArray fullImage =
                     manager.create(bb, new Shape(height, width, CHANNEL), DataType.UINT8);
             NDArray resized = NDImageUtils.resize(fullImage, originW, originH);
-            NDArray ret = resized.toType(DataType.UINT8, false);
 
-            return ImageFactory.getInstance().fromNDArray(ret);
+            return ImageFactory.getInstance().fromNDArray(resized);
         }
     }
 

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArrayEx.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArrayEx.java
@@ -582,7 +582,8 @@ public class PtNDArrayEx implements NDArrayEx {
                                     new long[] {height, width},
                                     getInterpolationMode(interpolation),
                                     false)
-                            .transpose(0, 2, 3, 1);
+                            .transpose(0, 2, 3, 1)
+                            .toType(array.getDataType(), false);
             if (dim == 3) {
                 result = result.squeeze(0);
             }

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArrayEx.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArrayEx.java
@@ -517,11 +517,15 @@ public class TfNDArrayEx implements NDArrayEx {
                                     .addInput(temp)
                                     .addInput(size)
                                     .buildSingletonOrThrow()) {
-                return image.squeeze();
+                return image.squeeze().toType(array.getDataType(), false);
             }
         }
         try (NDArray size = manager.create(new int[] {height, width})) {
-            return manager.opExecutor(op).addInput(array).addInput(size).buildSingletonOrThrow();
+            return manager.opExecutor(op)
+                    .addInput(array)
+                    .addInput(size)
+                    .buildSingletonOrThrow()
+                    .toType(array.getDataType(), false);
         }
     }
 

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayOtherOpTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayOtherOpTest.java
@@ -975,21 +975,21 @@ public class NDArrayOtherOpTest {
     public void testResize() {
         try (NDManager manager = NDManager.newBaseManager()) {
             // test on HWC
-            NDArray fullImage = manager.create(new Shape(600, 800, 3), DataType.UINT8);
+            NDArray fullImage = manager.create(new Shape(28, 28, 3), DataType.UINT8);
             Assert.assertEquals(fullImage.getDataType(), DataType.UINT8);
-            NDArray resized = NDImageUtils.resize(fullImage, 500, 700);
+            NDArray resized = NDImageUtils.resize(fullImage, 32, 32);
             Assert.assertEquals(resized.getDataType(), DataType.UINT8);
 
             // test on CHW
-            fullImage = manager.create(new Shape(3, 600, 800), DataType.UINT8);
+            fullImage = manager.create(new Shape(3, 28, 28), DataType.UINT8);
             Assert.assertEquals(fullImage.getDataType(), DataType.UINT8);
-            resized = NDImageUtils.resize(fullImage, 500, 700);
+            resized = NDImageUtils.resize(fullImage, 32, 32);
             Assert.assertEquals(resized.getDataType(), DataType.UINT8);
 
             // test type that is converted to in PtNDArrayEx.java
-            fullImage = manager.create(new Shape(600, 800, 3), DataType.FLOAT32);
+            fullImage = manager.create(new Shape(28, 28, 3), DataType.FLOAT32);
             Assert.assertEquals(fullImage.getDataType(), DataType.FLOAT32);
-            resized = NDImageUtils.resize(fullImage, 500, 700);
+            resized = NDImageUtils.resize(fullImage, 32, 32);
             Assert.assertEquals(resized.getDataType(), DataType.FLOAT32);
         }
     }

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayOtherOpTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayOtherOpTest.java
@@ -14,6 +14,7 @@ package ai.djl.integration.tests.ndarray;
 
 import ai.djl.engine.Engine;
 import ai.djl.engine.EngineException;
+import ai.djl.modality.cv.util.NDImageUtils;
 import ai.djl.ndarray.LazyNDArray;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDArrays;
@@ -967,6 +968,29 @@ public class NDArrayOtherOpTest {
                 NDArray grad = x.getGradient();
                 Assert.assertEquals(1f, grad.getFloat(0));
             }
+        }
+    }
+
+    @Test
+    public void testResize() {
+        try (NDManager manager = NDManager.newBaseManager()) {
+            // test on HWC
+            NDArray fullImage = manager.create(new Shape(600, 800, 3), DataType.UINT8);
+            Assert.assertEquals(fullImage.getDataType(), DataType.UINT8);
+            NDArray resized = NDImageUtils.resize(fullImage, 500, 700);
+            Assert.assertEquals(resized.getDataType(), DataType.UINT8);
+
+            // test on CHW
+            fullImage = manager.create(new Shape(3, 600, 800), DataType.UINT8);
+            Assert.assertEquals(fullImage.getDataType(), DataType.UINT8);
+            resized = NDImageUtils.resize(fullImage, 500, 700);
+            Assert.assertEquals(resized.getDataType(), DataType.UINT8);
+
+            // test type that is converted to in PtNDArrayEx.java
+            fullImage = manager.create(new Shape(600, 800, 3), DataType.FLOAT32);
+            Assert.assertEquals(fullImage.getDataType(), DataType.FLOAT32);
+            resized = NDImageUtils.resize(fullImage, 500, 700);
+            Assert.assertEquals(resized.getDataType(), DataType.FLOAT32);
         }
     }
 }


### PR DESCRIPTION
## Description ##

Fixes the NDArray from being set to a float32 format

- When calling the resize method from the DJL-demo repo, the `PtNDArrayEx.java` is called and changes the `NDArray` type from `UINT8` to `float32`. This fix changes it back to it's original dataType that it was prior to being changed to `float32`.
