### PR TITLE
Adds support for intermediate sequential block results

### DIFF
--- a/model-zoo/src/main/java/ai/djl/basicmodelzoo/cv/classification/ResNetV1.java
+++ b/model-zoo/src/main/java/ai/djl/basicmodelzoo/cv/classification/ResNetV1.java
@@ -170,7 +170,7 @@ public final class ResNetV1 {
      * @param builder the {@link Builder} with the necessary arguments
      * @return a {@link Block} that represents the required ResNet model
      */
-    public static Block resnet(Builder builder) {
+    public static SequentialBlock resnet(Builder builder) {
         int numStages = builder.units.length;
         long height = builder.imageShape.get(1);
         SequentialBlock resNet = new SequentialBlock();
@@ -300,7 +300,7 @@ public final class ResNetV1 {
          *
          * @return the {@link ResNetV1} block
          */
-        public Block build() {
+        public SequentialBlock build() {
             if (imageShape == null) {
                 throw new IllegalArgumentException("Must set imageShape");
             }


### PR DESCRIPTION
This makes it so that SequentialBlocks can be used to get the internal results
required for models such as yolo.