### PR TITLE
[fix] add data type check to array setter

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
@@ -403,10 +403,12 @@ public abstract class BaseNDManager implements NDManager {
      * @param expected the expected size
      * @throws IllegalArgumentException if buffer size is invalid
      */
-    public static void validateBufferSize(Buffer buffer, DataType dataType, int expected) {
+    public static void validateBuffer(Buffer buffer, DataType dataType, int expected) {
         boolean isByteBuffer = buffer instanceof ByteBuffer;
         DataType type = DataType.fromBuffer(buffer);
-        if (!isByteBuffer && type != dataType) {
+        if (type != dataType && !isByteBuffer) {
+            // It's ok if type != datatype and buffer is ByteBuffer,
+            // since buffer will be copied into ByteBuffer
             throw new IllegalArgumentException(
                     "The input data type: "
                             + type

--- a/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
@@ -404,9 +404,18 @@ public abstract class BaseNDManager implements NDManager {
      * @throws IllegalArgumentException if buffer size is invalid
      */
     public static void validateBufferSize(Buffer buffer, DataType dataType, int expected) {
+        boolean isByteBuffer = buffer instanceof ByteBuffer;
+        DataType type = DataType.fromBuffer(buffer);
+        if (!isByteBuffer && type != dataType) {
+            throw new IllegalArgumentException(
+                    "The input data type: "
+                            + type
+                            + " does not match target array data type: "
+                            + dataType);
+        }
+
         int remaining = buffer.remaining();
-        int expectedSize =
-                buffer instanceof ByteBuffer ? dataType.getNumOfBytes() * expected : expected;
+        int expectedSize = isByteBuffer ? dataType.getNumOfBytes() * expected : expected;
         if (remaining < expectedSize) {
             throw new IllegalArgumentException(
                     "The NDArray size is: " + expected + ", but buffer size is: " + remaining);

--- a/api/src/main/java/ai/djl/ndarray/NDArray.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArray.java
@@ -400,9 +400,9 @@ public interface NDArray extends NDResource, BytesSupplier {
     /**
      * Sets this {@code NDArray} value from {@link Buffer}.
      *
-     * @param data the input buffered data
+     * @param buffer the input buffered data
      */
-    void set(Buffer data);
+    void set(Buffer buffer);
 
     /**
      * Sets this {@code NDArray} value from an array of floats.

--- a/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
@@ -211,8 +211,8 @@ public abstract class NDArrayAdapter implements NDArray {
 
     /** {@inheritDoc} */
     @Override
-    public void set(Buffer data) {
-        NDArray array = manager.create(data, getShape(), getDataType());
+    public void set(Buffer buffer) {
+        NDArray array = manager.create(buffer, getShape(), getDataType());
         intern(array);
         array.detach();
     }

--- a/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
@@ -212,16 +212,6 @@ public abstract class NDArrayAdapter implements NDArray {
     /** {@inheritDoc} */
     @Override
     public void set(Buffer data) {
-        DataType arrayType = getDataType();
-        DataType inputType = DataType.fromBuffer(data);
-        if (arrayType != inputType) {
-            throw new IllegalArgumentException(
-                    "The input data type: "
-                            + inputType
-                            + " does not match target array data type: "
-                            + arrayType);
-        }
-
         NDArray array = manager.create(data, getShape(), getDataType());
         intern(array);
         array.detach();

--- a/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
@@ -212,6 +212,16 @@ public abstract class NDArrayAdapter implements NDArray {
     /** {@inheritDoc} */
     @Override
     public void set(Buffer data) {
+        DataType arrayType = getDataType();
+        DataType inputType = DataType.fromBuffer(data);
+        if (arrayType != inputType) {
+            throw new IllegalArgumentException(
+                    "The input data type: "
+                            + inputType
+                            + " does not match target array data type: "
+                            + arrayType);
+        }
+
         NDArray array = manager.create(data, getShape(), getDataType());
         intern(array);
         array.detach();

--- a/engines/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrNDManager.java
+++ b/engines/dlr/dlr-engine/src/main/java/ai/djl/dlr/engine/DlrNDManager.java
@@ -81,7 +81,7 @@ public class DlrNDManager extends BaseNDManager {
             throw new UnsupportedOperationException("DlrNDArray only supports float32.");
         }
         int size = Math.toIntExact(shape.size());
-        BaseNDManager.validateBufferSize(data, dataType, size);
+        BaseNDManager.validateBuffer(data, dataType, size);
         if (data instanceof ByteBuffer) {
             return new DlrNDArray(this, alternativeManager, (ByteBuffer) data, shape, dataType);
         }

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
@@ -302,31 +302,18 @@ public class MxNDArray extends NativeResource<Pointer> implements LazyNDArray {
 
     /** {@inheritDoc} */
     @Override
-    public void set(Buffer data) {
-        DataType arrayType = getDataType();
-        DataType inputType = DataType.fromBuffer(data);
-        if (arrayType != inputType) {
-            DataType[] types = {DataType.UINT8, DataType.INT8, DataType.BOOLEAN};
-            if (Arrays.stream(types).noneMatch(x -> x == arrayType)
-                    || Arrays.stream(types).noneMatch(x -> x == inputType)) {
-                throw new IllegalArgumentException(
-                        "The input data type: "
-                                + inputType
-                                + " does not match target array data type: "
-                                + arrayType);
-            }
-        }
-
+    public void set(Buffer buffer) {
         int size = Math.toIntExact(size());
-        BaseNDManager.validateBufferSize(data, getDataType(), size);
-        if (data.isDirect()) {
-            JnaUtils.syncCopyFromCPU(getHandle(), data, size);
+        DataType type = getDataType();
+        BaseNDManager.validateBufferSize(buffer, type, size);
+        if (buffer.isDirect()) {
+            JnaUtils.syncCopyFromCPU(getHandle(), buffer, size);
             return;
         }
 
-        ByteBuffer buf = manager.allocateDirect(size * getDataType().getNumOfBytes());
-        BaseNDManager.copyBuffer(data, buf);
-        JnaUtils.syncCopyFromCPU(getHandle(), buf, size);
+        ByteBuffer bb = manager.allocateDirect(size * type.getNumOfBytes());
+        BaseNDManager.copyBuffer(buffer, bb);
+        JnaUtils.syncCopyFromCPU(getHandle(), bb, size);
     }
 
     /** {@inheritDoc} */

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
@@ -306,21 +306,25 @@ public class MxNDArray extends NativeResource<Pointer> implements LazyNDArray {
         DataType arrayType = getDataType();
         DataType inputType = DataType.fromBuffer(data);
         if (arrayType != inputType) {
-            throw new IllegalArgumentException(
-                    "The input data type: "
-                            + inputType
-                            + " does not match target array data type: "
-                            + arrayType);
+            DataType[] types = {DataType.UINT8, DataType.INT8, DataType.BOOLEAN};
+            if (Arrays.stream(types).noneMatch(x -> x == arrayType)
+                    || Arrays.stream(types).noneMatch(x -> x == inputType)) {
+                throw new IllegalArgumentException(
+                        "The input data type: "
+                                + inputType
+                                + " does not match target array data type: "
+                                + arrayType);
+            }
         }
 
         int size = Math.toIntExact(size());
-        BaseNDManager.validateBufferSize(data, arrayType, size);
+        BaseNDManager.validateBufferSize(data, getDataType(), size);
         if (data.isDirect()) {
             JnaUtils.syncCopyFromCPU(getHandle(), data, size);
             return;
         }
 
-        ByteBuffer buf = manager.allocateDirect(size * arrayType.getNumOfBytes());
+        ByteBuffer buf = manager.allocateDirect(size * getDataType().getNumOfBytes());
         BaseNDManager.copyBuffer(data, buf);
         JnaUtils.syncCopyFromCPU(getHandle(), buf, size);
     }

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
@@ -305,7 +305,7 @@ public class MxNDArray extends NativeResource<Pointer> implements LazyNDArray {
     public void set(Buffer buffer) {
         int size = Math.toIntExact(size());
         DataType type = getDataType();
-        BaseNDManager.validateBufferSize(buffer, type, size);
+        BaseNDManager.validateBuffer(buffer, type, size);
         if (buffer.isDirect()) {
             JnaUtils.syncCopyFromCPU(getHandle(), buffer, size);
             return;

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
@@ -303,15 +303,24 @@ public class MxNDArray extends NativeResource<Pointer> implements LazyNDArray {
     /** {@inheritDoc} */
     @Override
     public void set(Buffer data) {
+        DataType arrayType = getDataType();
+        DataType inputType = DataType.fromBuffer(data);
+        if (arrayType != inputType) {
+            throw new IllegalArgumentException(
+                    "The input data type: "
+                            + inputType
+                            + " does not match target array data type: "
+                            + arrayType);
+        }
+
         int size = Math.toIntExact(size());
-        DataType type = getDataType();
-        BaseNDManager.validateBufferSize(data, type, size);
+        BaseNDManager.validateBufferSize(data, arrayType, size);
         if (data.isDirect()) {
             JnaUtils.syncCopyFromCPU(getHandle(), data, size);
             return;
         }
 
-        ByteBuffer buf = manager.allocateDirect(size * type.getNumOfBytes());
+        ByteBuffer buf = manager.allocateDirect(size * arrayType.getNumOfBytes());
         BaseNDManager.copyBuffer(data, buf);
         JnaUtils.syncCopyFromCPU(getHandle(), buf, size);
     }

--- a/engines/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtNDManager.java
+++ b/engines/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtNDManager.java
@@ -73,7 +73,7 @@ public class OrtNDManager extends BaseNDManager {
                     "Use NDManager.create(String[], Shape) to create String NDArray.");
         }
         int size = Math.toIntExact(shape.size());
-        BaseNDManager.validateBufferSize(data, dataType, size);
+        BaseNDManager.validateBuffer(data, dataType, size);
         OnnxTensor tensor = OrtUtils.toTensor(env, data, shape, dataType);
         return new OrtNDArray(this, alternativeManager, tensor);
     }

--- a/engines/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpNDManager.java
+++ b/engines/paddlepaddle/paddlepaddle-engine/src/main/java/ai/djl/paddlepaddle/engine/PpNDManager.java
@@ -91,7 +91,7 @@ public class PpNDManager extends BaseNDManager {
     @Override
     public PpNDArray create(Buffer data, Shape shape, DataType dataType) {
         int size = Math.toIntExact(shape.size());
-        BaseNDManager.validateBufferSize(data, dataType, size);
+        BaseNDManager.validateBuffer(data, dataType, size);
         if (data.isDirect() && data instanceof ByteBuffer) {
             return JniUtils.createNdArray(this, (ByteBuffer) data, shape, dataType);
         }

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -226,6 +226,16 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public void set(Buffer data) {
+        DataType arrayType = getDataType();
+        DataType inputType = DataType.fromBuffer(data);
+        if (arrayType != inputType) {
+            throw new IllegalArgumentException(
+                    "The input data type: "
+                            + inputType
+                            + " does not match target array data type: "
+                            + arrayType);
+        }
+
         int size = Math.toIntExact(size());
         BaseNDManager.validateBufferSize(data, getDataType(), size);
         // TODO how do we handle the exception happened in the middle
@@ -240,7 +250,6 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
             return;
         }
         // int8, uint8, boolean use ByteBuffer, so need to explicitly input DataType
-        DataType inputType = DataType.fromBuffer(data);
         ByteBuffer buf = manager.allocateDirect(size * inputType.getNumOfBytes());
         BaseNDManager.copyBuffer(data, buf);
 

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -228,7 +228,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     public void set(Buffer buffer) {
         int size = Math.toIntExact(size());
         DataType type = getDataType();
-        BaseNDManager.validateBufferSize(buffer, type, size);
+        BaseNDManager.validateBuffer(buffer, type, size);
         // TODO how do we handle the exception happened in the middle
         dataRef = null;
         if (buffer.isDirect() && buffer instanceof ByteBuffer) {

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -229,11 +229,15 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
         DataType arrayType = getDataType();
         DataType inputType = DataType.fromBuffer(data);
         if (arrayType != inputType) {
-            throw new IllegalArgumentException(
-                    "The input data type: "
-                            + inputType
-                            + " does not match target array data type: "
-                            + arrayType);
+            DataType[] types = {DataType.UINT8, DataType.INT8, DataType.BOOLEAN};
+            if (Arrays.stream(types).noneMatch(x -> x == arrayType)
+                    || Arrays.stream(types).noneMatch(x -> x == inputType)) {
+                throw new IllegalArgumentException(
+                        "The input data type: "
+                                + inputType
+                                + " does not match target array data type: "
+                                + arrayType);
+            }
         }
 
         int size = Math.toIntExact(size());

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDManager.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDManager.java
@@ -66,7 +66,7 @@ public class PtNDManager extends BaseNDManager {
     @Override
     public PtNDArray create(Buffer data, Shape shape, DataType dataType) {
         int size = Math.toIntExact(shape.size());
-        BaseNDManager.validateBufferSize(data, dataType, size);
+        BaseNDManager.validateBuffer(data, dataType, size);
         if (data.isDirect() && data instanceof ByteBuffer) {
             return JniUtils.createNdFromByteBuffer(
                     this, (ByteBuffer) data, shape, dataType, SparseFormat.DENSE, device);

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
@@ -193,7 +193,7 @@ public class TfNDArray extends NativeResource<TFE_TensorHandle> implements NDArr
         }
         int size = Math.toIntExact(getShape().size());
         DataType type = getDataType();
-        BaseNDManager.validateBufferSize(buffer, type, size);
+        BaseNDManager.validateBuffer(buffer, type, size);
         if (buffer instanceof ByteBuffer) {
             JavacppUtils.setByteBuffer(getHandle(), (ByteBuffer) buffer);
             return;

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
@@ -186,34 +186,21 @@ public class TfNDArray extends NativeResource<TFE_TensorHandle> implements NDArr
 
     /** {@inheritDoc} */
     @Override
-    public void set(Buffer data) {
-        DataType arrayType = getDataType();
-        DataType inputType = DataType.fromBuffer(data);
-        if (arrayType != inputType) {
-            DataType[] types = {DataType.UINT8, DataType.INT8, DataType.BOOLEAN};
-            if (Arrays.stream(types).noneMatch(x -> x == arrayType)
-                    || Arrays.stream(types).noneMatch(x -> x == inputType)) {
-                throw new IllegalArgumentException(
-                        "The input data type: "
-                                + inputType
-                                + " does not match target array data type: "
-                                + arrayType);
-            }
-        }
-
+    public void set(Buffer buffer) {
         if (getDevice().isGpu()) {
             // TODO: Implement set for GPU
             throw new UnsupportedOperationException("GPU Tensor cannot be modified after creation");
         }
         int size = Math.toIntExact(getShape().size());
-        BaseNDManager.validateBufferSize(data, arrayType, size);
-        if (data instanceof ByteBuffer) {
-            JavacppUtils.setByteBuffer(getHandle(), (ByteBuffer) data);
+        DataType type = getDataType();
+        BaseNDManager.validateBufferSize(buffer, type, size);
+        if (buffer instanceof ByteBuffer) {
+            JavacppUtils.setByteBuffer(getHandle(), (ByteBuffer) buffer);
             return;
         }
-        ByteBuffer buf = getManager().allocateDirect(size * arrayType.getNumOfBytes());
-        BaseNDManager.copyBuffer(data, buf);
-        JavacppUtils.setByteBuffer(getHandle(), buf);
+        ByteBuffer bb = getManager().allocateDirect(size * type.getNumOfBytes());
+        BaseNDManager.copyBuffer(buffer, bb);
+        JavacppUtils.setByteBuffer(getHandle(), bb);
     }
 
     /** {@inheritDoc} */

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
@@ -190,11 +190,15 @@ public class TfNDArray extends NativeResource<TFE_TensorHandle> implements NDArr
         DataType arrayType = getDataType();
         DataType inputType = DataType.fromBuffer(data);
         if (arrayType != inputType) {
-            throw new IllegalArgumentException(
-                    "The input data type: "
-                            + inputType
-                            + " does not match target array data type: "
-                            + arrayType);
+            DataType[] types = {DataType.UINT8, DataType.INT8, DataType.BOOLEAN};
+            if (Arrays.stream(types).noneMatch(x -> x == arrayType)
+                    || Arrays.stream(types).noneMatch(x -> x == inputType)) {
+                throw new IllegalArgumentException(
+                        "The input data type: "
+                                + inputType
+                                + " does not match target array data type: "
+                                + arrayType);
+            }
         }
 
         if (getDevice().isGpu()) {

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
@@ -187,17 +187,27 @@ public class TfNDArray extends NativeResource<TFE_TensorHandle> implements NDArr
     /** {@inheritDoc} */
     @Override
     public void set(Buffer data) {
+        DataType arrayType = getDataType();
+        DataType inputType = DataType.fromBuffer(data);
+        if (arrayType != inputType) {
+            throw new IllegalArgumentException(
+                    "The input data type: "
+                            + inputType
+                            + " does not match target array data type: "
+                            + arrayType);
+        }
+
         if (getDevice().isGpu()) {
             // TODO: Implement set for GPU
             throw new UnsupportedOperationException("GPU Tensor cannot be modified after creation");
         }
         int size = Math.toIntExact(getShape().size());
-        BaseNDManager.validateBufferSize(data, getDataType(), size);
+        BaseNDManager.validateBufferSize(data, arrayType, size);
         if (data instanceof ByteBuffer) {
             JavacppUtils.setByteBuffer(getHandle(), (ByteBuffer) data);
             return;
         }
-        ByteBuffer buf = getManager().allocateDirect(size * getDataType().getNumOfBytes());
+        ByteBuffer buf = getManager().allocateDirect(size * arrayType.getNumOfBytes());
         BaseNDManager.copyBuffer(data, buf);
         JavacppUtils.setByteBuffer(getHandle(), buf);
     }

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDManager.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDManager.java
@@ -85,7 +85,7 @@ public class TfNDManager extends BaseNDManager {
                     "Use NDManager.create(String[], Charset, Shape) to create String NDArray.");
         }
         int size = Math.toIntExact(shape.size());
-        BaseNDManager.validateBufferSize(data, dataType, size);
+        BaseNDManager.validateBuffer(data, dataType, size);
         if (data.isDirect() && data instanceof ByteBuffer) {
             TFE_TensorHandle handle =
                     JavacppUtils.createTFETensorFromByteBuffer(

--- a/engines/tensorrt/src/main/java/ai/djl/tensorrt/engine/TrtNDArray.java
+++ b/engines/tensorrt/src/main/java/ai/djl/tensorrt/engine/TrtNDArray.java
@@ -63,6 +63,16 @@ public class TrtNDArray extends NDArrayAdapter {
     /** {@inheritDoc} */
     @Override
     public void set(Buffer data) {
+        DataType arrayType = getDataType();
+        DataType inputType = DataType.fromBuffer(data);
+        if (arrayType != inputType) {
+            throw new IllegalArgumentException(
+                    "The input data type: "
+                            + inputType
+                            + " does not match target array data type: "
+                            + arrayType);
+        }
+
         int size = Math.toIntExact(shape.size());
         BaseNDManager.validateBufferSize(data, dataType, size);
         BaseNDManager.copyBuffer(data, this.data);

--- a/engines/tensorrt/src/main/java/ai/djl/tensorrt/engine/TrtNDArray.java
+++ b/engines/tensorrt/src/main/java/ai/djl/tensorrt/engine/TrtNDArray.java
@@ -21,6 +21,7 @@ import ai.djl.ndarray.types.Shape;
 
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.UUID;
 
 /** {@code TrtNDArray} is the TensorRT implementation of {@link NDArray}. */
@@ -66,11 +67,15 @@ public class TrtNDArray extends NDArrayAdapter {
         DataType arrayType = getDataType();
         DataType inputType = DataType.fromBuffer(data);
         if (arrayType != inputType) {
-            throw new IllegalArgumentException(
-                    "The input data type: "
-                            + inputType
-                            + " does not match target array data type: "
-                            + arrayType);
+            DataType[] types = {DataType.UINT8, DataType.INT8, DataType.BOOLEAN};
+            if (Arrays.stream(types).noneMatch(x -> x == arrayType)
+                    || Arrays.stream(types).noneMatch(x -> x == inputType)) {
+                throw new IllegalArgumentException(
+                        "The input data type: "
+                                + inputType
+                                + " does not match target array data type: "
+                                + arrayType);
+            }
         }
 
         int size = Math.toIntExact(shape.size());

--- a/engines/tensorrt/src/main/java/ai/djl/tensorrt/engine/TrtNDArray.java
+++ b/engines/tensorrt/src/main/java/ai/djl/tensorrt/engine/TrtNDArray.java
@@ -64,7 +64,7 @@ public class TrtNDArray extends NDArrayAdapter {
     @Override
     public void set(Buffer buffer) {
         int size = Math.toIntExact(shape.size());
-        BaseNDManager.validateBufferSize(buffer, dataType, size);
+        BaseNDManager.validateBuffer(buffer, dataType, size);
         BaseNDManager.copyBuffer(buffer, data);
     }
 }

--- a/engines/tensorrt/src/main/java/ai/djl/tensorrt/engine/TrtNDArray.java
+++ b/engines/tensorrt/src/main/java/ai/djl/tensorrt/engine/TrtNDArray.java
@@ -21,7 +21,6 @@ import ai.djl.ndarray.types.Shape;
 
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.UUID;
 
 /** {@code TrtNDArray} is the TensorRT implementation of {@link NDArray}. */
@@ -63,23 +62,9 @@ public class TrtNDArray extends NDArrayAdapter {
 
     /** {@inheritDoc} */
     @Override
-    public void set(Buffer data) {
-        DataType arrayType = getDataType();
-        DataType inputType = DataType.fromBuffer(data);
-        if (arrayType != inputType) {
-            DataType[] types = {DataType.UINT8, DataType.INT8, DataType.BOOLEAN};
-            if (Arrays.stream(types).noneMatch(x -> x == arrayType)
-                    || Arrays.stream(types).noneMatch(x -> x == inputType)) {
-                throw new IllegalArgumentException(
-                        "The input data type: "
-                                + inputType
-                                + " does not match target array data type: "
-                                + arrayType);
-            }
-        }
-
+    public void set(Buffer buffer) {
         int size = Math.toIntExact(shape.size());
-        BaseNDManager.validateBufferSize(data, dataType, size);
-        BaseNDManager.copyBuffer(data, this.data);
+        BaseNDManager.validateBufferSize(buffer, dataType, size);
+        BaseNDManager.copyBuffer(buffer, data);
     }
 }

--- a/engines/tensorrt/src/main/java/ai/djl/tensorrt/engine/TrtNDManager.java
+++ b/engines/tensorrt/src/main/java/ai/djl/tensorrt/engine/TrtNDManager.java
@@ -72,7 +72,7 @@ public class TrtNDManager extends BaseNDManager {
     @Override
     public TrtNDArray create(Buffer data, Shape shape, DataType dataType) {
         int size = Math.toIntExact(shape.size());
-        BaseNDManager.validateBufferSize(data, dataType, size);
+        BaseNDManager.validateBuffer(data, dataType, size);
         if (data.isDirect() && data instanceof ByteBuffer) {
             return new TrtNDArray(this, alternativeManager, (ByteBuffer) data, shape, dataType);
         }

--- a/engines/tflite/tflite-engine/src/main/java/ai/djl/tflite/engine/TfLiteNDManager.java
+++ b/engines/tflite/tflite-engine/src/main/java/ai/djl/tflite/engine/TfLiteNDManager.java
@@ -63,7 +63,7 @@ public class TfLiteNDManager extends BaseNDManager {
     @Override
     public TfLiteNDArray create(Buffer data, Shape shape, DataType dataType) {
         int size = Math.toIntExact(shape.size());
-        BaseNDManager.validateBufferSize(data, dataType, size);
+        BaseNDManager.validateBuffer(data, dataType, size);
         if (data.isDirect() && data instanceof ByteBuffer) {
             return new TfLiteNDArray(this, alternativeManager, (ByteBuffer) data, shape, dataType);
         }


### PR DESCRIPTION
## Description ##

Fix https://github.com/deepjavalibrary/djl/issues/1970. The test code is therein.

## details
A poential place to convert the datatype from the input data type to the target array data type is in
https://github.com/deepjavalibrary/djl/blob/aeb9135686605aab846ada67df800c954b5ebf63/api/src/main/java/ai/djl/ndarray/BaseNDManager.java#L428

Here it does the job of:
> 2\. Multiple dataType maps to the same Buffer type, we have to handle them differently

But it is not ideal to conver the Buffer type inside java
https://stackoverflow.com/questions/38745123/bytebufferasshortbuffer-cannot-be-cast-to-java-nio-floatbuffer
Cannot cast 'java.nio.HeapIntBuffer' to 'java.nio.FloatBuffer'

So here we simply throw an exception when datatypes don't match.
