### PR TITLE
[pytorch] Handles PYTORCH_VERSION is empty case

### DIFF
--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
@@ -507,11 +507,11 @@ public final class LibUtils {
             this.apiVersion = platform.getApiVersion();
             this.classifier = platform.getClassifier();
             version = Utils.getEnvOrSystemProperty("PYTORCH_VERSION");
-            if (version == null) {
+            if (version == null || version.isEmpty()) {
                 version = platform.getVersion();
             }
             flavor = Utils.getEnvOrSystemProperty("PYTORCH_FLAVOR");
-            if (flavor == null) {
+            if (flavor == null || flavor.isEmpty()) {
                 if (CudaUtils.getGpuCount() > 0) {
                     flavor = "cu" + CudaUtils.getCudaVersionString() + "-precxx11";
                 } else {


### PR DESCRIPTION
Change-Id: I9a8c70df7b5ca2cac39f7c652d7f0fbf6e741aa8

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
