### PR TITLE
Fixes memory leak when using NDManager.newBaseManager()

### DIFF
--- a/engines/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrNDManager.java
+++ b/engines/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrNDManager.java
@@ -17,6 +17,7 @@ import ai.djl.engine.Engine;
 import ai.djl.ndarray.BaseNDManager;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
+import ai.djl.ndarray.NDResource;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 
@@ -114,6 +115,15 @@ public class DlrNDManager extends BaseNDManager {
         /** {@inheritDoc} */
         @Override
         public void detachInternal(String resourceId) {}
+
+        /** {@inheritDoc} */
+        @Override
+        public void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
+
+        /** {@inheritDoc} */
+        @Override
+        public void tempAttachInternal(
+                NDManager originalManager, String resourceId, NDResource resource) {}
 
         /** {@inheritDoc} */
         @Override

--- a/engines/ml/xgboost/src/main/java/ai/djl/ml/xgboost/XgbNDManager.java
+++ b/engines/ml/xgboost/src/main/java/ai/djl/ml/xgboost/XgbNDManager.java
@@ -17,6 +17,7 @@ import ai.djl.engine.Engine;
 import ai.djl.ndarray.BaseNDManager;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
+import ai.djl.ndarray.NDResource;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.ndarray.types.SparseFormat;
@@ -181,6 +182,15 @@ public class XgbNDManager extends BaseNDManager {
         /** {@inheritDoc} */
         @Override
         public void detachInternal(String resourceId) {}
+
+        /** {@inheritDoc} */
+        @Override
+        public void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
+
+        /** {@inheritDoc} */
+        @Override
+        public void tempAttachInternal(
+                NDManager originalManager, String resourceId, NDResource resource) {}
 
         /** {@inheritDoc} */
         @Override

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDManager.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDManager.java
@@ -397,16 +397,16 @@ public class MxNDManager extends BaseNDManager {
 
         /** {@inheritDoc} */
         @Override
-        void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
+        public void detachInternal(String resourceId) {}
+
+        /** {@inheritDoc} */
+        @Override
+        public void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
 
         /** {@inheritDoc} */
         @Override
         public void tempAttachInternal(
                 NDManager originalManager, String resourceId, NDResource resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void detachInternal(String resourceId) {}
 
         /** {@inheritDoc} */
         @Override

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDManager.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDManager.java
@@ -397,6 +397,10 @@ public class MxNDManager extends BaseNDManager {
 
         /** {@inheritDoc} */
         @Override
+        void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
+
+        /** {@inheritDoc} */
+        @Override
         public void tempAttachInternal(
                 NDManager originalManager, String resourceId, NDResource resource) {}
 

--- a/engines/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtNDManager.java
+++ b/engines/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtNDManager.java
@@ -18,6 +18,7 @@ import ai.djl.engine.EngineException;
 import ai.djl.ndarray.BaseNDManager;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
+import ai.djl.ndarray.NDResource;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 import ai.onnxruntime.OnnxTensor;
@@ -137,6 +138,15 @@ public class OrtNDManager extends BaseNDManager {
         /** {@inheritDoc} */
         @Override
         public void detachInternal(String resourceId) {}
+
+        /** {@inheritDoc} */
+        @Override
+        public void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
+
+        /** {@inheritDoc} */
+        @Override
+        public void tempAttachInternal(
+                NDManager originalManager, String resourceId, NDResource resource) {}
 
         /** {@inheritDoc} */
         @Override

--- a/engines/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpNDManager.java
+++ b/engines/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpNDManager.java
@@ -17,6 +17,7 @@ import ai.djl.engine.Engine;
 import ai.djl.ndarray.BaseNDManager;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
+import ai.djl.ndarray.NDResource;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.paddlepaddle.jni.JniUtils;
@@ -123,6 +124,15 @@ public class PpNDManager extends BaseNDManager {
         /** {@inheritDoc} */
         @Override
         public void detachInternal(String resourceId) {}
+
+        /** {@inheritDoc} */
+        @Override
+        public void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
+
+        /** {@inheritDoc} */
+        @Override
+        public void tempAttachInternal(
+                NDManager originalManager, String resourceId, NDResource resource) {}
 
         /** {@inheritDoc} */
         @Override

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDManager.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDManager.java
@@ -184,6 +184,10 @@ public class PtNDManager extends BaseNDManager {
 
         /** {@inheritDoc} */
         @Override
+        void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
+
+        /** {@inheritDoc} */
+        @Override
         public void detachInternal(String resourceId) {}
 
         /** {@inheritDoc} */

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDManager.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDManager.java
@@ -17,6 +17,7 @@ import ai.djl.engine.Engine;
 import ai.djl.ndarray.BaseNDManager;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
+import ai.djl.ndarray.NDResource;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.ndarray.types.SparseFormat;
@@ -180,15 +181,16 @@ public class PtNDManager extends BaseNDManager {
 
         /** {@inheritDoc} */
         @Override
-        public void attachInternal(String resourceId, AutoCloseable resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
-
-        /** {@inheritDoc} */
-        @Override
         public void detachInternal(String resourceId) {}
+
+        /** {@inheritDoc} */
+        @Override
+        public void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
+
+        /** {@inheritDoc} */
+        @Override
+        public void tempAttachInternal(
+                NDManager originalManager, String resourceId, NDResource resource) {}
 
         /** {@inheritDoc} */
         @Override

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDManager.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDManager.java
@@ -17,6 +17,7 @@ import ai.djl.engine.Engine;
 import ai.djl.ndarray.BaseNDManager;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
+import ai.djl.ndarray.NDResource;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.tensorflow.engine.javacpp.JavacppUtils;
@@ -319,6 +320,15 @@ public class TfNDManager extends BaseNDManager {
         /** {@inheritDoc} */
         @Override
         public void detachInternal(String resourceId) {}
+
+        /** {@inheritDoc} */
+        @Override
+        public void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
+
+        /** {@inheritDoc} */
+        @Override
+        public void tempAttachInternal(
+                NDManager originalManager, String resourceId, NDResource resource) {}
 
         /** {@inheritDoc} */
         @Override

--- a/engines/tensorrt/src/main/java/ai/djl/tensorrt/engine/TrtNDManager.java
+++ b/engines/tensorrt/src/main/java/ai/djl/tensorrt/engine/TrtNDManager.java
@@ -17,6 +17,7 @@ import ai.djl.engine.Engine;
 import ai.djl.ndarray.BaseNDManager;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
+import ai.djl.ndarray.NDResource;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.util.Float16Utils;
@@ -138,6 +139,15 @@ public class TrtNDManager extends BaseNDManager {
         /** {@inheritDoc} */
         @Override
         public void detachInternal(String resourceId) {}
+
+        /** {@inheritDoc} */
+        @Override
+        public void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
+
+        /** {@inheritDoc} */
+        @Override
+        public void tempAttachInternal(
+                NDManager originalManager, String resourceId, NDResource resource) {}
 
         /** {@inheritDoc} */
         @Override

--- a/engines/tflite/tflite-engine/src/main/java/ai/djl/tflite/engine/TfLiteNDManager.java
+++ b/engines/tflite/tflite-engine/src/main/java/ai/djl/tflite/engine/TfLiteNDManager.java
@@ -17,6 +17,7 @@ import ai.djl.engine.Engine;
 import ai.djl.ndarray.BaseNDManager;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
+import ai.djl.ndarray.NDResource;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 
@@ -100,6 +101,15 @@ public class TfLiteNDManager extends BaseNDManager {
         /** {@inheritDoc} */
         @Override
         public void detachInternal(String resourceId) {}
+
+        /** {@inheritDoc} */
+        @Override
+        public void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
+
+        /** {@inheritDoc} */
+        @Override
+        public void tempAttachInternal(
+                NDManager originalManager, String resourceId, NDResource resource) {}
 
         /** {@inheritDoc} */
         @Override


### PR DESCRIPTION
…DManager (#1886)

## Description ##

When using pytorch-engine:0.18.0 `NDManager.newBaseManager()`, it will call `attachUncappedInternal` to attach the created PtNDManger to PtNDManager$SystemManager's `resources` field, but never detach it, thus cause memory leak.

By implementing `attachUncappedInternal` in PtNDManager$SystemManager without doing anything, avoid PtNDManager cannot be sweeped by JVM
