### PR TITLE
[tokenizers] load truncation and padding settings from options, updat…

### DIFF
--- a/extensions/tokenizers/rust/src/lib.rs
+++ b/extensions/tokenizers/rust/src/lib.rs
@@ -422,9 +422,9 @@ pub extern "system" fn Java_ai_djl_huggingface_tokenizers_jni_TokenizersLibrary_
         .into();
     let len = max_length as usize;
     let res_strategy = match strategy.as_ref() {
-        "batch_longest" => Ok(PaddingStrategy::BatchLongest),
-        "fixed" => Ok(PaddingStrategy::Fixed(len)),
-        _ => Err("strategy must be one of [batch_longest, fixed]"),
+        "longest" => Ok(PaddingStrategy::BatchLongest),
+        "max_length" => Ok(PaddingStrategy::Fixed(len)),
+        _ => Err("strategy must be one of [longest, max_length]"),
     };
 
     let mut params = PaddingParams::default();

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizer.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizer.java
@@ -351,17 +351,6 @@ public final class HuggingFaceTokenizer extends NativeResource<Long> implements 
         }
     }
 
-    /**
-     * Enables truncation to specified length for the tokenizer.
-     *
-     * @param maxLength truncate to specified length
-     */
-    public void setTruncation(int maxLength) {
-        truncation = TruncationStrategy.LONGEST_FIRST;
-        this.maxLength = maxLength;
-        updateTruncationAndPadding();
-    }
-
     /** Enables truncation to only truncate the first item. */
     public void setTruncateFirstOnly() {
         if (truncation != TruncationStrategy.ONLY_FIRST) {
@@ -392,15 +381,38 @@ public final class HuggingFaceTokenizer extends NativeResource<Long> implements 
     }
 
     /**
-     * Enables padding to pad to specified length.
-     *
-     * @param maxLength truncate to specified length
-     * @param padToMultipleOf pad the sequence to a multiple of the provided value
+     * Enables padding to pad sequences to previously specified maxLength, or modelMaxLength if not
+     * specified.
      */
-    public void setPadding(int maxLength, int padToMultipleOf) {
-        this.maxLength = maxLength;
-        this.padToMultipleOf = padToMultipleOf;
-        updateTruncationAndPadding();
+    public void setPaddingMaxLength() {
+        if (padding != PaddingStrategy.MAX_LENGTH) {
+            padding = PaddingStrategy.MAX_LENGTH;
+            updateTruncationAndPadding();
+        }
+    }
+
+    /**
+     * Sets maxLength for padding and truncation.
+     *
+     * @param maxLength the length to truncate and/or pad sequences to
+     */
+    public void setMaxLength(int maxLength) {
+        if (this.maxLength != maxLength) {
+            this.maxLength = maxLength;
+            updateTruncationAndPadding();
+        }
+    }
+
+    /**
+     * Sets padToMultipleOf for padding.
+     *
+     * @param padToMultipleOf the multiple of sequences should be padded to
+     */
+    public void setPadToMultipleOf(int padToMultipleOf) {
+        if (this.padToMultipleOf != padToMultipleOf) {
+            this.padToMultipleOf = padToMultipleOf;
+            updateTruncationAndPadding();
+        }
     }
 
     /*
@@ -468,7 +480,7 @@ public final class HuggingFaceTokenizer extends NativeResource<Long> implements 
     }
 
     /** An enum to represent the different available truncation strategies. */
-    enum TruncationStrategy {
+    private enum TruncationStrategy {
         LONGEST_FIRST,
         ONLY_FIRST,
         ONLY_SECOND,
@@ -481,7 +493,7 @@ public final class HuggingFaceTokenizer extends NativeResource<Long> implements 
          * @return the matching PaddingStrategy type
          * @throws IllegalArgumentException if the value does not match any TruncationStrategy type
          */
-        public static TruncationStrategy fromValue(String value) {
+        static TruncationStrategy fromValue(String value) {
             if ("true".equals(value)) {
                 return TruncationStrategy.LONGEST_FIRST;
             } else if ("false".equals(value)) {
@@ -497,7 +509,7 @@ public final class HuggingFaceTokenizer extends NativeResource<Long> implements 
     }
 
     /** An enum to represent the different available padding strategies. */
-    enum PaddingStrategy {
+    private enum PaddingStrategy {
         LONGEST,
         MAX_LENGTH,
         DO_NOT_PAD;
@@ -509,7 +521,7 @@ public final class HuggingFaceTokenizer extends NativeResource<Long> implements 
          * @return the matching PaddingStrategy type
          * @throws IllegalArgumentException if the value does not match any PaddingStrategy type
          */
-        public static PaddingStrategy fromValue(String value) {
+        static PaddingStrategy fromValue(String value) {
             if ("true".equals(value)) {
                 return PaddingStrategy.LONGEST;
             } else if ("false".equals(value)) {

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/TokenizersLibrary.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/TokenizersLibrary.java
@@ -53,13 +53,23 @@ public final class TokenizersLibrary {
 
     public native String decode(long tokenizer, long[] ids, boolean addSpecialTokens);
 
+    public native String getTruncationStrategy(long tokenizer);
+
+    public native String getPaddingStrategy(long tokenizer);
+
+    public native int getMaxLength(long tokenizer);
+
+    public native int getStride(long tokenizer);
+
+    public native int getPadToMultipleOf(long tokenizer);
+
     public native void disablePadding(long tokenizer);
 
     public native void setPadding(
-            long tokenizer, long length, String paddingStrategy, long padToMultipleOf);
+            long tokenizer, int maxLength, String paddingStrategy, int padToMultipleOf);
 
     public native void disableTruncation(long tokenizer);
 
     public native void setTruncation(
-            long tokenizer, long maxLength, String truncationStrategy, long stride);
+            long tokenizer, int maxLength, String truncationStrategy, int stride);
 }

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/TokenizersLibrary.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/TokenizersLibrary.java
@@ -56,7 +56,7 @@ public final class TokenizersLibrary {
     public native void disablePadding(long tokenizer);
 
     public native void setPadding(
-            long tokenizer, long maxLength, String paddingStrategy, long padToMultipleOf);
+            long tokenizer, long length, String paddingStrategy, long padToMultipleOf);
 
     public native void disableTruncation(long tokenizer);
 


### PR DESCRIPTION
[tokenizers] load truncation and padding settings from options, update apis

## Description ##
- loading truncation/padding settings from options when creating new tokenizer instance
- Updated APIs for setting truncation/padding post tokenizer creation. Of note:
  - maxLength parameter is shared by both truncation and padding, and settable by its own method
  - No support for stride in this implementation
 - Updated unit test coverage - used the supported combinations from https://huggingface.co/docs/transformers/v4.20.1/en/pad_truncation to guide test cases

