### PR TITLE
Updated image factories for HWC and CHW

### DIFF
--- a/android/core/src/androidTest/java/ai/djl/android/core/BitmapWrapperTest.java
+++ b/android/core/src/androidTest/java/ai/djl/android/core/BitmapWrapperTest.java
@@ -90,6 +90,12 @@ public class BitmapWrapperTest {
                     .transpose(2, 0, 1)
                     .toType(DataType.FLOAT32, true);
             assertEquals(array, converted);
+
+            array = manager.arange(0, 12, 1, DataType.UINT8).reshape(3, 2, 2);
+            array = array.transpose(1, 2, 0);
+            image = factory.fromNDArray(array);
+            converted = image.toNDArray(manager);
+            assertEquals(array, converted);
         }
     }
 }

--- a/android/core/src/main/java/ai/djl/android/core/BitmapImageFactory.java
+++ b/android/core/src/main/java/ai/djl/android/core/BitmapImageFactory.java
@@ -110,7 +110,6 @@ public class BitmapImageFactory extends ImageFactory {
         int height = (int) shape.get(0);
         int width = (int) shape.get(1);
         Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
-        int imageArea = height * width;
         for (int h = 0; h < height; ++h) {
             for (int w = 0; w < width; ++w) {
                 int pos = (h * width + w) * 3;

--- a/android/core/src/main/java/ai/djl/android/core/BitmapImageFactory.java
+++ b/android/core/src/main/java/ai/djl/android/core/BitmapImageFactory.java
@@ -90,35 +90,33 @@ public class BitmapImageFactory extends ImageFactory {
         } else if (shape.get(0) == 1 || shape.get(2) == 1) {
             throw new UnsupportedOperationException("Grayscale image is not supported");
         }
+        int[] raw = array.toType(DataType.UINT8, false).toUint8Array();
         if (NDImageUtils.isCHW(shape)) {
             int height = (int) shape.get(1);
             int width = (int) shape.get(2);
             Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
-            int[] raw = array.toType(DataType.UINT8, false).toUint8Array();
             int imageArea = width * height;
             for (int h = 0; h < height; ++h) {
                 for (int w = 0; w < width; ++w) {
-                    int pos = (h * width + w);
-                    int red = raw[pos] & 0xFF;
-                    int green = raw[imageArea + pos] & 0xFF;
-                    int blue = raw[imageArea * 2 + pos] & 0xFF;
+                    int index = h * width + w;
+                    int red = raw[index] & 0xFF;
+                    int green = raw[imageArea + index] & 0xFF;
+                    int blue = raw[imageArea * 2 + index] & 0xFF;
                     bitmap.setPixel(w, h, Color.argb(255, red, green, blue));
                 }
             }
             return new BitMapWrapper(bitmap);
         }
-        shape = array.getShape();
         int height = (int) shape.get(0);
         int width = (int) shape.get(1);
         Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
-        int[] raw = array.toType(DataType.UINT8, false).toUint8Array();
         int imageArea = height * width;
         for (int h = 0; h < height; ++h) {
             for (int w = 0; w < width; ++w) {
-                int pos = (h * width + w);
+                int pos = (h * width + w) * 3;
                 int red = raw[pos];
-                int green = raw[imageArea + pos];
-                int blue = raw[imageArea * 2 + pos];
+                int green = raw[pos + 1];
+                int blue = raw[pos + 2];
                 bitmap.setPixel(w, h, Color.argb(255, red, green, blue));
             }
         }

--- a/android/core/src/main/java/ai/djl/android/core/BitmapImageFactory.java
+++ b/android/core/src/main/java/ai/djl/android/core/BitmapImageFactory.java
@@ -91,20 +91,34 @@ public class BitmapImageFactory extends ImageFactory {
             throw new UnsupportedOperationException("Grayscale image is not supported");
         }
         if (NDImageUtils.isCHW(shape)) {
-            array = array.transpose(1, 2, 0);
-            shape = array.getShape();
+            int height = (int) shape.get(1);
+            int width = (int) shape.get(2);
+            Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+            int[] raw = array.toType(DataType.UINT8, false).toUint8Array();
+            int imageArea = width * height;
+            for (int h = 0; h < height; ++h) {
+                for (int w = 0; w < width; ++w) {
+                    int pos = (h * width + w);
+                    int red = raw[pos] & 0xFF;
+                    int green = raw[imageArea + pos] & 0xFF;
+                    int blue = raw[imageArea * 2 + pos] & 0xFF;
+                    bitmap.setPixel(w, h, Color.argb(255, red, green, blue));
+                }
+            }
+            return new BitMapWrapper(bitmap);
         }
-
+        shape = array.getShape();
         int height = (int) shape.get(0);
         int width = (int) shape.get(1);
         Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
         int[] raw = array.toType(DataType.UINT8, false).toUint8Array();
+        int imageArea = height * width;
         for (int h = 0; h < height; ++h) {
             for (int w = 0; w < width; ++w) {
-                int pos = (h * width + w) * 3;
+                int pos = (h * width + w);
                 int red = raw[pos];
-                int green = raw[pos + 1];
-                int blue = raw[pos + 2];
+                int green = raw[imageArea + pos];
+                int blue = raw[imageArea * 2 + pos];
                 bitmap.setPixel(w, h, Color.argb(255, red, green, blue));
             }
         }

--- a/api/src/main/java/ai/djl/modality/cv/BufferedImageFactory.java
+++ b/api/src/main/java/ai/djl/modality/cv/BufferedImageFactory.java
@@ -91,8 +91,24 @@ public class BufferedImageFactory extends ImageFactory {
             throw new UnsupportedOperationException("Grayscale image is not supported");
         }
         if (NDImageUtils.isCHW(shape)) {
-            array = array.transpose(1, 2, 0);
-            shape = array.getShape();
+            int height = (int) shape.get(1);
+            int width = (int) shape.get(2);
+            BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+            int[] raw = array.toType(DataType.UINT8, false).toUint8Array();
+            int[] pixels = new int[width * height];
+            int imageArea = height * width;
+            for (int h = 0; h < height; ++h) {
+                for (int w = 0; w < width; ++w) {
+                    int index = h * width + w;
+                    int pos = index;
+                    int red = raw[pos];
+                    int green = raw[imageArea + pos];
+                    int blue = raw[imageArea * 2 + pos];
+                    pixels[index] = (red << 16) | (green << 8) | blue;
+                }
+            }
+            image.setRGB(0, 0, width, height, pixels, 0, width);
+            return new BufferedImageWrapper(image);
         }
         int height = (int) shape.get(0);
         int width = (int) shape.get(1);

--- a/api/src/main/java/ai/djl/modality/cv/BufferedImageFactory.java
+++ b/api/src/main/java/ai/djl/modality/cv/BufferedImageFactory.java
@@ -90,20 +90,19 @@ public class BufferedImageFactory extends ImageFactory {
         } else if (shape.get(0) == 1 || shape.get(2) == 1) {
             throw new UnsupportedOperationException("Grayscale image is not supported");
         }
+        int[] raw = array.toType(DataType.UINT8, false).toUint8Array();
         if (NDImageUtils.isCHW(shape)) {
             int height = (int) shape.get(1);
             int width = (int) shape.get(2);
             BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
-            int[] raw = array.toType(DataType.UINT8, false).toUint8Array();
             int[] pixels = new int[width * height];
             int imageArea = height * width;
             for (int h = 0; h < height; ++h) {
                 for (int w = 0; w < width; ++w) {
                     int index = h * width + w;
-                    int pos = index;
-                    int red = raw[pos];
-                    int green = raw[imageArea + pos];
-                    int blue = raw[imageArea * 2 + pos];
+                    int red = raw[index];
+                    int green = raw[imageArea + index];
+                    int blue = raw[imageArea * 2 + index];
                     pixels[index] = (red << 16) | (green << 8) | blue;
                 }
             }
@@ -113,7 +112,6 @@ public class BufferedImageFactory extends ImageFactory {
         int height = (int) shape.get(0);
         int width = (int) shape.get(1);
         BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
-        int[] raw = array.toType(DataType.UINT8, false).toUint8Array();
         int[] pixels = new int[width * height];
         for (int h = 0; h < height; ++h) {
             for (int w = 0; w < width; ++w) {

--- a/integration/src/main/java/ai/djl/integration/tests/modality/cv/BufferedImageFactoryTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/modality/cv/BufferedImageFactoryTest.java
@@ -47,6 +47,12 @@ public class BufferedImageFactoryTest {
             NDArray converted =
                     image.toNDArray(manager).transpose(2, 0, 1).toType(DataType.FLOAT32, true);
             Assertions.assertAlmostEquals(array, converted);
+
+            array = manager.arange(0, 12, 1, DataType.UINT8).reshape(3, 2, 2);
+            array = array.transpose(1, 2, 0);
+            image = factory.fromNDArray(array);
+            converted = image.toNDArray(manager);
+            Assertions.assertAlmostEquals(array, converted);
         }
     }
 }

--- a/integration/src/main/java/ai/djl/integration/tests/modality/cv/BufferedImageFactoryTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/modality/cv/BufferedImageFactoryTest.java
@@ -48,10 +48,9 @@ public class BufferedImageFactoryTest {
                     image.toNDArray(manager).transpose(2, 0, 1).toType(DataType.FLOAT32, true);
             Assertions.assertAlmostEquals(array, converted);
 
-            array = manager.arange(0, 12, 1, DataType.UINT8).reshape(3, 2, 2);
             array = array.transpose(1, 2, 0);
             image = factory.fromNDArray(array);
-            converted = image.toNDArray(manager);
+            converted = image.toNDArray(manager).toType(DataType.FLOAT32, false);
             Assertions.assertAlmostEquals(array, converted);
         }
     }


### PR DESCRIPTION
## Description ##

Both image factories now handle HWC and CHW formats

- Transpose is not available for all engines so we must handle the different formats without transposing to a single format type
- Test on the apps and within DJL repo
