### PR TITLE
Fix changed name for LightGBM publishing

### DIFF
--- a/engines/ml/lightgbm/build.gradle
+++ b/engines/ml/lightgbm/build.gradle
@@ -15,7 +15,6 @@ dependencies {
 publishing {
     publications {
         maven(MavenPublication) {
-            artifactId "lightgbm-engine"
             pom {
                 name = "DJL Engine Adapter for LightGBM"
                 description = "Deep Java Library (DJL) Engine Adapter for LightGBM"


### PR DESCRIPTION
To match xgboost and file path, should use artifact id "lightgbm"
