### PR TITLE
[ci] Upgrade gradle to 7.5.1 and support JDK18

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip

--- a/tools/gradle/check.gradle
+++ b/tools/gradle/check.gradle
@@ -1,4 +1,4 @@
-if (JavaVersion.current() < JavaVersion.VERSION_18) {
+if (JavaVersion.current() < JavaVersion.VERSION_19) {
     apply plugin: "com.github.spotbugs"
     spotbugs {
         excludeFilter = file("${rootProject.projectDir}/tools/conf/findbugs-exclude.xml")


### PR DESCRIPTION
Change-Id: Ida3c741c30923b8238ee409357216af62d46b24c

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
