### PR TITLE
Add script to import huggingface model into djl model zoo

### DIFF
--- a/extensions/tokenizers/build.gradle
+++ b/extensions/tokenizers/build.gradle
@@ -85,6 +85,14 @@ task compileJNI {
     }
 }
 
+task formatPython {
+    doFirst {
+        exec {
+            commandLine "bash", "-c", "find . -name '*.py' -print0 | xargs -0 yapf --in-place"
+        }
+    }
+}
+
 clean.doFirst {
     delete System.getProperty("user.home") + "/.djl.ai/tokenizers"
     delete "rust/target"

--- a/extensions/tokenizers/src/main/python/arg_parser.py
+++ b/extensions/tokenizers/src/main/python/arg_parser.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+#
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+
+import argparse
+import os
+
+
+def converter_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-l",
+                        "--limit",
+                        type=int,
+                        default=1,
+                        help="Max amount of models to convert")
+    parser.add_argument("-o", "--output-dir", help="Model output directory")
+    parser.add_argument("-t",
+                        "--categories",
+                        nargs="*",
+                        help="Model categories to convert")
+    args = parser.parse_args()
+    if not args.categories:
+        args.categories = ["question-answering"]
+    if args.output_dir is None:
+        args.output_dir = "."
+
+    if not os.path.exists(args.output_dir):
+        raise ValueError(f"Invalid output directory: {args.output_dir}.")
+
+    return args

--- a/extensions/tokenizers/src/main/python/huggingface_converter.py
+++ b/extensions/tokenizers/src/main/python/huggingface_converter.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python
+#
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+
+import logging
+import os.path
+import sys
+from arg_parser import converter_args
+from metadata import HuggingfaceMetadata
+from zip_utils import zip_dir
+import shutil
+from shasum import sha1_sum
+
+import json
+from huggingface_hub import HfApi
+from huggingface_hub import hf_hub_download
+from transformers import pipeline
+import torch
+
+SUPPORTED_TASK = {
+    "fill-mask": {
+        "translator":
+        "ai.djl.huggingface.translator.FillMaskTranslatorFactory",
+        "application": "nlp/fill_mask",
+        "inputs": "Hello I'm a [MASK] model."
+    },
+    "question-answering": {
+        "translator":
+        "ai.djl.huggingface.translator.QuestionAnsweringTranslatorFactory",
+        "application": "nlp/question_answer",
+        "inputs": {
+            "question":
+            "When did BBC Japan start broadcasting?",
+            "context":
+            "BBC Japan was a general entertainment Channel. Which operated between December 2004 and April 2006."
+            " It ceased operations after its Japanese distributor folded. "
+        },
+        "output": "december 2004"
+    },
+    "text-classification": {
+        "translator":
+        "ai.djl.huggingface.translator.SentimentAnalysisTranslatorFactory",
+        "application": "nlp/text_classification",
+        "inputs": "I like DJL. DJL is the best DL framework!"
+    },
+    "token-classification": {
+        "translator":
+        "ai.djl.huggingface.translator.TokenClassificationTranslatorFactory",
+        "application": "nlp/token_classification",
+        "inputs": "I like DJL. DJL is the best DL framework!"
+    },
+}
+
+ARCHITECTURES_2_TASK = {
+    "ForQuestionAnswering": "question-answering",
+    "ForTokenClassification": "token-classification",
+    "ForSequenceClassification": "text-classification",
+    "ForMultipleChoice": "text-classification",
+    "ForMaskedLM": "fill-mask"
+}
+
+
+class HuggingfaceConverter:
+
+    def __init__(self, limit: int, output_dir: str):
+        self.limit = limit
+        self.output_dir = output_dir
+        self.processed_models = {}
+        self.device = torch.device(
+            "cuda:0" if torch.cuda.is_available() else "cpu")
+
+        output_path = os.path.join(output_dir, "processed_models.json")
+        if os.path.exists(output_path):
+            with open(output_path, "r") as f:
+                self.processed_models = json.load(f)
+
+    def convert_huggingface_models(self, category: str):
+        api = HfApi()
+        models = api.list_models(filter=f"{category},pytorch",
+                                 sort="downloads",
+                                 direction=-1,
+                                 limit=self.limit)
+
+        temp_dir = f"{self.output_dir}/tmp"
+
+        for model_info in models:
+            if self.processed_models.get(model_info.modelId):
+                logging.info(f"Skip converted mode: {model_info.modelId}.")
+                continue
+
+            result, reason, size = self.save_model(model_info.modelId)
+            self.save_progress(model_info.modelId, model_info.sha, result,
+                               reason, size)
+            shutil.rmtree(temp_dir)
+
+    def save_model(self, model_id: str):
+        config = hf_hub_download(repo_id=model_id, filename="config.json")
+        task, architecture = self.to_supported_task(config)
+        if not task:
+            return False, "Unsupported model architecture: {architecture}", -1
+
+        temp_dir = f"{self.output_dir}/tmp"
+        if not os.path.exists(temp_dir):
+            os.makedirs(temp_dir)
+
+        hf_pipeline = self.load_model(task, model_id)
+        # Save tokenizer.json
+        self.save_tokenizer(hf_pipeline, temp_dir)
+        # Save config.json just for reference
+        shutil.copyfile(config, os.path.join(temp_dir, "config.json"))
+        # Save jit traced .pt file
+        model_file = self.jit_trace_model(hf_pipeline, task, model_id,
+                                          temp_dir)
+        if not model_file:
+            return False, "Failed to trace model", -1
+
+        if not self.verify_jit_model(hf_pipeline, task, model_file):
+            return False, "Failed verify jit model", -1
+
+        size = self.save_model_zoo(task, model_id, temp_dir)
+
+        return True, None, size
+
+    @staticmethod
+    def save_tokenizer(hf_pipeline, temp_dir: str):
+        hf_pipeline.tokenizer.save_pretrained(temp_dir)
+        # only keep tokenizer.json file
+        for path in os.listdir(temp_dir):
+            if path != "tokenizer.json":
+                os.remove(os.path.join(temp_dir, path))
+
+    def jit_trace_model(self, hf_pipeline, task: str, model_id: str,
+                        temp_dir: str):
+        input_ids, attention_mask = self.encode_inputs(task,
+                                                       hf_pipeline.tokenizer)
+
+        # noinspection PyBroadException
+        try:
+            script_module = torch.jit.trace(hf_pipeline.model,
+                                            (input_ids, attention_mask),
+                                            strict=False)
+        except:
+            try:
+                script_module = torch.jit.trace(hf_pipeline.model,
+                                                input_ids,
+                                                strict=False)
+            except Exception as e:
+                logging.warning(f"Failed to trace model: {model_id}.")
+                logging.warning(e, exc_info=True)
+                return None
+
+        model_name = model_id.split("/")[-1]
+        model_file = os.path.join(temp_dir, f"{model_name}.pt")
+        script_module.save(model_file)
+        return model_file
+
+    def save_model_zoo(self, task: str, model_id: str, temp_dir: str):
+        artifact_ids = model_id.split("/")
+        model_name = artifact_ids[-1]
+
+        application = SUPPORTED_TASK[task]["application"]
+        translator = SUPPORTED_TASK[task]["translator"]
+        repo_dir = f"{self.output_dir}/model/{application}/ai/djl/huggingface/{model_id}"
+        model_dir = f"{repo_dir}/0.0.1"
+        if not os.path.exists(model_dir):
+            os.makedirs(model_dir)
+
+        # Save serving.properties
+        serving_file = os.path.join(temp_dir, "serving.properties")
+        with open(serving_file, 'w') as f:
+            f.write(
+                f"engine=PyTorch\noption.modelName={model_name}\noption.mapLocation=true\n"
+                f"translatorFactory={translator}")
+
+        # Save model as .zip file
+        zip_file = os.path.join(model_dir, f"{model_name}.zip")
+        zip_dir(temp_dir, zip_file)
+
+        # Save metadata.json
+
+        sha1 = sha1_sum(zip_file)
+        file_size = os.path.getsize(zip_file)
+        metadata = HuggingfaceMetadata(artifact_ids, application, translator,
+                                       sha1, file_size)
+        metadata_file = os.path.join(repo_dir, "metadata.json")
+        metadata.save_metadata(metadata_file)
+
+        return file_size
+
+    def verify_jit_model(self, hf_pipeline, task: str, model_file: str):
+        expected_output = SUPPORTED_TASK[task]["output"]
+        input_ids, attention_mask = self.encode_inputs(task,
+                                                       hf_pipeline.tokenizer)
+
+        if torch.cuda.is_available():
+            traced_model = torch.jit.load(model_file, map_location='cuda:0')
+            traced_model.to(self.device)
+            input_ids = input_ids.to(self.device)
+            attention_mask = attention_mask.to(self.device)
+        else:
+            traced_model = torch.jit.load(model_file)
+
+        traced_model.eval()
+
+        # test traced model
+        out = traced_model(input_ids, attention_mask)
+
+        if task == "question-answering":
+            answer_start = torch.argmax(out["start_logits"])
+            answer_end = torch.argmax(out["end_logits"]) + 1
+            tokenizer = hf_pipeline.tokenizer
+
+            out_ids = input_ids[0].tolist()[answer_start:answer_end]
+            tokens = tokenizer.convert_ids_to_tokens(out_ids)
+            prediction = tokenizer.convert_tokens_to_string(tokens)
+
+            if prediction.lower() != expected_output:
+                inputs = SUPPORTED_TASK[task]["inputs"]
+                pipeline_output = hf_pipeline(inputs)
+                if pipeline_output != prediction:
+                    return False, f"Unexpected inference result: {prediction}"
+                else:
+                    logging.warning(
+                        f"pipeline output differs from expected: {pipeline_output}"
+                    )
+        else:
+            if hasattr(out, "last_hidden_layer"):
+                return False, f"Unexpected inference result: {out}"
+
+        return True
+
+    @staticmethod
+    def load_model(task: str, model_id: str):
+        logging.info(f"Loading model: {model_id}.")
+        kwargs = {
+            "tokenizer": model_id,
+            "device": -1  # always use CPU to trace the model
+        }
+        hf_pipeline = pipeline(task=task,
+                               model=model_id,
+                               framework="pt",
+                               **kwargs)
+        return hf_pipeline
+
+    @staticmethod
+    def encode_inputs(task: str, tokenizer):
+        inputs = SUPPORTED_TASK[task]["inputs"]
+        if type(inputs) is dict:
+            text = inputs["question"]
+            text_pair = inputs["context"]
+        else:
+            text = inputs
+            text_pair = None
+
+        encoding = tokenizer.encode_plus(text,
+                                         text_pair=text_pair,
+                                         return_tensors='pt')
+        return encoding["input_ids"], encoding["attention_mask"]
+
+    @staticmethod
+    def to_supported_task(config: str):
+        with open(config) as f:
+            config = json.load(f)
+            architecture = config.get("architectures", [None])[0]
+            for arch in ARCHITECTURES_2_TASK:
+                if architecture.endswith(arch):
+                    return ARCHITECTURES_2_TASK[arch], architecture
+
+            return None, architecture
+
+    def save_progress(self, model_id: str, sha: str, result: bool, reason: str,
+                      size: int):
+        status = {
+            "result": "success" if result else "failed",
+            "sha1": sha,
+            "size": size
+        }
+        if reason:
+            status["reason"] = reason
+        self.processed_models[model_id] = status
+
+        dict_file = os.path.join(self.output_dir, "processed_models.json")
+        with open(dict_file, 'w') as f:
+            json.dump(self.processed_models,
+                      f,
+                      sort_keys=True,
+                      indent=2,
+                      ensure_ascii=False)
+
+
+def main():
+    logging.basicConfig(stream=sys.stdout,
+                        format="%(message)s",
+                        level=logging.INFO)
+    args = converter_args()
+    converter = HuggingfaceConverter(args.limit, args.output_dir)
+    for category in args.categories:
+        converter.convert_huggingface_models(category)
+
+    logging.info("finished.")
+
+
+if __name__ == "__main__":
+    main()

--- a/extensions/tokenizers/src/main/python/metadata.py
+++ b/extensions/tokenizers/src/main/python/metadata.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+#
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+import json
+
+
+class HuggingfaceMetadata:
+
+    def __init__(self,
+                 artifact_ids: list[str],
+                 application: str,
+                 translator: str,
+                 sha1: str,
+                 file_size: int,
+                 tags: dict = None):
+        self.model_name = artifact_ids[-1]
+        artifact_ids[0:-1].insert(0, "ai.djl.huggingface")
+        self.group_id = ".".join(artifact_ids)
+        self.application = application
+        self.translator = translator
+        self.sha1 = sha1
+        self.file_size = file_size
+        self.tags = tags
+
+    def save_metadata(self, metadata_file: str):
+        metadata = {
+            "metadataVersion": "0.2",
+            "resourceType": "model",
+            "application": self.application,
+            "groupId": self.group_id,
+            "artifactId": self.model_name,
+            "name": self.model_name,
+            "description":
+            f"Huggingface transformers model: {self.model_name}",
+            "website": "http://www.djl.ai/extensions/tokenizers",
+            "licenses": {
+                "license": {
+                    "name": "The Apache License, Version 2.0",
+                    "url": "https://www.apache.org/licenses/LICENSE-2.0"
+                }
+            },
+            "artifacts": {
+                "version": "0.0.1",
+                "snapshot": False,
+                "name": self.model_name,
+                "properties": self.tags,
+                "arguments": {
+                    "translatorFactory": self.translator
+                },
+                "options": {
+                    "mapLocation": True
+                },
+                "files": {
+                    "model": {
+                        "uri": f"0.0.1/{self.model_name}.zip",
+                        "name": "",
+                        "sha1Hash": self.sha1,
+                        "size": self.file_size
+                    }
+                }
+            }
+        }
+        with open(metadata_file, 'w') as f:
+            json.dump(metadata,
+                      f,
+                      sort_keys=False,
+                      indent=2,
+                      ensure_ascii=False)

--- a/extensions/tokenizers/src/main/python/requirements.txt
+++ b/extensions/tokenizers/src/main/python/requirements.txt
@@ -1,0 +1,4 @@
+huggingface_hub
+transformers
+torch
+protobuf==3.20.0

--- a/extensions/tokenizers/src/main/python/shasum.py
+++ b/extensions/tokenizers/src/main/python/shasum.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+#
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+import hashlib
+
+
+def sha1_sum(file_name: str):
+    with open(file_name, 'rb') as f:
+        content = f.read()
+        return hashlib.sha1(content).hexdigest()

--- a/extensions/tokenizers/src/main/python/zip_utils.py
+++ b/extensions/tokenizers/src/main/python/zip_utils.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+#
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+import os
+import zipfile
+
+
+def add_to_zip(path: str, handle: zipfile.ZipFile):
+    for root, dirs, files in os.walk(path):
+        for file in files:
+            file_path = os.path.join(root, file)
+            entry_name = os.path.relpath(file_path, path)
+            handle.write(file_path, entry_name)
+
+
+def zip_dir(src_dir: str, output_file: str):
+    with zipfile.ZipFile(output_file, 'w', zipfile.ZIP_DEFLATED) as f:
+        add_to_zip(src_dir, f)


### PR DESCRIPTION
This feature allows users to import huggingface models into DJL model zoo.

- It will download huggingface models and use pytorch jit to trace the model. It also saves the model in DJL model zoo format.
- The script can allows you to limit the amount of models that are loaded so that you don't have to import all of the models at once. Previously imported models will be ignored. 
- The traced model will be validated using sample input and output. If the model validation fails, the model will not be imported and will be marked as import failure.
- If the machine has GPU, the validation will use GPU to run the inference and make sure the model works on GPU.

This program is only tested for the question answering model. The top 20 question answering on huggingface have been tested.
The exported model zoo. model has been manual tested with DJL huggingface QuestionAnsweringTranslator.
This script may not work with non-english models.
To run this program you must install the dependencies described in the requirement.txt file and make sure transformers and huggingface_hub are on the latest version.
Some models have dependencies on protobuf. The protobuf version has to be on 3.20.0.