### PR TITLE
Allow overriding special token flags in encode and decode methods

### DIFF
--- a/extensions/tokenizers/rust/src/lib.rs
+++ b/extensions/tokenizers/rust/src/lib.rs
@@ -383,7 +383,7 @@ pub extern "system" fn Java_ai_djl_huggingface_tokenizers_jni_TokenizersLibrary_
     _: JObject,
     handle: jlong,
     ids: jlongArray,
-    add_special_tokens: jboolean,
+    skip_special_tokens: jboolean,
 ) -> jstring {
     let tokenizer = cast_handle::<Tokenizer>(handle);
     let long_ids = env.get_long_array_elements(ids, ReleaseMode::NoCopyBack).unwrap();
@@ -396,7 +396,7 @@ pub extern "system" fn Java_ai_djl_huggingface_tokenizers_jni_TokenizersLibrary_
             decode_ids.push(*val as u32);
         }
     }
-    let decoding: String = tokenizer.decode(decode_ids, add_special_tokens == JNI_TRUE).unwrap();
+    let decoding: String = tokenizer.decode(decode_ids, skip_special_tokens == JNI_TRUE).unwrap();
     let ret = env
         .new_string(decoding)
         .expect("Couldn't create java string!")

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizer.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizer.java
@@ -140,10 +140,37 @@ public final class HuggingFaceTokenizer extends NativeResource<Long> implements 
      * Returns the {@code Encoding} of the input sentence.
      *
      * @param text the input sentence
+     * @param addSpecialTokens whether to encode the sequence with special tokens relative to their
+     *     model
+     * @return the {@code Encoding} of the input sentence
+     */
+    public Encoding encode(String text, boolean addSpecialTokens) {
+        long encoding = TokenizersLibrary.LIB.encode(getHandle(), text, addSpecialTokens);
+        return toEncoding(encoding);
+    }
+
+    /**
+     * Returns the {@code Encoding} of the input sentence.
+     *
+     * @param text the input sentence
      * @return the {@code Encoding} of the input sentence
      */
     public Encoding encode(String text) {
-        long encoding = TokenizersLibrary.LIB.encode(getHandle(), text, addSpecialTokens);
+        return encode(text, addSpecialTokens);
+    }
+
+    /**
+     * Returns the {@code Encoding} of the input sentence.
+     *
+     * @param text the input sentence
+     * @param textPair the second input sentence
+     * @param addSpecialTokens whether to encode the sequence with special tokens relative to their
+     *     model
+     * @return the {@code Encoding} of the input sentence
+     */
+    public Encoding encode(String text, String textPair, boolean addSpecialTokens) {
+        long encoding =
+                TokenizersLibrary.LIB.encodeDual(getHandle(), text, textPair, addSpecialTokens);
         return toEncoding(encoding);
     }
 
@@ -155,9 +182,20 @@ public final class HuggingFaceTokenizer extends NativeResource<Long> implements 
      * @return the {@code Encoding} of the input sentence
      */
     public Encoding encode(String text, String textPair) {
-        long encoding =
-                TokenizersLibrary.LIB.encodeDual(getHandle(), text, textPair, addSpecialTokens);
-        return toEncoding(encoding);
+        return encode(text, textPair, addSpecialTokens);
+    }
+
+    /**
+     * Returns the {@code Encoding} of the input sentences.
+     *
+     * @param inputs the input sentences
+     * @param addSpecialTokens whether to encode the sequence with special tokens relative to their
+     *     model
+     * @return the {@code Encoding} of the input sentences
+     */
+    public Encoding encode(List<String> inputs, boolean addSpecialTokens) {
+        String[] array = inputs.toArray(new String[0]);
+        return encode(array, addSpecialTokens);
     }
 
     /**
@@ -167,8 +205,20 @@ public final class HuggingFaceTokenizer extends NativeResource<Long> implements 
      * @return the {@code Encoding} of the input sentences
      */
     public Encoding encode(List<String> inputs) {
-        String[] array = inputs.toArray(new String[0]);
-        return encode(array);
+        return encode(inputs, addSpecialTokens);
+    }
+
+    /**
+     * Returns the {@code Encoding} of the input sentences.
+     *
+     * @param inputs the input sentences
+     * @param addSpecialTokens whether to encode the sequence with special tokens relative to their
+     *     model
+     * @return the {@code Encoding} of the input sentences
+     */
+    public Encoding encode(String[] inputs, boolean addSpecialTokens) {
+        long encoding = TokenizersLibrary.LIB.encodeList(getHandle(), inputs, addSpecialTokens);
+        return toEncoding(encoding);
     }
 
     /**
@@ -178,8 +228,20 @@ public final class HuggingFaceTokenizer extends NativeResource<Long> implements 
      * @return the {@code Encoding} of the input sentences
      */
     public Encoding encode(String[] inputs) {
-        long encoding = TokenizersLibrary.LIB.encodeList(getHandle(), inputs, addSpecialTokens);
-        return toEncoding(encoding);
+        return encode(inputs, addSpecialTokens);
+    }
+
+    /**
+     * Returns the {@code Encoding} of the input sentence in batch.
+     *
+     * @param inputs the batch of input sentence
+     * @param addSpecialTokens whether to encode the sequence with special tokens relative to their
+     *     model
+     * @return the {@code Encoding} of the input sentence in batch
+     */
+    public Encoding[] batchEncode(List<String> inputs, boolean addSpecialTokens) {
+        String[] array = inputs.toArray(new String[0]);
+        return batchEncode(array, addSpecialTokens);
     }
 
     /**
@@ -189,17 +251,18 @@ public final class HuggingFaceTokenizer extends NativeResource<Long> implements 
      * @return the {@code Encoding} of the input sentence in batch
      */
     public Encoding[] batchEncode(List<String> inputs) {
-        String[] array = inputs.toArray(new String[0]);
-        return batchEncode(array);
+        return batchEncode(inputs, addSpecialTokens);
     }
 
     /**
      * Returns the {@code Encoding} of the input sentence in batch.
      *
      * @param inputs the batch of input sentence
+     * @param addSpecialTokens whether to encode the sequence with special tokens relative to their
+     *     model
      * @return the {@code Encoding} of the input sentence in batch
      */
-    public Encoding[] batchEncode(String[] inputs) {
+    public Encoding[] batchEncode(String[] inputs, boolean addSpecialTokens) {
         long[] encodings = TokenizersLibrary.LIB.batchEncode(getHandle(), inputs, addSpecialTokens);
         Encoding[] ret = new Encoding[encodings.length];
         for (int i = 0; i < encodings.length; ++i) {
@@ -209,13 +272,34 @@ public final class HuggingFaceTokenizer extends NativeResource<Long> implements 
     }
 
     /**
+     * Returns the {@code Encoding} of the input sentence in batch.
+     *
+     * @param inputs the batch of input sentence
+     * @return the {@code Encoding} of the input sentence in batch
+     */
+    public Encoding[] batchEncode(String[] inputs) {
+        return batchEncode(inputs, addSpecialTokens);
+    }
+
+    /**
+     * Returns the decoded String from the input ids.
+     *
+     * @param ids the input ids
+     * @param skipSpecialTokens whether to remove special tokens in the decoding
+     * @return the decoded String from the input ids
+     */
+    public String decode(long[] ids, boolean skipSpecialTokens) {
+        return TokenizersLibrary.LIB.decode(getHandle(), ids, skipSpecialTokens);
+    }
+
+    /**
      * Returns the decoded String from the input ids.
      *
      * @param ids the input ids
      * @return the decoded String from the input ids
      */
     public String decode(long[] ids) {
-        return TokenizersLibrary.LIB.decode(getHandle(), ids, addSpecialTokens);
+        return decode(ids, !addSpecialTokens);
     }
 
     private Encoding toEncoding(long encoding) {

--- a/extensions/tokenizers/src/test/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizerTest.java
+++ b/extensions/tokenizers/src/test/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizerTest.java
@@ -122,13 +122,35 @@ public class HuggingFaceTokenizerTest {
                             101, 3570, 1110, 170, 21162, 1285, 119, 2750, 4250, 146, 112, 173, 1474,
                             102
                         });
-        List<String> expectedDecodings =
+        List<String> expectedDecodingsNoSpecialTokens =
                 Arrays.asList(
                         "Hello, y ' all! How are you?",
                         "Today is a sunny day. Good weather I ' d say");
+        List<String> expectedDecodingsWithSpecialTokens =
+                Arrays.asList(
+                        "[CLS] Hello, y ' all! How are you [UNK]? [SEP]",
+                        "[CLS] Today is a sunny day. Good weather I ' d say [SEP]");
         try (HuggingFaceTokenizer tokenizer = HuggingFaceTokenizer.newInstance("bert-base-cased")) {
             for (int i = 0; i < testIds.size(); ++i) {
-                Assert.assertEquals(tokenizer.decode(testIds.get(i)), expectedDecodings.get(i));
+                Assert.assertEquals(
+                        tokenizer.decode(testIds.get(i)),
+                        expectedDecodingsWithSpecialTokens.get(i));
+                Assert.assertEquals(
+                        tokenizer.decode(testIds.get(i), true),
+                        expectedDecodingsNoSpecialTokens.get(i));
+            }
+        }
+
+        Map<String, String> options = new ConcurrentHashMap<>();
+        options.put("addSpecialTokens", "false");
+        try (HuggingFaceTokenizer tokenizer =
+                HuggingFaceTokenizer.newInstance("bert-base-cased", options)) {
+            for (int i = 0; i < testIds.size(); ++i) {
+                Assert.assertEquals(
+                        tokenizer.decode(testIds.get(i)), expectedDecodingsNoSpecialTokens.get(i));
+                Assert.assertEquals(
+                        tokenizer.decode(testIds.get(i), false),
+                        expectedDecodingsWithSpecialTokens.get(i));
             }
         }
     }


### PR DESCRIPTION
## Description ##

The tokenizer python and rust apis allow users to pass boolean flags to encode and decode methods to override special token behavior set during initialization. 

This change adds apis for the user to override the behavior in java similar to python and rust.

I also updated the naming of this flag for the decoding method to match the tokenizers naming.
