### PR TITLE
Make the constructor of Encoding protected.

### DIFF
--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/Encoding.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/Encoding.java
@@ -25,7 +25,7 @@ public class Encoding {
     private long[] specialTokenMask;
     private CharSpan[] charTokenSpans;
 
-    Encoding(
+    protected Encoding(
             long[] ids,
             long[] typeIds,
             String[] tokens,


### PR DESCRIPTION
Allow subclasses of Encoding to be created outside of the package.

## Description ##
 
The relevant discussion is in https://github.com/deepjavalibrary/djl/issues/1938
