### PR TITLE
Fix capped manager on Tf engine

### DIFF
--- a/engines/ml/lightgbm/src/main/java/ai/djl/ml/lightgbm/LgbmNDArray.java
+++ b/engines/ml/lightgbm/src/main/java/ai/djl/ml/lightgbm/LgbmNDArray.java
@@ -55,6 +55,14 @@ public class LgbmNDArray extends NDArrayAdapter {
         handle = new AtomicReference<>();
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public void returnResource(NDManager manager) {
+        detach();
+        this.manager = manager;
+        manager.attachUncappedInternal(getUid(), this);
+    }
+
     /**
      * Returns the native LightGBM handle to the array.
      *

--- a/engines/ml/xgboost/src/main/java/ai/djl/ml/xgboost/XgbNDArray.java
+++ b/engines/ml/xgboost/src/main/java/ai/djl/ml/xgboost/XgbNDArray.java
@@ -100,6 +100,14 @@ public class XgbNDArray extends NDArrayAdapter {
 
     /** {@inheritDoc} */
     @Override
+    public void returnResource(NDManager manager) {
+        detach();
+        this.manager = manager;
+        manager.attachUncappedInternal(getUid(), this);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void detach() {
         manager.detachInternal(getUid());
         manager = XgbNDManager.getSystemManager();

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
@@ -230,6 +230,14 @@ public class TfNDArray extends NativeResource<TFE_TensorHandle> implements NDArr
 
     /** {@inheritDoc} */
     @Override
+    public void returnResource(NDManager manager) {
+        detach();
+        this.manager = (TfNDManager) manager;
+        manager.attachUncappedInternal(getUid(), this);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void tempAttach(NDManager manager) {
         NDManager original = this.manager;
         detach();


### PR DESCRIPTION
## Description ##

This is to fix a problem in the capped manager feature which is triggered when running `gradle :integration::test` on TensorFlow engine. In `testIndexationUsesSpecificUncappedManager`, the resource, whose original manager is capped, is temporarily attached to a submanager. At the end of the try block, it will be attached back to the original capped manager. (So this error doesn't trigger test failure, but only appears as an exception).  The fix is to apply `attachUncappedInternal` which circumvents capping protection.


