### PR TITLE
[Fix] Closing error in MXNet when indexing results in an empty array

### DIFF
--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayIndexer.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayIndexer.java
@@ -46,6 +46,15 @@ public class MxNDArrayIndexer extends NDArrayIndexer {
     @Override
     public NDArray get(NDArray array, NDIndexFullSlice fullSlice) {
         array = manager.from(array);
+        long[] min = fullSlice.getMin();
+        long[] max = fullSlice.getMax();
+        long[] s = array.getShape().getShape();
+        for (int i = 0; i < min.length; i++) {
+            if (min[i] >= max[i] || min[i] >= s[i]) {
+                return manager.create(new Shape(0));
+            }
+        }
+
         MxOpParams params = new MxOpParams();
         params.addTupleParam("begin", fullSlice.getMin());
         params.addTupleParam("end", fullSlice.getMax());

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
@@ -153,9 +153,9 @@ public class NDIndexTest {
         // This is to check the resource closing issue in MXNet engine is circumvented.
         // MXNetError: Check failed: delay_alloc:
         try (NDManager manager = NDManager.newBaseManager()) {
-            NDArray tmp = manager.create(new Shape(2, 2)).get(":4, 3:4");
-            NDArray tmp1 = manager.create(new Shape(2)).get("3:3");
-            NDArray tmp2 = manager.create(new Shape(2)).get("2:3");
+            NDArray dumb1 = manager.create(new Shape(2, 2)).get(":4, 3:4");
+            NDArray dumb2 = manager.create(new Shape(2)).get("3:3");
+            NDArray dumb3 = manager.create(new Shape(2)).get("2:3");
         }
     }
 

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
@@ -149,7 +149,7 @@ public class NDIndexTest {
     }
 
     @Test
-    public void testEmpty() {
+    public void testEmptyArrayClosing() {
         // This is to check the resource closing issue in MXNet engine is circumvented.
         // MXNetError: Check failed: delay_alloc:
         try (NDManager manager = NDManager.newBaseManager()) {

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
@@ -149,6 +149,17 @@ public class NDIndexTest {
     }
 
     @Test
+    public void testEmpty() {
+        // This is to check the resource closing issue in MXNet engine is circumvented.
+        // MXNetError: Check failed: delay_alloc:
+        try (NDManager manager = NDManager.newBaseManager()) {
+            NDArray tmp = manager.create(new Shape(2, 2)).get(":4, 3:4");
+            NDArray tmp1 = manager.create(new Shape(2)).get("3:3");
+            NDArray tmp2 = manager.create(new Shape(2)).get("2:3");
+        }
+    }
+
+    @Test
     public void testSetArray() {
         try (NDManager manager = NDManager.newBaseManager()) {
             NDArray original = manager.create(new float[] {1, 2, 3, 4}, new Shape(2, 2));

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDIndexTest.java
@@ -153,9 +153,9 @@ public class NDIndexTest {
         // This is to check the resource closing issue in MXNet engine is circumvented.
         // MXNetError: Check failed: delay_alloc:
         try (NDManager manager = NDManager.newBaseManager()) {
-            NDArray dumb1 = manager.create(new Shape(2, 2)).get(":4, 3:4");
-            NDArray dumb2 = manager.create(new Shape(2)).get("3:3");
-            NDArray dumb3 = manager.create(new Shape(2)).get("2:3");
+            manager.create(new Shape(2, 2)).get(":4, 3:4");
+            manager.create(new Shape(2)).get("3:3");
+            manager.create(new Shape(2)).get("2:3");
         }
     }
 


### PR DESCRIPTION
## Description ##

This is to fix the resource closing issue in MXNet engine:
MXNetError: Check failed: delay_alloc:
which happened in the following code
```
        try (NDManager manager = NDManager.newBaseManager()) {
            NDArray dumb1 = manager.create(new Shape(2, 2)).get(":4, 3:4");
            NDArray dumb2 = manager.create(new Shape(2)).get("3:3");
            NDArray dumb3 = manager.create(new Shape(2)).get("2:3");
        }
```
The fix is to check the indices within java.