### PR TITLE
[doc] Immutable array output from InferenceMode PyTorch

### DIFF
--- a/api/src/main/java/ai/djl/translate/PostProcessor.java
+++ b/api/src/main/java/ai/djl/translate/PostProcessor.java
@@ -25,7 +25,8 @@ public interface PostProcessor<O> {
      * Processes the output NDList to the corresponding output object.
      *
      * @param ctx the toolkit used for post-processing
-     * @param list the output NDList after inference
+     * @param list the output NDList after inference, usually immutable in some engines, e.g.
+     *     PyTorch. See: <a href="https://github.com/deepjavalibrary/djl/issues/1774">...</a>
      * @return the output object of expected type
      * @throws Exception if an error occurs during processing output
      */

--- a/api/src/main/java/ai/djl/translate/PostProcessor.java
+++ b/api/src/main/java/ai/djl/translate/PostProcessor.java
@@ -26,7 +26,7 @@ public interface PostProcessor<O> {
      *
      * @param ctx the toolkit used for post-processing
      * @param list the output NDList after inference, usually immutable in some engines, e.g.
-     *     PyTorch. See: <a href="https://github.com/deepjavalibrary/djl/issues/1774">...</a>
+     *     PyTorch. @see <a href="https://github.com/deepjavalibrary/djl/issues/1774">Issue 1774</a>
      * @return the output object of expected type
      * @throws Exception if an error occurs during processing output
      */

--- a/api/src/main/java/ai/djl/translate/PostProcessor.java
+++ b/api/src/main/java/ai/djl/translate/PostProcessor.java
@@ -25,7 +25,7 @@ public interface PostProcessor<O> {
      * Processes the output NDList to the corresponding output object.
      *
      * @param ctx the toolkit used for post-processing
-     * @param list the output NDList after inference, usually immutable in some engines, e.g.
+     * @param list the output NDList after inference, usually immutable in engines like
      *     PyTorch. @see <a href="https://github.com/deepjavalibrary/djl/issues/1774">Issue 1774</a>
      * @return the output object of expected type
      * @throws Exception if an error occurs during processing output


### PR DESCRIPTION
This doc change originates from [issue 1774](https://github.com/deepjavalibrary/djl/issues/1774). It reminds user that the output array during inference mode is immutable. When they need to change the output NDArray in a implementation of postProcessor, they will know.
