### PR TITLE
Cache the PyTorch "files.txt".

### DIFF
--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.lang.reflect.Method;
 import java.net.URL;

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.FileOutputStream;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLDecoder;

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
@@ -26,7 +26,6 @@ import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLDecoder;
-import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
@@ -392,6 +392,12 @@ public final class LibUtils {
         String link = "https://publish.djl.ai/pytorch/" + matcher.group(1);
         Path tmp = null;
         
+        try {
+            Files.createDirectories(cacheDir);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create a pytorch cache directory", e);
+        }
+        
         String localFiles = cacheDir + File.separator + "files.txt";
         String localTempFiles = cacheDir + File.separator + "tmpfiles.txt";
         try (InputStream is = new URL(link + "/files.txt").openStream();
@@ -399,6 +405,7 @@ public final class LibUtils {
              FileOutputStream fos = new FileOutputStream(localTempFiles);
             ) {
             fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+            fos.close();
             Files.move(Path.of(localTempFiles), Path.of(localFiles), StandardCopyOption.REPLACE_EXISTING);
         } catch (Exception e) {
             logger.warn("Could not download the PyTorch files: ", link);

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
@@ -411,7 +411,7 @@ public final class LibUtils {
             logger.warn("Could not download the PyTorch files: ", link);
         }            
         
-        try (InputStream is =  new FileInputStream(localFiles.toFile())) {
+        try (InputStream is = Files.newInputStream(indexFile)) {
             // if files not found
             Files.createDirectories(cacheDir);
             List<String> lines = Utils.readLines(is);

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
@@ -397,21 +397,21 @@ public final class LibUtils {
         } catch (IOException e) {
             throw new RuntimeException("Failed to create a pytorch cache directory", e);
         }
-        
-        String localFiles = cacheDir + File.separator + "files.txt";
-        String localTempFiles = cacheDir + File.separator + "tmpfiles.txt";
+         
+        Path localFiles = cacheDir.resolve("files.txt");
+        Path localTempFiles = cacheDir.resolve("tmpfiles.txt");
         try (InputStream is = new URL(link + "/files.txt").openStream();
              ReadableByteChannel rbc = Channels.newChannel(is);
-             FileOutputStream fos = new FileOutputStream(localTempFiles);
+             FileOutputStream fos = new FileOutputStream(localTempFiles.toFile());
             ) {
             fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
             fos.close();
-            Files.move(Path.of(localTempFiles), Path.of(localFiles), StandardCopyOption.REPLACE_EXISTING);
+            Files.move(localTempFiles, localFiles, StandardCopyOption.REPLACE_EXISTING);
         } catch (Exception e) {
             logger.warn("Could not download the PyTorch files: ", link);
         }
         
-        try (InputStream is =  new FileInputStream(localFiles)) {
+        try (InputStream is =  new FileInputStream(localFiles.toFile())) {
             // if files not found
             Files.createDirectories(cacheDir);
             List<String> lines = Utils.readLines(is);

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
@@ -405,11 +405,15 @@ public final class LibUtils {
              FileOutputStream fos = new FileOutputStream(localTempFiles.toFile());
             ) {
             fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
-            fos.close();
-            Files.move(localTempFiles, localFiles, StandardCopyOption.REPLACE_EXISTING);
         } catch (Exception e) {
             logger.warn("Could not download the PyTorch files: ", link);
         }
+        
+        try {
+            Files.move(localTempFiles, localFiles, StandardCopyOption.REPLACE_EXISTING);
+        } catch (Exception e) {
+            logger.warn("Could not download the PyTorch files: ", link);
+        }            
         
         try (InputStream is =  new FileInputStream(localFiles.toFile())) {
             // if files not found

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
@@ -387,21 +387,21 @@ public final class LibUtils {
         }
         String link = "https://publish.djl.ai/pytorch/" + matcher.group(1);
         Path tmp = null;
-        
-        Path indexFile = cacheDir.resolve(version + ".txt"); 
+
+        Path indexFile = cacheDir.resolve(version + ".txt");
         if (Files.notExists(indexFile)) {
-            Path tempFile = cacheDir.resolve(version + ".tmp"); 
+            Path tempFile = cacheDir.resolve(version + ".tmp");
             try (InputStream is = new URL(link + "/files.txt").openStream()) {
                 Files.createDirectories(cacheDir);
-                Files.copy(is, tempFile, StandardCopyOption.REPLACE_EXISTING); 
-                Utils.moveQuietly(tempFile, indexFile); 
+                Files.copy(is, tempFile, StandardCopyOption.REPLACE_EXISTING);
+                Utils.moveQuietly(tempFile, indexFile);
             } catch (IOException e) {
-                throw new IllegalStateException("Failed to save pytorch index file", e); 
-            } finally { 
-                Utils.deleteQuietly(tempFile); 
+                throw new IllegalStateException("Failed to save pytorch index file", e);
+            } finally {
+                Utils.deleteQuietly(tempFile);
             }
         }
-        
+
         try (InputStream is = Files.newInputStream(indexFile)) {
             // if files not found
             Files.createDirectories(cacheDir);

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
@@ -26,7 +26,6 @@ import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLDecoder;
-import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;


### PR DESCRIPTION
The cached "files.txt" ensures DJL will still run when the machine is offline, and the native torch jar is not added to the classpath.

## Description ##

Projects that run DJL pytorch models might not work if the machine cannot access "https://publish.djl.ai/pytorch/files.txt" when the "detected" platform is a placeholder (for example the native torch jar is not added to the project).

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
