### PR TITLE
[pytorch] Allows block only model for PyTorch

### DIFF
--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtModel.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtModel.java
@@ -97,15 +97,24 @@ public class PtModel extends BaseModel {
                 properties.put(extraFileKeys[i], extraFileValues[i]);
             }
         } else {
-            Path paramFile = paramPathResolver(prefix, options);
-            if (paramFile == null) {
-                throw new IOException(
-                        "Parameter file not found in: "
-                                + modelDir
-                                + ". If you only specified model path, make sure path name match"
-                                + "your saved model file name.");
+            boolean hasParameter = true;
+            if (options != null) {
+                String paramOption = (String) options.get("hasParameter");
+                if (paramOption != null) {
+                    hasParameter = Boolean.parseBoolean(paramOption);
+                }
             }
-            readParameters(paramFile, options);
+            if (hasParameter) {
+                Path paramFile = paramPathResolver(prefix, options);
+                if (paramFile == null) {
+                    throw new IOException(
+                            "Parameter file not found in: "
+                                    + modelDir
+                                    + ". If you only specified model path, make sure path name"
+                                    + " matchyour saved model file name.");
+                }
+                readParameters(paramFile, options);
+            }
         }
     }
 

--- a/extensions/tokenizers/src/test/java/ai/djl/huggingface/tokenizers/TranslatorTest.java
+++ b/extensions/tokenizers/src/test/java/ai/djl/huggingface/tokenizers/TranslatorTest.java
@@ -12,7 +12,6 @@
  */
 package ai.djl.huggingface.tokenizers;
 
-import ai.djl.Model;
 import ai.djl.ModelException;
 import ai.djl.huggingface.translator.QuestionAnsweringTranslatorFactory;
 import ai.djl.inference.Predictor;
@@ -20,8 +19,6 @@ import ai.djl.modality.nlp.qa.QAInput;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.NDManager;
-import ai.djl.ndarray.types.DataType;
-import ai.djl.ndarray.types.Shape;
 import ai.djl.nn.Block;
 import ai.djl.nn.LambdaBlock;
 import ai.djl.repository.zoo.Criteria;
@@ -72,12 +69,6 @@ public class TranslatorTest {
                         "model");
         Path modelDir = Paths.get("build/model");
         Files.createDirectories(modelDir);
-        Model testModel = Model.newInstance("model");
-        testModel.setBlock(block);
-        block.initialize(testModel.getNDManager(), DataType.FLOAT32, new Shape(1));
-        testModel.save(modelDir, "model");
-        testModel.close();
-
         Criteria<QAInput, String> criteria =
                 Criteria.builder()
                         .setTypes(QAInput.class, String.class)
@@ -85,6 +76,7 @@ public class TranslatorTest {
                         .optBlock(block)
                         .optEngine("PyTorch")
                         .optArgument("tokenizer", "bert-base-cased")
+                        .optOption("hasParameter", "false")
                         .optTranslatorFactory(new QuestionAnsweringTranslatorFactory())
                         .build();
 


### PR DESCRIPTION
Change-Id: Id4c8b734ffc0ad07685e1df1f977c8dcb50dec79

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
