### PR TITLE
Catch SecurityException if access denied

### DIFF
--- a/api/src/main/java/ai/djl/util/cuda/CudaUtils.java
+++ b/api/src/main/java/ai/djl/util/cuda/CudaUtils.java
@@ -187,6 +187,10 @@ public final class CudaUtils {
             logger.debug("cudart library not found.");
             logger.trace("", e);
             return null;
+        } catch (SecurityException e) {
+            logger.warn("Access denied during loading cudart library.");
+            logger.trace("", e);
+            return null;
         }
     }
 

--- a/api/src/test/java/ai/djl/util/SecurityManagerTest.java
+++ b/api/src/test/java/ai/djl/util/SecurityManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
  * with the License. A copy of the License is located at

--- a/api/src/test/java/ai/djl/util/SecurityManagerTest.java
+++ b/api/src/test/java/ai/djl/util/SecurityManagerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.util;
+
+import ai.djl.util.cuda.CudaUtils;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.FilePermission;
+import java.security.Permission;
+
+public class SecurityManagerTest {
+
+    private SecurityManager originalSM;
+
+    @BeforeTest
+    public void setUp() {
+        originalSM = System.getSecurityManager();
+    }
+
+    @AfterTest
+    public void tearDown() {
+        System.setSecurityManager(originalSM);
+    }
+
+    @Test
+    public void testGetenv() {
+        // Disable access to system environment
+        SecurityManager sm =
+                new SecurityManager() {
+                    @Override
+                    public void checkPermission(Permission perm) {
+                        if (perm instanceof RuntimePermission
+                                && perm.getName().startsWith("getenv.")) {
+                            throw new SecurityException(
+                                    "Don't have permission to read system environment: "
+                                            + perm.getName());
+                        }
+                    }
+                };
+        System.setSecurityManager(sm);
+
+        Assert.assertNull(Utils.getenv("HOME"));
+        Assert.assertNull(Utils.getenv("TEST"));
+        Assert.assertEquals(Utils.getenv("HOME", "/home"), "/home");
+        Assert.assertEquals(Utils.getenv("TEST", "test"), "test");
+        Assert.assertEquals(Utils.getenv().size(), 0);
+    }
+
+    @Test
+    public void testCudaUtils() {
+        // Disable access to the cudart library files
+        SecurityManager sm =
+                new SecurityManager() {
+                    @Override
+                    public void checkPermission(Permission perm) {
+                        if (perm instanceof FilePermission && perm.getName().contains("cudart")) {
+                            throw new SecurityException(
+                                    "Don't have permission to read file: " + perm.getName());
+                        }
+                    }
+                };
+        System.setSecurityManager(sm);
+
+        Assert.assertFalse(CudaUtils.hasCuda());
+        Assert.assertEquals(CudaUtils.getGpuCount(), 0);
+    }
+}


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

CudaUtils throws SecurityException if read from system location is not allowed. This change catches exception if access denied during loading cudart library.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
