### PR TITLE
[api] Support queryString for JarRepository

### DIFF
--- a/api/src/main/java/ai/djl/repository/JarRepository.java
+++ b/api/src/main/java/ai/djl/repository/JarRepository.java
@@ -40,12 +40,14 @@ public class JarRepository extends AbstractRepository {
 
     private String artifactId;
     private String modelName;
+    private String queryString;
 
     private Metadata metadata;
     private boolean resolved;
 
-    JarRepository(String name, URI uri, String fileName) {
+    JarRepository(String name, URI uri, String fileName, String queryString) {
         super(name, uri);
+        this.queryString = queryString;
         modelName = arguments.get("model_name");
         artifactId = arguments.get("artifact_id");
         if (artifactId == null) {
@@ -120,7 +122,7 @@ public class JarRepository extends AbstractRepository {
         metadata = new Metadata.MatchAllMetadata();
         metadata.setArtifactId(artifactId);
         metadata.setArtifacts(Collections.singletonList(artifact));
-        String hash = md5hash(uri.toString());
+        String hash = md5hash(queryString == null ? uri.toString() : uri.toString() + queryString);
         MRL mrl = model(Application.UNDEFINED, DefaultModelZoo.GROUP_ID, hash);
         metadata.setRepositoryUri(mrl.toURI());
 

--- a/api/src/main/java/ai/djl/repository/RepositoryFactoryImpl.java
+++ b/api/src/main/java/ai/djl/repository/RepositoryFactoryImpl.java
@@ -137,6 +137,7 @@ class RepositoryFactoryImpl implements RepositoryFactory {
         @Override
         public Repository newInstance(String name, URI uri) {
             String p = uri.getPath();
+            String queryString = uri.getRawQuery();
             if (p.startsWith("/")) {
                 p = p.substring(1);
             }
@@ -157,7 +158,7 @@ class RepositoryFactoryImpl implements RepositoryFactory {
             }
 
             fileName = FilenameUtils.getNamePart(fileName);
-            return new JarRepository(name, uri, fileName);
+            return new JarRepository(name, uri, fileName, queryString);
         }
 
         /** {@inheritDoc} */

--- a/api/src/test/java/ai/djl/repository/JarRepositoryTest.java
+++ b/api/src/test/java/ai/djl/repository/JarRepositoryTest.java
@@ -45,7 +45,7 @@ public class JarRepositoryTest {
         URL[] url = {jarFile.toUri().toURL()};
         try {
             Thread.currentThread().setContextClassLoader(new URLClassLoader(url));
-            Repository repo = Repository.newInstance("test", "jar:///test.zip");
+            Repository repo = Repository.newInstance("test", "jar:///test.zip?hash=1");
             Assert.assertEquals("test", repo.getName());
             Assert.assertTrue(repo.isRemote());
 


### PR DESCRIPTION
Change-Id: I2c5e92bbb1da52db2298d90f1c36cbef33873151

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
