### PR TITLE
Updates gradle version to 7.5 and fix format

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,9 @@
 org.gradle.daemon=true
-org.gradle.jvmargs=-Xmx1024M
+org.gradle.jvmargs=-Xmx1024M --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
 systemProp.org.gradle.internal.http.socketTimeout=120000
 systemProp.org.gradle.internal.http.connectionTimeout=60000

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip


### PR DESCRIPTION
Fixes same problem as https://github.com/deepjavalibrary/djl-serving/issues/184
using workaround described in https://github.com/diffplug/spotless/issues/834
and found in
https://github.com/diffplug/spotless/tree/main/plugin-gradle#google-java-format.
