### PR TITLE
Creates a SystemNDManager interface

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
@@ -315,6 +315,9 @@ public abstract class BaseNDManager implements NDManager {
     /** {@inheritDoc} */
     @Override
     public synchronized void attachInternal(String resourceId, AutoCloseable resource) {
+        if (this instanceof SystemNDManager) {
+            return;
+        }
         if (capped.get()) {
             throw new IllegalStateException("NDManager is capped for addition of resources.");
         }
@@ -324,6 +327,9 @@ public abstract class BaseNDManager implements NDManager {
     /** {@inheritDoc} */
     @Override
     public synchronized void attachUncappedInternal(String resourceId, AutoCloseable resource) {
+        if (this instanceof SystemNDManager) {
+            return;
+        }
         if (closed.get()) {
             throw new IllegalStateException("NDManager has been closed already.");
         }
@@ -349,6 +355,9 @@ public abstract class BaseNDManager implements NDManager {
     @Override
     public void tempAttachInternal(
             NDManager originalManager, String resourceId, NDResource resource) {
+        if (this instanceof SystemNDManager) {
+            return;
+        }
         if (closed.get()) {
             throw new IllegalStateException("NDManager has been closed already.");
         }
@@ -358,6 +367,9 @@ public abstract class BaseNDManager implements NDManager {
     /** {@inheritDoc} */
     @Override
     public synchronized void detachInternal(String resourceId) {
+        if (this instanceof SystemNDManager) {
+            return;
+        }
         if (closed.get()) {
             // This may happen in the middle of BaseNDManager.close()
             return;
@@ -387,6 +399,9 @@ public abstract class BaseNDManager implements NDManager {
     /** {@inheritDoc} */
     @Override
     public void close() {
+        if (this instanceof SystemNDManager) {
+            return;
+        }
         if (!closed.getAndSet(true)) {
             for (AutoCloseable closeable : resources.values()) {
                 try {

--- a/api/src/main/java/ai/djl/ndarray/NDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/NDManager.java
@@ -1634,4 +1634,11 @@ public interface NDManager extends AutoCloseable {
     /** {@inheritDoc} */
     @Override
     void close();
+
+    /**
+     * A {@link SystemNDManager} is a marker class for a base NDManager.
+     *
+     * <p>Unlike a typical {@link NDManager}, they can not be closed and don't track memory.
+     */
+    interface SystemNDManager {}
 }

--- a/engines/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrNDManager.java
+++ b/engines/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrNDManager.java
@@ -17,7 +17,6 @@ import ai.djl.engine.Engine;
 import ai.djl.ndarray.BaseNDManager;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
-import ai.djl.ndarray.NDResource;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 
@@ -102,28 +101,11 @@ public class DlrNDManager extends BaseNDManager {
     }
 
     /** The SystemManager is the root {@link DlrNDManager} of which all others are children. */
-    private static final class SystemManager extends DlrNDManager {
+    private static final class SystemManager extends DlrNDManager implements SystemNDManager {
 
         SystemManager() {
             super(null, null);
         }
-
-        /** {@inheritDoc} */
-        @Override
-        public void attachInternal(String resourceId, AutoCloseable resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void detachInternal(String resourceId) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void tempAttachInternal(
-                NDManager originalManager, String resourceId, NDResource resource) {}
 
         /** {@inheritDoc} */
         @Override

--- a/engines/ml/lightgbm/src/main/java/ai/djl/ml/lightgbm/LgbmNDManager.java
+++ b/engines/ml/lightgbm/src/main/java/ai/djl/ml/lightgbm/LgbmNDManager.java
@@ -88,22 +88,10 @@ public class LgbmNDManager extends BaseNDManager {
     }
 
     /** The SystemManager is the root {@link LgbmNDManager} of which all others are children. */
-    private static final class SystemManager extends LgbmNDManager {
+    private static final class SystemManager extends LgbmNDManager implements SystemNDManager {
 
         SystemManager() {
             super(null, null);
         }
-
-        /** {@inheritDoc} */
-        @Override
-        public void attachInternal(String resourceId, AutoCloseable resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void detachInternal(String resourceId) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void close() {}
     }
 }

--- a/engines/ml/xgboost/src/main/java/ai/djl/ml/xgboost/XgbNDManager.java
+++ b/engines/ml/xgboost/src/main/java/ai/djl/ml/xgboost/XgbNDManager.java
@@ -17,7 +17,6 @@ import ai.djl.engine.Engine;
 import ai.djl.ndarray.BaseNDManager;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
-import ai.djl.ndarray.NDResource;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.ndarray.types.SparseFormat;
@@ -169,31 +168,10 @@ public class XgbNDManager extends BaseNDManager {
     }
 
     /** The SystemManager is the root {@link XgbNDManager} of which all others are children. */
-    private static final class SystemManager extends XgbNDManager {
+    private static final class SystemManager extends XgbNDManager implements SystemNDManager {
 
         SystemManager() {
             super(null, null);
         }
-
-        /** {@inheritDoc} */
-        @Override
-        public void attachInternal(String resourceId, AutoCloseable resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void detachInternal(String resourceId) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void tempAttachInternal(
-                NDManager originalManager, String resourceId, NDResource resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void close() {}
     }
 }

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDManager.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDManager.java
@@ -20,7 +20,6 @@ import ai.djl.ndarray.BaseNDManager;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.NDManager;
-import ai.djl.ndarray.NDResource;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.ndarray.types.SparseFormat;
@@ -427,31 +426,10 @@ public class MxNDManager extends BaseNDManager {
     }
 
     /** The SystemManager is the root {@link MxNDManager} of which all others are children. */
-    private static final class SystemManager extends MxNDManager {
+    private static final class SystemManager extends MxNDManager implements SystemNDManager {
 
         SystemManager() {
             super(null, null, JnaUtils.getVersion());
         }
-
-        /** {@inheritDoc} */
-        @Override
-        public void attachInternal(String resourceId, AutoCloseable resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void detachInternal(String resourceId) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void tempAttachInternal(
-                NDManager originalManager, String resourceId, NDResource resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void close() {}
     }
 }

--- a/engines/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtNDManager.java
+++ b/engines/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtNDManager.java
@@ -18,7 +18,6 @@ import ai.djl.engine.EngineException;
 import ai.djl.ndarray.BaseNDManager;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
-import ai.djl.ndarray.NDResource;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 import ai.onnxruntime.OnnxTensor;
@@ -125,28 +124,11 @@ public class OrtNDManager extends BaseNDManager {
     }
 
     /** The SystemManager is the root {@link OrtNDManager} of which all others are children. */
-    private static final class SystemManager extends OrtNDManager {
+    private static final class SystemManager extends OrtNDManager implements SystemNDManager {
 
         SystemManager() {
             super(null, null, OrtEnvironment.getEnvironment());
         }
-
-        /** {@inheritDoc} */
-        @Override
-        public void attachInternal(String resourceId, AutoCloseable resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void detachInternal(String resourceId) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void tempAttachInternal(
-                NDManager originalManager, String resourceId, NDResource resource) {}
 
         /** {@inheritDoc} */
         @Override

--- a/engines/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpNDManager.java
+++ b/engines/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpNDManager.java
@@ -17,7 +17,6 @@ import ai.djl.engine.Engine;
 import ai.djl.ndarray.BaseNDManager;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
-import ai.djl.ndarray.NDResource;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.paddlepaddle.jni.JniUtils;
@@ -111,28 +110,11 @@ public class PpNDManager extends BaseNDManager {
     }
 
     /** The SystemManager is the root {@link PpNDManager} of which all others are children. */
-    private static final class SystemManager extends PpNDManager {
+    private static final class SystemManager extends PpNDManager implements SystemNDManager {
 
         SystemManager() {
             super(null, null);
         }
-
-        /** {@inheritDoc} */
-        @Override
-        public void attachInternal(String resourceId, AutoCloseable resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void detachInternal(String resourceId) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void tempAttachInternal(
-                NDManager originalManager, String resourceId, NDResource resource) {}
 
         /** {@inheritDoc} */
         @Override

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDManager.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDManager.java
@@ -17,7 +17,6 @@ import ai.djl.engine.Engine;
 import ai.djl.ndarray.BaseNDManager;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
-import ai.djl.ndarray.NDResource;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.ndarray.types.SparseFormat;
@@ -180,27 +179,10 @@ public class PtNDManager extends BaseNDManager {
     }
 
     /** The SystemManager is the root {@link PtNDManager} of which all others are children. */
-    private static final class SystemManager extends PtNDManager {
+    private static final class SystemManager extends PtNDManager implements SystemNDManager {
 
         SystemManager() {
             super(null, null);
         }
-
-        /** {@inheritDoc} */
-        @Override
-        public void detachInternal(String resourceId) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void tempAttachInternal(
-                NDManager originalManager, String resourceId, NDResource resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void close() {}
     }
 }

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDManager.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDManager.java
@@ -17,7 +17,6 @@ import ai.djl.engine.Engine;
 import ai.djl.ndarray.BaseNDManager;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
-import ai.djl.ndarray.NDResource;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.tensorflow.engine.javacpp.JavacppUtils;
@@ -307,31 +306,10 @@ public class TfNDManager extends BaseNDManager {
         return new TfOpExecutor(this, getEagerSession(), operation);
     }
 
-    private static final class SystemManager extends TfNDManager {
+    private static final class SystemManager extends TfNDManager implements SystemNDManager {
 
         SystemManager() {
             super(null, null);
         }
-
-        /** {@inheritDoc} */
-        @Override
-        public void attachInternal(String resourceId, AutoCloseable resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void detachInternal(String resourceId) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void tempAttachInternal(
-                NDManager originalManager, String resourceId, NDResource resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void close() {}
     }
 }

--- a/engines/tensorrt/src/main/java/ai/djl/tensorrt/engine/TrtNDManager.java
+++ b/engines/tensorrt/src/main/java/ai/djl/tensorrt/engine/TrtNDManager.java
@@ -17,7 +17,6 @@ import ai.djl.engine.Engine;
 import ai.djl.ndarray.BaseNDManager;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
-import ai.djl.ndarray.NDResource;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.util.Float16Utils;
@@ -126,31 +125,10 @@ public class TrtNDManager extends BaseNDManager {
     }
 
     /** The SystemManager is the root {@link TrtNDManager} of which all others are children. */
-    private static final class SystemManager extends TrtNDManager {
+    private static final class SystemManager extends TrtNDManager implements SystemNDManager {
 
         SystemManager() {
             super(null, null);
         }
-
-        /** {@inheritDoc} */
-        @Override
-        public void attachInternal(String resourceId, AutoCloseable resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void detachInternal(String resourceId) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void tempAttachInternal(
-                NDManager originalManager, String resourceId, NDResource resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void close() {}
     }
 }

--- a/engines/tflite/tflite-engine/src/main/java/ai/djl/tflite/engine/TfLiteNDManager.java
+++ b/engines/tflite/tflite-engine/src/main/java/ai/djl/tflite/engine/TfLiteNDManager.java
@@ -17,7 +17,6 @@ import ai.djl.engine.Engine;
 import ai.djl.ndarray.BaseNDManager;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDManager;
-import ai.djl.ndarray.NDResource;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 
@@ -88,31 +87,10 @@ public class TfLiteNDManager extends BaseNDManager {
     }
 
     /** The SystemManager is the root {@link TfLiteNDManager} of which all others are children. */
-    private static final class SystemManager extends TfLiteNDManager {
+    private static final class SystemManager extends TfLiteNDManager implements SystemNDManager {
 
         SystemManager() {
             super(null, null);
         }
-
-        /** {@inheritDoc} */
-        @Override
-        public void attachInternal(String resourceId, AutoCloseable resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void detachInternal(String resourceId) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void attachUncappedInternal(String resourceId, AutoCloseable resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void tempAttachInternal(
-                NDManager originalManager, String resourceId, NDResource resource) {}
-
-        /** {@inheritDoc} */
-        @Override
-        public void close() {}
     }
 }


### PR DESCRIPTION
fixes #1886

This creates an interface for SystemNDManagers. That way, the behavior of
skipping over various functions can be moved to the BaseNDManager instead of
each individual SystemManager