### PR TITLE
Upgrade to PyTorch 1.12.1 Canary

### DIFF
--- a/.github/workflows/native_s3_pytorch.yml
+++ b/.github/workflows/native_s3_pytorch.yml
@@ -29,3 +29,5 @@ jobs:
         working-directory: engines/pytorch/pytorch-native
         run: |
           ./gradlew uploadS3
+          PYTORCH_VERSION=$(cat gradle.properties | awk -F '=' '/pytorch_version/ {print $2}')
+          aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/pytorch/${PYTORCH_VERSION}/*"

--- a/engines/pytorch/pytorch-native/build.gradle
+++ b/engines/pytorch/pytorch-native/build.gradle
@@ -141,7 +141,7 @@ def copyNativeLibToOutputDir(Map<String, String> fileStoreMap, String binaryRoot
         // GPU dependencies
         copy {
             from("${outputDir}/libtorch/lib/") {
-                include "libtorch_cuda*.so", "torch_cuda*.dll", "libc10_cuda.so", "c10_cuda.dll", "libcaffe2_nvrtc.so", "libnvrtc*.so.*", "libcudart*.*", "*nvToolsExt*.*", "cudnn*.dll", "caffe2_nvrtc.dll", "nvrtc64*.dll", "uv.dll"
+                include "libtorch_cuda*.so", "torch_cuda*.dll", "libc10_cuda.so", "c10_cuda.dll", "libcaffe2_nvrtc.so", "libnvrtc*.so.*", "libcudart*.*", "*nvToolsExt*.*", "cudnn*.dll", "caffe2_nvrtc.dll", "nvrtc64*.dll", "uv.dll", "libcublas*", "zlibwapi.dll"
             }
             into("${outputDir}/native/lib")
         }


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Upgrade to PyTorch 1.12.1 Canary

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
