### PR TITLE
[ONNX Runtime] Fix OrtNDArray double close issue

### DIFF
--- a/engines/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtNDArray.java
+++ b/engines/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtNDArray.java
@@ -76,7 +76,12 @@ public class OrtNDArray extends NDArrayAdapter {
     /** {@inheritDoc} */
     @Override
     public void intern(NDArray replaced) {
-        tensor.getAndSet(((OrtNDArray) replaced).getTensor()).close();
+        OrtNDArray arr = (OrtNDArray) replaced;
+        OnnxTensor oldHandle = tensor.getAndSet(arr.tensor.getAndSet(null));
+        if (oldHandle != null) {
+            oldHandle.close();
+        }
+        replaced.close();
     }
 
     /** {@inheritDoc} */
@@ -113,10 +118,10 @@ public class OrtNDArray extends NDArrayAdapter {
     /** {@inheritDoc} */
     @Override
     public void close() {
-        super.close();
         OnnxTensor ortTensor = tensor.getAndSet(null);
         if (ortTensor != null) {
             ortTensor.close();
         }
+        super.close();
     }
 }


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Fix crash caused by double close OrtNDArray

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
