### PR TITLE
Update to mxnet 1.9.1

### DIFF
--- a/engines/mxnet/native/build.gradle
+++ b/engines/mxnet/native/build.gradle
@@ -202,7 +202,7 @@ task downloadMxnetNativeLib() {
             from("${BINARY_ROOT}/mkl/linux/native/lib") {
                 exclude '**/libmxnet.so'
             }
-            into("${BINARY_ROOT}/cu110mkl/linux/native/lib")
+            into("${BINARY_ROOT}/cu112mkl/linux/native/lib")
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ systemProp.org.gradle.internal.http.connectionTimeout=60000
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 djl_version=0.19.0
-mxnet_version=1.9.0
+mxnet_version=1.9.1
 pytorch_version=1.11.0
 tensorflow_version=2.7.0
 tflite_version=2.6.2


### PR DESCRIPTION
Canary for cuda112 mxnet engine is failing https://github.com/deepjavalibrary/djl-demo/runs/7794346123?check_suite_focus=true
