### PR TITLE
[api] Fixes NDArrayAdapter toDevice() and toType() behavior

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
@@ -133,19 +133,26 @@ public abstract class NDArrayAdapter implements NDArray {
     /** {@inheritDoc} */
     @Override
     public NDArray toDevice(Device device, boolean copy) {
-        if (device.equals(getDevice()) && !copy) {
+        if (device.equals(getDevice())) {
+            if (copy) {
+                return duplicate();
+            }
             return this;
         }
-        return duplicate();
+        throw new UnsupportedOperationException(UNSUPPORTED_MSG);
     }
 
     /** {@inheritDoc} */
     @Override
     public NDArray toType(DataType dataType, boolean copy) {
-        if (dataType.equals(getDataType()) && !copy) {
+        if (dataType.equals(getDataType())) {
+            if (copy) {
+                return duplicate();
+            }
             return this;
         }
-        return duplicate();
+        // TODO: each engine should override this method
+        throw new UnsupportedOperationException(UNSUPPORTED_MSG);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Change-Id: Iaf90c609a832f3f7bc2a863bdb44cfc7df34dbae

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
