### PR TITLE
Bulk Batch creation

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/NDArray.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArray.java
@@ -587,7 +587,19 @@ public interface NDArray extends NDResource, BytesSupplier {
      * @param index picks the elements of an NDArray and output to the same entry as in index
      * @return the partial {@code NDArray} of the same shape as index
      */
-    NDArray take(NDArray index);
+    default NDArray take(NDArray index) {
+        return take(this.getManager(), index);
+    }
+
+    /**
+     * Returns a partial {@code NDArray} pointed by index according to linear indexing, and the of
+     * output is of the same shape as index.
+     *
+     * @param manager the manager used to create the arrays
+     * @param index picks the elements of an NDArray and output to the same entry as in index
+     * @return the partial {@code NDArray} of the same shape as index
+     */
+    NDArray take(NDManager manager, NDArray index);
 
     /**
      * Set the entries of {@code NDArray} pointed by index according to linear indexing, to be the

--- a/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
@@ -193,7 +193,7 @@ public abstract class NDArrayAdapter implements NDArray {
 
     /** {@inheritDoc} */
     @Override
-    public NDArray take(NDArray index) {
+    public NDArray take(NDManager manager, NDArray index) {
         throw new UnsupportedOperationException(UNSUPPORTED_MSG);
     }
 

--- a/api/src/main/java/ai/djl/ndarray/index/NDArrayIndexer.java
+++ b/api/src/main/java/ai/djl/ndarray/index/NDArrayIndexer.java
@@ -18,6 +18,7 @@ import ai.djl.ndarray.index.dim.NDIndexBooleans;
 import ai.djl.ndarray.index.dim.NDIndexElement;
 import ai.djl.ndarray.index.full.NDIndexFullPick;
 import ai.djl.ndarray.index.full.NDIndexFullSlice;
+import ai.djl.ndarray.index.full.NDIndexFullTake;
 
 import java.util.List;
 import java.util.Optional;
@@ -33,6 +34,15 @@ public abstract class NDArrayIndexer {
      * @return the subArray
      */
     public abstract NDArray get(NDArray array, NDIndexFullPick fullPick);
+
+    /**
+     * Returns a subarray by taken the elements from one axis.
+     *
+     * @param array the array to get from
+     * @param fullTake the elements to pick
+     * @return the subArray
+     */
+    public abstract NDArray get(NDArray array, NDIndexFullTake fullTake);
 
     /**
      * Returns a subarray at the slice.
@@ -63,6 +73,11 @@ public abstract class NDArrayIndexer {
                         "get() currently doesn't support more that one boolean NDArray");
             }
             return array.booleanMask(((NDIndexBooleans) indices.get(0)).getIndex());
+        }
+
+        Optional<NDIndexFullTake> fullTake = NDIndexFullTake.fromIndex(index, array.getShape());
+        if (fullTake.isPresent()) {
+            return get(array, fullTake.get());
         }
 
         Optional<NDIndexFullPick> fullPick = NDIndexFullPick.fromIndex(index, array.getShape());

--- a/api/src/main/java/ai/djl/ndarray/index/NDArrayIndexer.java
+++ b/api/src/main/java/ai/djl/ndarray/index/NDArrayIndexer.java
@@ -20,6 +20,9 @@ import ai.djl.ndarray.index.full.NDIndexFullPick;
 import ai.djl.ndarray.index.full.NDIndexFullSlice;
 import ai.djl.ndarray.index.full.NDIndexFullTake;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -77,6 +80,11 @@ public abstract class NDArrayIndexer {
 
         Optional<NDIndexFullTake> fullTake = NDIndexFullTake.fromIndex(index, array.getShape());
         if (fullTake.isPresent()) {
+            Logger logger = LoggerFactory.getLogger(NDArrayIndexer.class);
+            logger.warn(
+                    "The definition of the getter by array NDIndex: get(NDIndex array) has changed"
+                        + " from pick to take.If you still want to use array index as pick, then do"
+                        + " it explicitly by get(new NDIndex().addPickDim(array));");
             return get(array, fullTake.get());
         }
 

--- a/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullPick.java
+++ b/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullPick.java
@@ -17,7 +17,6 @@ import ai.djl.ndarray.index.NDIndex;
 import ai.djl.ndarray.index.dim.NDIndexAll;
 import ai.djl.ndarray.index.dim.NDIndexElement;
 import ai.djl.ndarray.index.dim.NDIndexPick;
-import ai.djl.ndarray.index.dim.NDIndexTake;
 import ai.djl.ndarray.types.Shape;
 
 import java.util.Optional;

--- a/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullPick.java
+++ b/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullPick.java
@@ -27,7 +27,6 @@ public final class NDIndexFullPick {
 
     private NDArray indices;
     private int axis;
-    private boolean indexTake;
 
     /**
      * Constructs a new {@link NDIndexFullPick}.
@@ -73,7 +72,6 @@ public final class NDIndexFullPick {
                             "Only rank-1 indexing array is supported for pick");
                 }
                 fullPick = new NDIndexFullPick(indexElem, axis);
-                fullPick.setIndexTake(true);
             } else {
                 // Invalid dim for fullPick
                 return Optional.empty();
@@ -98,23 +96,5 @@ public final class NDIndexFullPick {
      */
     public int getAxis() {
         return axis;
-    }
-
-    /**
-     * Returns if a "take" rather than a "pick" operation is intended.
-     *
-     * @return <code>true</code> for "take"
-     */
-    public boolean isIndexTake() {
-        return indexTake;
-    }
-
-    /**
-     * Sets if a "take" rather than a "pick" operation is intended.
-     *
-     * @param indexTake <code>true</code> for "take"
-     */
-    public void setIndexTake(boolean indexTake) {
-        this.indexTake = indexTake;
     }
 }

--- a/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullPick.java
+++ b/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullPick.java
@@ -27,6 +27,7 @@ public final class NDIndexFullPick {
 
     private NDArray indices;
     private int axis;
+    private boolean indexTake;
 
     /**
      * Constructs a new {@link NDIndexFullPick}.
@@ -72,6 +73,7 @@ public final class NDIndexFullPick {
                             "Only rank-1 indexing array is supported for pick");
                 }
                 fullPick = new NDIndexFullPick(indexElem, axis);
+                fullPick.setIndexTake(true);
             } else {
                 // Invalid dim for fullPick
                 return Optional.empty();
@@ -96,5 +98,23 @@ public final class NDIndexFullPick {
      */
     public int getAxis() {
         return axis;
+    }
+
+    /**
+     * Returns if a "take" rather than a "pick" operation is intended.
+     *
+     * @return <code>true</code> for "take"
+     */
+    public boolean isIndexTake() {
+        return indexTake;
+    }
+
+    /**
+     * Sets if a "take" rather than a "pick" operation is intended.
+     *
+     * @param indexTake <code>true</code> for "take"
+     */
+    public void setIndexTake(boolean indexTake) {
+        this.indexTake = indexTake;
     }
 }

--- a/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullPick.java
+++ b/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullPick.java
@@ -60,18 +60,6 @@ public final class NDIndexFullPick {
                 }
                 NDArray indexElem = ((NDIndexPick) el).getIndex();
                 fullPick = new NDIndexFullPick(indexElem, axis);
-            } else if (el instanceof NDIndexTake) {
-                if (fullPick != null) {
-                    // Don't support multiple picks
-                    throw new UnsupportedOperationException(
-                            "Only one pick per get is currently supported");
-                }
-                NDArray indexElem = ((NDIndexTake) el).getIndex();
-                if (!indexElem.getShape().isRankOne()) {
-                    throw new UnsupportedOperationException(
-                            "Only rank-1 indexing array is supported for pick");
-                }
-                fullPick = new NDIndexFullPick(indexElem, axis);
             } else {
                 // Invalid dim for fullPick
                 return Optional.empty();

--- a/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullTake.java
+++ b/api/src/main/java/ai/djl/ndarray/index/full/NDIndexFullTake.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.ndarray.index.full;
+
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.index.NDIndex;
+import ai.djl.ndarray.index.dim.NDIndexAll;
+import ai.djl.ndarray.index.dim.NDIndexElement;
+import ai.djl.ndarray.index.dim.NDIndexTake;
+import ai.djl.ndarray.types.Shape;
+
+import java.util.Optional;
+
+/** A simplified representation of a take-based {@link NDIndex}. */
+public final class NDIndexFullTake {
+
+    private NDArray indices;
+    private int axis;
+
+    /**
+     * Constructs a new {@link NDIndexFullTake}.
+     *
+     * @param indices the indices to take
+     * @param axis the axis to take at
+     */
+    private NDIndexFullTake(NDArray indices, int axis) {
+        this.indices = indices;
+        this.axis = axis;
+    }
+
+    /**
+     * Returns (if possible) the {@link NDIndexFullTake} representation of an {@link NDIndex}.
+     *
+     * @param index the index to represent
+     * @param target the shape of the array to index
+     * @return the full take representation or nothing if it can't represent the index
+     */
+    public static Optional<NDIndexFullTake> fromIndex(NDIndex index, Shape target) {
+        int axis = 0;
+        NDIndexFullTake fullTake = null;
+        for (NDIndexElement el : index.getIndices()) {
+            if (el instanceof NDIndexAll) {
+                axis++;
+            } else if (el instanceof NDIndexTake) {
+                if (fullTake != null) {
+                    // Don't support multiple takes
+                    throw new UnsupportedOperationException(
+                            "Only one take per get is currently supported");
+                }
+                NDArray indexElem = ((NDIndexTake) el).getIndex();
+                if (!indexElem.getShape().isRankOne()) {
+                    throw new UnsupportedOperationException(
+                            "Only rank-1 indexing array is supported for take");
+                }
+                fullTake = new NDIndexFullTake(indexElem, axis);
+            } else {
+                // Invalid dim for fullTake
+                return Optional.empty();
+            }
+        }
+        return Optional.ofNullable(fullTake);
+    }
+
+    /**
+     * Returns the indices to take.
+     *
+     * @return the indices to take
+     */
+    public NDArray getIndices() {
+        return indices;
+    }
+
+    /**
+     * Returns the axis to take.
+     *
+     * @return the axis to take
+     */
+    public int getAxis() {
+        return axis;
+    }
+}

--- a/api/src/main/java/ai/djl/training/dataset/ArrayDataset.java
+++ b/api/src/main/java/ai/djl/training/dataset/ArrayDataset.java
@@ -111,15 +111,14 @@ public class ArrayDataset extends RandomAccessDataset {
      */
     public Record getByIndices(NDManager manager, long... indices) {
         try (NDArray ndIndices = manager.create(indices)) {
-            NDIndex index = new NDIndex("{}", ndIndices);
             NDList datum = new NDList();
             NDList label = new NDList();
             for (NDArray array : data) {
-                datum.add(array.get(manager, index));
+                datum.add(array.take(manager, ndIndices));
             }
             if (labels != null) {
                 for (NDArray array : labels) {
-                    label.add(array.get(manager, index));
+                    label.add(array.take(manager, ndIndices));
                 }
             }
             return new Record(datum, label);

--- a/api/src/main/java/ai/djl/training/dataset/ArrayDataset.java
+++ b/api/src/main/java/ai/djl/training/dataset/ArrayDataset.java
@@ -111,14 +111,15 @@ public class ArrayDataset extends RandomAccessDataset {
      */
     public Record getByIndices(NDManager manager, long... indices) {
         try (NDArray ndIndices = manager.create(indices)) {
+            NDIndex index = new NDIndex("{}", ndIndices);
             NDList datum = new NDList();
             NDList label = new NDList();
             for (NDArray array : data) {
-                datum.add(array.take(manager, ndIndices));
+                datum.add(array.get(manager, index));
             }
             if (labels != null) {
                 for (NDArray array : labels) {
-                    label.add(array.take(manager, ndIndices));
+                    label.add(array.get(manager, index));
                 }
             }
             return new Record(datum, label);

--- a/api/src/main/java/ai/djl/training/dataset/BulkDataIterable.java
+++ b/api/src/main/java/ai/djl/training/dataset/BulkDataIterable.java
@@ -116,9 +116,13 @@ public class BulkDataIterable extends DataIterable {
      * Checks whether the given indices actually represents a range.
      *
      * @param indices the indices to examine
-     * @return whether the given indices are sorted in ascending order with no gap
+     * @return whether the given indices are sorted in ascending order with no gap and has at least
+     *     one element
      */
     public static boolean isRange(List<Long> indices) {
+        if (indices.isEmpty()) {
+            return false;
+        }
         long from = indices.get(0);
         for (long index : indices) {
             if (index != from++) {

--- a/api/src/main/java/ai/djl/training/dataset/BulkDataIterable.java
+++ b/api/src/main/java/ai/djl/training/dataset/BulkDataIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
  * with the License. A copy of the License is located at

--- a/api/src/main/java/ai/djl/training/dataset/BulkDataIterable.java
+++ b/api/src/main/java/ai/djl/training/dataset/BulkDataIterable.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.training.dataset;
+
+import ai.djl.Device;
+import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.NDManager;
+import ai.djl.translate.Batchifier;
+import ai.djl.translate.Pipeline;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * BulkDataIterable specializes DataIterable in using {@link ArrayDataset#getByRange(NDManager,
+ * long, long)} or {@link ArrayDataset#getByIndices(NDManager, long...)} to create {@link Batch}
+ * instances more efficiently.
+ */
+public class BulkDataIterable extends DataIterable {
+
+    /**
+     * Creates a new instance of {@code BulkDataIterable} with the given parameters.
+     *
+     * @param dataset the dataset to iterate on
+     * @param manager the manager to create the arrays
+     * @param sampler a sampler to sample data with
+     * @param dataBatchifier a batchifier for data
+     * @param labelBatchifier a batchifier for labels
+     * @param pipeline the pipeline of transforms to apply on the data
+     * @param targetPipeline the pipeline of transforms to apply on the labels
+     * @param executor an {@link ExecutorService}
+     * @param preFetchNumber the number of samples to prefetch
+     * @param device the {@link Device}
+     */
+    public BulkDataIterable(
+            ArrayDataset dataset,
+            NDManager manager,
+            Sampler sampler,
+            Batchifier dataBatchifier,
+            Batchifier labelBatchifier,
+            Pipeline pipeline,
+            Pipeline targetPipeline,
+            ExecutorService executor,
+            int preFetchNumber,
+            Device device) {
+        super(
+                dataset,
+                manager,
+                sampler,
+                dataBatchifier,
+                labelBatchifier,
+                pipeline,
+                targetPipeline,
+                executor,
+                preFetchNumber,
+                device);
+    }
+
+    @Override
+    protected Batch fetch(List<Long> indices, int progress) throws IOException {
+        NDManager subManager = manager.newSubManager();
+        subManager.setName("dataIter fetch");
+        int batchSize = indices.size();
+
+        Record record;
+        if (isRange(indices)) {
+            long fromIndex = indices.get(0);
+            long toIndex = fromIndex + indices.size();
+            record = ((ArrayDataset) dataset).getByRange(subManager, fromIndex, toIndex);
+        } else {
+            long[] indicesArr = indices.stream().mapToLong(Long::longValue).toArray();
+            record = ((ArrayDataset) dataset).getByIndices(subManager, indicesArr);
+        }
+
+        NDList batchData = record.getData();
+        // apply transform
+        if (pipeline != null) {
+            batchData = pipeline.transform(batchData);
+        }
+
+        NDList batchLabels = record.getLabels();
+
+        // apply label transform
+        if (targetPipeline != null) {
+            batchLabels = targetPipeline.transform(batchLabels);
+        }
+        // pin to a specific device
+        if (device != null) {
+            batchData = batchData.toDevice(device, false);
+            batchLabels = batchLabels.toDevice(device, false);
+        }
+        return new Batch(
+                subManager,
+                batchData,
+                batchLabels,
+                batchSize,
+                dataBatchifier,
+                labelBatchifier,
+                progress,
+                dataset.size(),
+                indices);
+    }
+
+    /**
+     * Checks whether the given indices actually represents a range.
+     *
+     * @param indices the indices to examine
+     * @return whether the given indices are sorted in ascending order with no gap
+     */
+    public static boolean isRange(List<Long> indices) {
+        long from = indices.get(0);
+        for (long index : indices) {
+            if (index != from++) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/api/src/main/java/ai/djl/training/dataset/DataIterable.java
+++ b/api/src/main/java/ai/djl/training/dataset/DataIterable.java
@@ -44,14 +44,14 @@ public class DataIterable implements Iterable<Batch>, Iterator<Batch> {
 
     private static final Logger logger = LoggerFactory.getLogger(DataIterable.class);
 
-    private RandomAccessDataset dataset;
-    private NDManager manager;
-    private Batchifier dataBatchifier;
-    private Batchifier labelBatchifier;
-    private Pipeline pipeline;
-    private Pipeline targetPipeline;
+    protected RandomAccessDataset dataset;
+    protected NDManager manager;
+    protected Batchifier dataBatchifier;
+    protected Batchifier labelBatchifier;
+    protected Pipeline pipeline;
+    protected Pipeline targetPipeline;
     private ExecutorService executor;
-    private Device device;
+    protected Device device;
 
     private Iterator<List<Long>> sample;
     // for multithreading
@@ -160,7 +160,7 @@ public class DataIterable implements Iterable<Batch>, Iterator<Batch> {
         }
     }
 
-    private Batch fetch(List<Long> indices, int progress) throws IOException {
+    protected Batch fetch(List<Long> indices, int progress) throws IOException {
         NDManager subManager = manager.newSubManager();
         subManager.setName("dataIter fetch");
         int batchSize = indices.size();

--- a/basicdataset/src/test/java/ai/djl/basicdataset/MnistTest.java
+++ b/basicdataset/src/test/java/ai/djl/basicdataset/MnistTest.java
@@ -15,20 +15,27 @@ package ai.djl.basicdataset;
 import ai.djl.Model;
 import ai.djl.basicdataset.cv.classification.Mnist;
 import ai.djl.ndarray.NDManager;
+import ai.djl.ndarray.types.Shape;
 import ai.djl.nn.Blocks;
 import ai.djl.repository.Repository;
 import ai.djl.training.DefaultTrainingConfig;
 import ai.djl.training.Trainer;
 import ai.djl.training.TrainingConfig;
 import ai.djl.training.dataset.Batch;
+import ai.djl.training.dataset.BulkDataIterable;
 import ai.djl.training.dataset.Dataset;
 import ai.djl.training.loss.Loss;
+import ai.djl.translate.StackBatchifier;
 import ai.djl.translate.TranslateException;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
 
 public class MnistTest {
 
@@ -78,6 +85,97 @@ public class MnistTest {
                 Assert.assertEquals(batch.getData().size(), 1);
                 Assert.assertEquals(batch.getLabels().size(), 1);
                 batch.close();
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testRandomSamplingCoversAllIndices() throws IOException, TranslateException {
+        TrainingConfig config = new DefaultTrainingConfig(Loss.softmaxCrossEntropyLoss());
+
+        try (Model model = Model.newInstance("model")) {
+            model.setBlock(Blocks.identityBlock());
+
+            NDManager manager = model.getNDManager();
+            Repository repository = Repository.newInstance("test", "src/test/resources/mlrepo");
+            Mnist mnist =
+                    Mnist.builder()
+                            .optManager(manager)
+                            .optUsage(Dataset.Usage.TEST)
+                            .optRepository(repository)
+                            .setSampling(32, true)
+                            .build();
+
+            List<Long> randomizedIndices = new ArrayList<>();
+            try (Trainer trainer = model.newTrainer(config)) {
+                for (Batch batch : trainer.iterateDataset(mnist)) {
+                    randomizedIndices.addAll((List<Long>) batch.getIndices());
+                    Assert.assertEquals(batch.getData().size(), 1);
+                    Assert.assertEquals(batch.getLabels().size(), 1);
+                    if (randomizedIndices.size() == 10000) {
+                        // 312 * 32 + 16 = 10000, so last batch has only 16 items left
+                        Assert.assertEquals(
+                                new Shape(16, 1, 28, 28), batch.getData().get(0).getShape());
+                    } else {
+                        Assert.assertEquals(
+                                new Shape(32, 1, 28, 28), batch.getData().get(0).getShape());
+                    }
+                    batch.close();
+                }
+            }
+            Assert.assertEquals(10000, randomizedIndices.size());
+            Collections.sort(randomizedIndices);
+            Assert.assertTrue(BulkDataIterable.isRange(randomizedIndices));
+        }
+    }
+
+    @Test
+    public void testBulkEqualsNonBulk() throws IOException, TranslateException {
+        TrainingConfig config = new DefaultTrainingConfig(Loss.softmaxCrossEntropyLoss());
+
+        try (Model model = Model.newInstance("model")) {
+            model.setBlock(Blocks.identityBlock());
+
+            NDManager manager = model.getNDManager();
+            Repository repository = Repository.newInstance("test", "src/test/resources/mlrepo");
+
+            // use BulkDataIterable
+            Mnist mnistBulk =
+                    Mnist.builder()
+                            .optManager(manager)
+                            .optUsage(Dataset.Usage.TEST)
+                            .optRepository(repository)
+                            .setSampling(32, false)
+                            .build();
+
+            // use only DataIterable (as not using Batchifier.STACK)
+            Mnist mnist =
+                    Mnist.builder()
+                            .optManager(manager)
+                            .optUsage(Dataset.Usage.TEST)
+                            .optRepository(repository)
+                            .setSampling(32, false)
+                            .optLabelBatchifier(new StackBatchifier() {})
+                            .build();
+
+            try (Trainer trainer = model.newTrainer(config)) {
+                Iterator<Batch> iterable = trainer.iterateDataset(mnist).iterator();
+                Iterator<Batch> bulkIterable = trainer.iterateDataset(mnistBulk).iterator();
+                Assert.assertFalse(iterable instanceof BulkDataIterable);
+                Assert.assertTrue(bulkIterable instanceof BulkDataIterable);
+                while (iterable.hasNext()) {
+                    Batch batch = iterable.next();
+                    Assert.assertTrue(bulkIterable.hasNext());
+                    Batch batchBulk = bulkIterable.next();
+                    Assert.assertEquals(batch.getIndices(), batchBulk.getIndices());
+                    Assert.assertEquals(batch.getSize(), batchBulk.getSize());
+                    Assert.assertEquals(batch.getData(), batchBulk.getData());
+                    Assert.assertEquals(batch.getLabels(), batchBulk.getLabels());
+                    batch.close();
+                    batchBulk.close();
+                }
+                Assert.assertFalse(bulkIterable.hasNext());
             }
         }
     }

--- a/basicdataset/src/test/java/ai/djl/basicdataset/MnistTest.java
+++ b/basicdataset/src/test/java/ai/djl/basicdataset/MnistTest.java
@@ -125,6 +125,7 @@ public class MnistTest {
                 }
             }
             Assert.assertEquals(10000, randomizedIndices.size());
+            Assert.assertFalse(BulkDataIterable.isRange(randomizedIndices));
             Collections.sort(randomizedIndices);
             Assert.assertTrue(BulkDataIterable.isRange(randomizedIndices));
         }

--- a/basicdataset/src/test/java/ai/djl/basicdataset/RandomAccessDatasetTest.java
+++ b/basicdataset/src/test/java/ai/djl/basicdataset/RandomAccessDatasetTest.java
@@ -58,6 +58,7 @@ public class RandomAccessDatasetTest {
             Record record = subset.get(manager, 0);
             Assert.assertEquals(record.getData().head().getLong(), 10);
 
+            /** Tests {@link #ArrayDataset.getByRange()} */
             List<Long> indices =
                     LongStream.range(10, 25).mapToObj(n -> n).collect(Collectors.toList());
             subset = dataset.subDataset(indices);
@@ -65,8 +66,18 @@ public class RandomAccessDatasetTest {
             record = subset.get(manager, 0);
             Assert.assertEquals(record.getData().head().getLong(), 10);
 
+            /** Tests {@link #ArrayDataset.getByIndices()} */
             Collections.reverse(indices);
             subset = dataset.subDataset(indices);
+            record = subset.get(manager, 0);
+            Assert.assertEquals(record.getData().head().getLong(), 24);
+
+            /** Tests {@link #RandomAccessDataset.subDataset(recordKeys, subRecordKeys)} */
+            List<String> subRecordKeys =
+                    indices.stream().map(k -> "key" + k).collect(Collectors.toList());
+            List<String> recordKeys =
+                    LongStream.range(0, 100).mapToObj(k -> "key" + k).collect(Collectors.toList());
+            subset = dataset.subDataset(recordKeys, subRecordKeys);
             record = subset.get(manager, 0);
             Assert.assertEquals(record.getData().head().getLong(), 24);
         }

--- a/basicdataset/src/test/java/ai/djl/basicdataset/RandomAccessDatasetTest.java
+++ b/basicdataset/src/test/java/ai/djl/basicdataset/RandomAccessDatasetTest.java
@@ -26,6 +26,10 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 
 public class RandomAccessDatasetTest {
 
@@ -53,6 +57,18 @@ public class RandomAccessDatasetTest {
             Assert.assertEquals(15, subset.size());
             Record record = subset.get(manager, 0);
             Assert.assertEquals(record.getData().head().getLong(), 10);
+
+            List<Long> indices =
+                    LongStream.range(10, 25).mapToObj(n -> n).collect(Collectors.toList());
+            subset = dataset.subDataset(indices);
+            Assert.assertEquals(15, subset.size());
+            record = subset.get(manager, 0);
+            Assert.assertEquals(record.getData().head().getLong(), 10);
+
+            Collections.reverse(indices);
+            subset = dataset.subDataset(indices);
+            record = subset.get(manager, 0);
+            Assert.assertEquals(record.getData().head().getLong(), 24);
         }
     }
 }

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
@@ -324,7 +324,7 @@ public class MxNDArray extends NativeResource<Pointer> implements LazyNDArray {
 
     /** {@inheritDoc} */
     @Override
-    public NDArray take(NDArray index) {
+    public NDArray take(NDManager manager, NDArray index) {
         MxOpParams params = new MxOpParams();
         params.add("mode", "wrap");
         return manager.invoke("take", new NDList(this.flatten(), index), params).singletonOrThrow();

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayIndexer.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayIndexer.java
@@ -36,14 +36,9 @@ public class MxNDArrayIndexer extends NDArrayIndexer {
         array = manager.from(array);
         MxOpParams params = new MxOpParams();
         params.addParam("axis", fullPick.getAxis());
-        if (!fullPick.isIndexTake()) {
-            params.addParam("keepdims", true);
-        }
+        params.addParam("keepdims", true);
         params.add("mode", "wrap");
-        return manager.invoke(
-                        fullPick.isIndexTake() ? "take" : "pick",
-                        new NDList(array, fullPick.getIndices()),
-                        params)
+        return manager.invoke("pick", new NDList(array, fullPick.getIndices()), params)
                 .singletonOrThrow();
     }
 

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayIndexer.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayIndexer.java
@@ -17,6 +17,7 @@ import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.index.NDArrayIndexer;
 import ai.djl.ndarray.index.full.NDIndexFullPick;
 import ai.djl.ndarray.index.full.NDIndexFullSlice;
+import ai.djl.ndarray.index.full.NDIndexFullTake;
 import ai.djl.ndarray.types.Shape;
 
 import java.util.Stack;
@@ -39,6 +40,17 @@ public class MxNDArrayIndexer extends NDArrayIndexer {
         params.addParam("keepdims", true);
         params.add("mode", "wrap");
         return manager.invoke("pick", new NDList(array, fullPick.getIndices()), params)
+                .singletonOrThrow();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray get(NDArray array, NDIndexFullTake fullTake) {
+        array = manager.from(array);
+        MxOpParams params = new MxOpParams();
+        params.addParam("axis", fullTake.getAxis());
+        params.add("mode", "wrap");
+        return manager.invoke("take", new NDList(array, fullTake.getIndices()), params)
                 .singletonOrThrow();
     }
 

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayIndexer.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayIndexer.java
@@ -36,9 +36,14 @@ public class MxNDArrayIndexer extends NDArrayIndexer {
         array = manager.from(array);
         MxOpParams params = new MxOpParams();
         params.addParam("axis", fullPick.getAxis());
-        params.addParam("keepdims", true);
+        if (!fullPick.isIndexTake()) {
+            params.addParam("keepdims", true);
+        }
         params.add("mode", "wrap");
-        return manager.invoke("pick", new NDList(array, fullPick.getIndices()), params)
+        return manager.invoke(
+                        fullPick.isIndexTake() ? "take" : "pick",
+                        new NDList(array, fullPick.getIndices()),
+                        params)
                 .singletonOrThrow();
     }
 

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -268,11 +268,11 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
 
     /** {@inheritDoc} */
     @Override
-    public NDArray take(NDArray index) {
+    public NDArray take(NDManager manager, NDArray index) {
         if (!(index instanceof PtNDArray)) {
             throw new IllegalArgumentException("Only PtNDArray is supported.");
         }
-        return JniUtils.take(this, (PtNDArray) index);
+        return JniUtils.take(this, (PtNDArray) index, (PtNDManager) manager);
     }
 
     /** {@inheritDoc} */

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArrayIndexer.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArrayIndexer.java
@@ -18,6 +18,7 @@ import ai.djl.ndarray.index.NDIndex;
 import ai.djl.ndarray.index.dim.NDIndexBooleans;
 import ai.djl.ndarray.index.full.NDIndexFullPick;
 import ai.djl.ndarray.index.full.NDIndexFullSlice;
+import ai.djl.ndarray.index.full.NDIndexFullTake;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.pytorch.jni.JniUtils;
 
@@ -37,6 +38,12 @@ public class PtNDArrayIndexer extends NDArrayIndexer {
     public NDArray get(NDArray array, NDIndexFullPick fullPick) {
         return JniUtils.pick(
                 manager.from(array), manager.from(fullPick.getIndices()), fullPick.getAxis());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray get(NDArray array, NDIndexFullTake fullTake) {
+        return JniUtils.take(manager.from(array), manager.from(fullTake.getIndices()), manager);
     }
 
     /** {@inheritDoc} */

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArrayIndexer.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArrayIndexer.java
@@ -63,12 +63,12 @@ public class PtNDArrayIndexer extends NDArrayIndexer {
             index.addAllDim();
         }
 
-        if (array == null || array instanceof PtNDArray && array.getManager() == manager) {
-            return JniUtils.indexAdv((PtNDArray) array, index);
+        if (array == null || array instanceof PtNDArray) {
+            return JniUtils.indexAdv((PtNDArray) array, index, manager);
         } else {
             PtNDArray arrayNew =
                     manager.create(array.toByteBuffer(), array.getShape(), array.getDataType());
-            return JniUtils.indexAdv(arrayNew, index);
+            return JniUtils.indexAdv(arrayNew, index, manager);
         }
     }
 

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
@@ -503,13 +503,12 @@ public final class JniUtils {
                 PyTorchLibrary.LIB.torchGather(ndArray.getHandle(), index.getHandle(), dim, false));
     }
 
-    public static PtNDArray take(PtNDArray ndArray, PtNDArray index) {
+    public static PtNDArray take(PtNDArray ndArray, PtNDArray index, PtNDManager manager) {
         if (index.getDataType() != DataType.INT64) {
             index = index.toType(DataType.INT64, true);
         }
         return new PtNDArray(
-                ndArray.getManager(),
-                PyTorchLibrary.LIB.torchTake(ndArray.getHandle(), index.getHandle()));
+                manager, PyTorchLibrary.LIB.torchTake(ndArray.getHandle(), index.getHandle()));
     }
 
     public static PtNDArray put(PtNDArray ndArray, PtNDArray index, PtNDArray data) {

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
@@ -358,7 +358,7 @@ public final class JniUtils {
     }
 
     @SuppressWarnings("OptionalGetWithoutIsPresent")
-    public static PtNDArray indexAdv(PtNDArray ndArray, NDIndex index) {
+    public static PtNDArray indexAdv(PtNDArray ndArray, NDIndex index, PtNDManager manager) {
         if (ndArray == null) {
             return ndArray;
         }
@@ -405,10 +405,7 @@ public final class JniUtils {
                 // Backward compatible
                 NDIndexFullPick fullPick =
                         NDIndexFullPick.fromIndex(index, ndArray.getShape()).get();
-                return pick(
-                        ndArray,
-                        ndArray.getManager().from(fullPick.getIndices()),
-                        fullPick.getAxis());
+                return pick(ndArray, manager.from(fullPick.getIndices()), fullPick.getAxis());
             }
         }
         if (indices.size() == index.getEllipsisIndex()) {
@@ -416,7 +413,7 @@ public final class JniUtils {
         }
 
         return new PtNDArray(
-                ndArray.getManager(),
+                manager,
                 PyTorchLibrary.LIB.torchIndexAdvGet(ndArray.getHandle(), torchIndexHandle));
     }
 

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
@@ -210,7 +210,7 @@ public class TfNDArray extends NativeResource<TFE_TensorHandle> implements NDArr
 
     /** {@inheritDoc} */
     @Override
-    public NDArray take(NDArray index) {
+    public NDArray take(NDManager manager, NDArray index) {
         throw new UnsupportedOperationException("Not implemented yet.");
     }
 

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArrayIndexer.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArrayIndexer.java
@@ -16,6 +16,7 @@ import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.index.NDArrayIndexer;
 import ai.djl.ndarray.index.full.NDIndexFullPick;
 import ai.djl.ndarray.index.full.NDIndexFullSlice;
+import ai.djl.ndarray.index.full.NDIndexFullTake;
 
 /** The {@link NDArrayIndexer} used by the {@link TfNDArray}. */
 public class TfNDArrayIndexer extends NDArrayIndexer {
@@ -29,6 +30,12 @@ public class TfNDArrayIndexer extends NDArrayIndexer {
     /** {@inheritDoc} */
     @Override
     public NDArray get(NDArray array, NDIndexFullPick fullPick) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray get(NDArray array, NDIndexFullTake fullTake) {
         throw new UnsupportedOperationException("Not implemented");
     }
 

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
@@ -50,6 +50,13 @@ public class NDIndexTest {
                     original.get(
                             new NDIndex().addAllDim().addPickDim(manager.create(new int[] {0, 1})));
             Assert.assertEquals(actual, expected);
+
+            // The difference between take and pick used combined with addAllDim()
+            NDArray yHat = manager.create(new float[][]{{0.1f, 0.3f, 0.6f}, {0.3f, 0.2f, 0.5f}});
+            NDArray yGet = yHat.get(new NDIndex(":, {}", manager.create(new int[]{0, 2})));
+            NDArray yPick = yHat.get(new NDIndex().addAllDim().addPickDim(manager.create(new int[]{0, 2})));
+            Assert.assertEquals(yGet, manager.create(new float[][]{{0.1f, 0.6f}, {0.3f, 0.5f}}));
+            Assert.assertEquals(yPick, manager.create(new float[][]{{0.1f}, {0.5f}}));
         }
     }
 

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
@@ -52,11 +52,13 @@ public class NDIndexTest {
             Assert.assertEquals(actual, expected);
 
             // The difference between take and pick used combined with addAllDim()
-            NDArray yHat = manager.create(new float[][]{{0.1f, 0.3f, 0.6f}, {0.3f, 0.2f, 0.5f}});
-            NDArray yGet = yHat.get(new NDIndex(":, {}", manager.create(new int[]{0, 2})));
-            NDArray yPick = yHat.get(new NDIndex().addAllDim().addPickDim(manager.create(new int[]{0, 2})));
-            Assert.assertEquals(yGet, manager.create(new float[][]{{0.1f, 0.6f}, {0.3f, 0.5f}}));
-            Assert.assertEquals(yPick, manager.create(new float[][]{{0.1f}, {0.5f}}));
+            NDArray yHat = manager.create(new float[][] {{0.1f, 0.3f, 0.6f}, {0.3f, 0.2f, 0.5f}});
+            NDArray yGet = yHat.get(new NDIndex(":, {}", manager.create(new int[] {0, 2})));
+            NDArray yPick =
+                    yHat.get(
+                            new NDIndex().addAllDim().addPickDim(manager.create(new int[] {0, 2})));
+            Assert.assertEquals(yGet, manager.create(new float[][] {{0.1f, 0.6f}, {0.3f, 0.5f}}));
+            Assert.assertEquals(yPick, manager.create(new float[][] {{0.1f}, {0.5f}}));
         }
     }
 

--- a/integration/src/main/java/ai/djl/integration/tests/nn/BlockCoreTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/nn/BlockCoreTest.java
@@ -198,7 +198,7 @@ public class BlockCoreTest {
         // number of linear transformations modeled by LinearCollection
         int splitSize = 6;
 
-        // following ndarrays will be scoped to modelLinearCollection's ndmanager so they can be
+        // following ndarrays will be scoped to <code>sharedManager</code> so they can be
         // used later in the for-loop
         NDArray expectedWeightForLinearCollection;
         NDArray expectedBiasForLinearCollection;
@@ -256,21 +256,13 @@ public class BlockCoreTest {
                         // copy initial weight/bias values from LinearCollection
                         Shape inputShape = new Shape(batchSize, featureSize);
                         block.setInitializer(
-                                (m, s, t) -> {
-                                    NDArray w =
-                                            expectedWeightForLinearCollection
-                                                    .get(splitIndex)
-                                                    .transpose();
-                                    w.attach(m);
-                                    return w;
-                                },
+                                (m, s, t) ->
+                                        expectedWeightForLinearCollection
+                                                .get(m, splitIndex)
+                                                .transpose(),
                                 Parameter.Type.WEIGHT);
                         block.setInitializer(
-                                (m, s, t) -> {
-                                    NDArray w = expectedBiasForLinearCollection.get(splitIndex);
-                                    w.attach(m);
-                                    return w;
-                                },
+                                (m, s, t) -> expectedBiasForLinearCollection.get(m, splitIndex),
                                 Parameter.Type.BIAS);
                         trainer.initialize(inputShape);
 


### PR DESCRIPTION
This pull requests optimizes Batch creation for ArrayDataset when using StackBatchifier .
My DJL application learns the data now in 58550ms  rather than 79843ms so 36% faster!
For applications not using range-based indexing but indices-based indexing, my DJL application would run in 66341ms , so still 20% faster. This is true for PyTorch, i get a test failure for MxNet, so this solution maybe restricted to PyTorch