### PR TITLE
[api] add NDArray gammaln and sample distribution function support.

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
@@ -234,6 +234,42 @@ public abstract class BaseNDManager implements NDManager {
 
     /** {@inheritDoc} */
     @Override
+    public NDArray sampleNormal(NDArray mu, NDArray sigma) {
+        throw new UnsupportedOperationException("Not supported!");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray sampleNormal(NDArray mu, NDArray sigma, Shape shape) {
+        throw new UnsupportedOperationException("Not supported!");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray samplePoisson(NDArray lam) {
+        throw new UnsupportedOperationException("Not supported!");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray samplePoisson(NDArray lam, Shape shape) {
+        throw new UnsupportedOperationException("Not supported!");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray sampleGamma(NDArray alpha, NDArray beta) {
+        throw new UnsupportedOperationException("Not supported!");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray sampleGamma(NDArray alpha, NDArray beta, Shape shape) {
+        throw new UnsupportedOperationException("Not supported!");
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public boolean isOpen() {
         return !closed.get();
     }

--- a/api/src/main/java/ai/djl/ndarray/NDArray.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArray.java
@@ -2013,6 +2013,23 @@ public interface NDArray extends NDResource, BytesSupplier {
     NDArray exp();
 
     /**
+     * Return the log of the absolute value of the gamma function of this {@code NDArray}
+     * element-wise.
+     *
+     * <p>Examples
+     *
+     * <pre>
+     * jshell&gt; NDArray array = manager.create(new float[] {0.5f, 1f, 1.5f});
+     * jshell&gt; array.gammaln();
+     * ND: (2) cpu() float32
+     * [ 0.5724,  0.0000, -0.1208]
+     * </pre>
+     *
+     * @return the result {@code NDArray}
+     */
+    NDArray gammaln();
+
+    /**
      * Returns the natural logarithmic value of this {@code NDArray} element-wise.
      *
      * <p>Examples

--- a/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
@@ -608,6 +608,12 @@ public abstract class NDArrayAdapter implements NDArray {
 
     /** {@inheritDoc} */
     @Override
+    public NDArray gammaln() {
+        return getAlternativeArray().gammaln();
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public NDArray log() {
         return getAlternativeArray().log();
     }

--- a/api/src/main/java/ai/djl/ndarray/NDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/NDManager.java
@@ -1384,6 +1384,75 @@ public interface NDManager extends AutoCloseable {
     NDArray randomMultinomial(int n, NDArray pValues, Shape shape);
 
     /**
+     * Concurrent sampling from multiple normal distributions with parameters *mu* (mean) and
+     * *sigma* (standard deviation).
+     *
+     * @param mu Means of the distributions
+     * @param sigma Standard deviations of the distributions
+     * @return the drawn samples {@link NDArray}
+     */
+    NDArray sampleNormal(NDArray mu, NDArray sigma);
+
+    /**
+     * Concurrent sampling from multiple normal distributions with parameters *mu* (mean) and
+     * *sigma* (standard deviation).
+     *
+     * @param mu Means of the distributions
+     * @param sigma Standard deviations of the distributions
+     * @param shape Shape to be sampled from each random distribution
+     * @return the drawn samples {@link NDArray}
+     */
+    NDArray sampleNormal(NDArray mu, NDArray sigma, Shape shape);
+
+    /**
+     * Draw random samples from a Poisson distribution.
+     *
+     * <p>Samples are distributed according to a Poisson distribution parametrized by *lambda*
+     * (rate). Samples will always be returned as a floating point data type.
+     *
+     * @param lam Lambda (rate) parameters of the distributions
+     * @return the drawn samples {@link NDArray}
+     */
+    NDArray samplePoisson(NDArray lam);
+
+    /**
+     * Draw random samples from a Poisson distribution.
+     *
+     * <p>Samples are distributed according to a Poisson distribution parametrized by *lambda*
+     * (rate). Samples will always be returned as a floating point data type.
+     *
+     * @param lam Lambda (rate) parameters of the distributions
+     * @param shape Shape to be sampled from each random distribution
+     * @return the drawn samples {@link NDArray}
+     */
+    NDArray samplePoisson(NDArray lam, Shape shape);
+
+    /**
+     * Draw random samples from a gamma distribution.
+     *
+     * <p>Samples are distributed according to a gamma distribution parametrized by *alpha* (shape)
+     * and *beta* (scale).
+     *
+     * @param alpha The shape of the gamma distribution
+     * @param beta The scale of the gamma distribution
+     * @return the drawn samples {@link NDArray}
+     */
+    NDArray sampleGamma(NDArray alpha, NDArray beta);
+
+    /**
+     * Draw random samples from a gamma distribution.
+     *
+     * <p>Samples are distributed according to a gamma distribution parametrized by *alpha* (shape)
+     * and *beta* (scale).
+     *
+     * @param alpha The shape of the gamma distribution
+     * @param beta The scale of the gamma distribution
+     * @param shape Shape to be sampled from each random distribution
+     * @return the drawn samples {@link NDArray}
+     */
+    NDArray sampleGamma(NDArray alpha, NDArray beta, Shape shape);
+
+    /**
      * Check if the manager is still valid.
      *
      * @return the current status

--- a/api/src/main/java/ai/djl/util/passthrough/PassthroughNDManager.java
+++ b/api/src/main/java/ai/djl/util/passthrough/PassthroughNDManager.java
@@ -173,6 +173,42 @@ public final class PassthroughNDManager implements NDManager {
 
     /** {@inheritDoc} */
     @Override
+    public NDArray sampleNormal(NDArray mu, NDArray sigma) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray sampleNormal(NDArray mu, NDArray sigma, Shape shape) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray samplePoisson(NDArray lam) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray samplePoisson(NDArray lam, Shape shape) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray sampleGamma(NDArray alpha, NDArray beta) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray sampleGamma(NDArray alpha, NDArray beta, Shape shape) {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public boolean isOpen() {
         return true;
     }

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
@@ -794,6 +794,12 @@ public class MxNDArray extends NativeResource<Pointer> implements LazyNDArray {
 
     /** {@inheritDoc} */
     @Override
+    public NDArray gammaln() {
+        return manager.invoke("gammaln", this, null);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public NDArray log() {
         return manager.invoke("_npi_log", this, null);
     }

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDManager.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDManager.java
@@ -277,6 +277,48 @@ public class MxNDManager extends BaseNDManager {
 
     /** {@inheritDoc} */
     @Override
+    public NDArray sampleNormal(NDArray mu, NDArray sigma) {
+        return invoke("sample_normal", new NDArray[] {mu, sigma}, null);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray sampleNormal(NDArray mu, NDArray sigma, Shape shape) {
+        MxOpParams params = new MxOpParams();
+        params.addParam("shape", shape);
+        return invoke("sample_normal", new NDArray[] {mu, sigma}, null);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray samplePoisson(NDArray lam) {
+        return invoke("sample_poisson", lam, null);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray samplePoisson(NDArray lam, Shape shape) {
+        MxOpParams params = new MxOpParams();
+        params.addParam("shape", shape);
+        return invoke("sample_poisson", lam, params);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray sampleGamma(NDArray alpha, NDArray beta) {
+        return invoke("sample_gamma", new NDArray[] {alpha, beta}, null);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray sampleGamma(NDArray alpha, NDArray beta, Shape shape) {
+        MxOpParams params = new MxOpParams();
+        params.addParam("shape", shape);
+        return invoke("sample_gamma", new NDArray[] {alpha, beta}, params);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public MxNDManager newSubManager(Device dev) {
         MxNDManager manager = new MxNDManager(this, dev, version);
         attachUncappedInternal(manager.uid, manager);

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDManager.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDManager.java
@@ -286,7 +286,7 @@ public class MxNDManager extends BaseNDManager {
     public NDArray sampleNormal(NDArray mu, NDArray sigma, Shape shape) {
         MxOpParams params = new MxOpParams();
         params.addParam("shape", shape);
-        return invoke("sample_normal", new NDArray[] {mu, sigma}, null);
+        return invoke("sample_normal", new NDArray[] {mu, sigma}, params);
     }
 
     /** {@inheritDoc} */

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -774,6 +774,12 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
 
     /** {@inheritDoc} */
     @Override
+    public NDArray gammaln() {
+        throw new UnsupportedOperationException("Not implemented yet.");
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public PtNDArray log() {
         return JniUtils.log(this);
     }

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
@@ -830,6 +830,7 @@ public class TfNDArray extends NativeResource<TFE_TensorHandle> implements NDArr
         return manager.opExecutor("Exp").addInput(this).buildSingletonOrThrow();
     }
 
+    /** {@inheritDoc} */
     @Override
     public NDArray gammaln() {
         throw new UnsupportedOperationException("Not implemented yet.");

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
@@ -830,6 +830,11 @@ public class TfNDArray extends NativeResource<TFE_TensorHandle> implements NDArr
         return manager.opExecutor("Exp").addInput(this).buildSingletonOrThrow();
     }
 
+    @Override
+    public NDArray gammaln() {
+        throw new UnsupportedOperationException("Not implemented yet.");
+    }
+
     /** {@inheritDoc} */
     @Override
     public NDArray log() {

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayCreationOpTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayCreationOpTest.java
@@ -446,4 +446,58 @@ public class NDArrayCreationOpTest {
             Assertions.assertAlmostEquals(expectedNormal, actualNormal, 1e-2f, 1e-2f);
         }
     }
+
+    @Test
+    public void testSamplePoisson() {
+        try (NDManager manager = NDManager.newBaseManager()) {
+            manager.getEngine().setRandomSeed(100);
+            NDArray lam = manager.create(new double[] {1., 8.5});
+            NDArray expected = manager.create(new double[] {1., 11.});
+            NDArray poisson = manager.samplePoisson(lam);
+            Assertions.assertAlmostEquals(poisson, expected);
+            expected =
+                    manager.create(new double[] {1., 1., 1., 2., 9., 10., 11., 10.})
+                            .reshape(new Shape(2, 2, 2));
+            poisson = manager.samplePoisson(lam, new Shape(2, 2));
+            Assertions.assertAlmostEquals(poisson, expected);
+        }
+    }
+
+    public void testSampleGamma() {
+        try (NDManager manager = NDManager.newBaseManager()) {
+            manager.getEngine().setRandomSeed(100);
+            NDArray alpha = manager.create(new double[] {0., 2.5});
+            NDArray beta = manager.create(new double[] {1., 0.7});
+            NDArray expected = manager.create(new double[] {0., 2.4592676});
+            NDArray gamma = manager.sampleGamma(alpha, beta);
+            Assertions.assertAlmostEquals(gamma, expected);
+            expected =
+                    manager.create(
+                                    new double[] {
+                                        0., 0., 0., 0., 2.286353, 0.90269035, 2.0772479, 3.3737767
+                                    })
+                            .reshape(new Shape(2, 2, 2));
+            gamma = manager.sampleGamma(alpha, beta, new Shape(2, 2));
+            Assertions.assertAlmostEquals(gamma, expected);
+        }
+    }
+
+    public void testSampleNormal() {
+        try (NDManager manager = NDManager.newBaseManager()) {
+            manager.getEngine().setRandomSeed(100);
+            NDArray alpha = manager.create(new double[] {0., 2.5});
+            NDArray beta = manager.create(new double[] {1., 3.7});
+            NDArray expected = manager.create(new double[] {0., 12.998987});
+            NDArray gamma = manager.sampleGamma(alpha, beta);
+            Assertions.assertAlmostEquals(gamma, expected);
+            expected =
+                    manager.create(
+                                    new double[] {
+                                        0., 0., 0., 0., 12.085011, 4.7713637, 10.979739, 17.83282
+                                    })
+                            .reshape(new Shape(2, 2, 2));
+            gamma = manager.sampleGamma(alpha, beta, new Shape(2, 2));
+            Assertions.assertAlmostEquals(gamma, expected);
+        }
+    }
 }

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayCreationOpTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayCreationOpTest.java
@@ -450,56 +450,64 @@ public class NDArrayCreationOpTest {
     @Test
     public void testSamplePoisson() {
         try (NDManager manager = NDManager.newBaseManager()) {
-            manager.getEngine().setRandomSeed(100);
             NDArray lam = manager.create(new double[] {1., 8.5});
-            NDArray expected = manager.create(new double[] {1., 11.});
+
             NDArray poisson = manager.samplePoisson(lam);
-            Assertions.assertAlmostEquals(poisson, expected);
-            expected =
-                    manager.create(new double[] {1., 1., 1., 2., 9., 10., 11., 10.})
-                            .reshape(new Shape(2, 2, 2));
-            poisson = manager.samplePoisson(lam, new Shape(2, 2));
-            Assertions.assertAlmostEquals(poisson, expected);
+            Assert.assertEquals(poisson.getShape(), new Shape(2));
+
+            poisson = manager.samplePoisson(lam, new Shape(1000, 1000));
+            Assert.assertEquals(poisson.getShape(), new Shape(2, 1000, 1000));
+
+            NDArray mean = poisson.mean(new int[] {1, 2});
+            NDArray std = poisson.transpose(1, 2, 0).sub(mean).pow(2).mean(new int[] {0, 1});
+
+            Assertions.assertAlmostEquals(mean.toFloatArray()[0], 1f, 2e-2f, 2e-2f);
+            Assertions.assertAlmostEquals(mean.toFloatArray()[1], 8.5f, 2e-2f, 2e-2f);
+            Assertions.assertAlmostEquals(std.toFloatArray()[0], 1f, 2e-2f, 2e-2f);
+            Assertions.assertAlmostEquals(std.toFloatArray()[1], 8.5f, 2e-2f, 2e-2f);
         }
     }
 
     @Test
     public void testSampleGamma() {
         try (NDManager manager = NDManager.newBaseManager()) {
-            manager.getEngine().setRandomSeed(100);
             NDArray alpha = manager.create(new double[] {0., 2.5});
             NDArray beta = manager.create(new double[] {1., 0.7});
-            NDArray expected = manager.create(new double[] {0., 2.4592676});
+
             NDArray gamma = manager.sampleGamma(alpha, beta);
-            Assertions.assertAlmostEquals(gamma, expected);
-            expected =
-                    manager.create(
-                                    new double[] {
-                                        0., 0., 0., 0., 2.286353, 0.90269035, 2.0772479, 3.3737767
-                                    })
-                            .reshape(new Shape(2, 2, 2));
-            gamma = manager.sampleGamma(alpha, beta, new Shape(2, 2));
-            Assertions.assertAlmostEquals(gamma, expected);
+            Assert.assertEquals(gamma.getShape(), new Shape(2));
+
+            gamma = manager.sampleGamma(alpha, beta, new Shape(1000, 1000));
+            Assert.assertEquals(gamma.getShape(), new Shape(2, 1000, 1000));
+
+            NDArray mean = gamma.mean(new int[] {1, 2});
+            NDArray std = gamma.transpose(1, 2, 0).sub(mean).pow(2).mean(new int[] {0, 1});
+
+            Assertions.assertAlmostEquals(mean.toFloatArray()[0], 0f, 2e-2f, 2e-2f);
+            Assertions.assertAlmostEquals(mean.toFloatArray()[1], 1.75f, 2e-2f, 2e-2f);
+            Assertions.assertAlmostEquals(std.toFloatArray()[0], 0f, 2e-2f, 2e-2f);
+            Assertions.assertAlmostEquals(std.toFloatArray()[1], 1.225f, 2e-2f, 2e-2f);
         }
     }
 
     @Test
     public void testSampleNormal() {
         try (NDManager manager = NDManager.newBaseManager()) {
-            manager.getEngine().setRandomSeed(100);
-            NDArray alpha = manager.create(new double[] {0., 2.5});
-            NDArray beta = manager.create(new double[] {1., 3.7});
-            NDArray expected = manager.create(new double[] {0., 12.998987});
-            NDArray gamma = manager.sampleGamma(alpha, beta);
-            Assertions.assertAlmostEquals(gamma, expected);
-            expected =
-                    manager.create(
-                                    new double[] {
-                                        0., 0., 0., 0., 12.085011, 4.7713637, 10.979739, 17.83282
-                                    })
-                            .reshape(new Shape(2, 2, 2));
-            gamma = manager.sampleGamma(alpha, beta, new Shape(2, 2));
-            Assertions.assertAlmostEquals(gamma, expected);
+            NDArray mu = manager.create(new double[] {0., 2.5});
+            NDArray sigma = manager.create(new double[] {1., 3.7});
+            NDArray normal = manager.sampleNormal(mu, sigma);
+            Assert.assertEquals(normal.getShape(), new Shape(2));
+
+            normal = manager.sampleNormal(mu, sigma, new Shape(1000, 1000));
+            Assert.assertEquals(normal.getShape(), new Shape(2, 1000, 1000));
+
+            NDArray mean = normal.mean(new int[] {1, 2});
+            NDArray std = normal.transpose(1, 2, 0).sub(mean).pow(2).mean(new int[] {0, 1});
+
+            Assertions.assertAlmostEquals(mean.toFloatArray()[0], 0f, 2e-2f, 2e-2f);
+            Assertions.assertAlmostEquals(mean.toFloatArray()[1], 2.5f, 2e-2f, 2e-2f);
+            Assertions.assertAlmostEquals(std.toFloatArray()[0], 1f, 2e-2f, 2e-2f);
+            Assertions.assertAlmostEquals(std.toFloatArray()[1], 13.69f, 2e-2f, 2e-2f);
         }
     }
 }

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayCreationOpTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayCreationOpTest.java
@@ -463,6 +463,7 @@ public class NDArrayCreationOpTest {
         }
     }
 
+    @Test
     public void testSampleGamma() {
         try (NDManager manager = NDManager.newBaseManager()) {
             manager.getEngine().setRandomSeed(100);
@@ -482,6 +483,7 @@ public class NDArrayCreationOpTest {
         }
     }
 
+    @Test
     public void testSampleNormal() {
         try (NDManager manager = NDManager.newBaseManager()) {
             manager.getEngine().setRandomSeed(100);

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayNumericOpTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayNumericOpTest.java
@@ -258,6 +258,30 @@ public class NDArrayNumericOpTest {
     }
 
     @Test
+    public void testGammaln() {
+        try (NDManager manager = NDManager.newBaseManager()) {
+            double[] data = {0.5, 1., 1.3782, 1.5};
+            NDArray array = manager.create(data);
+            data = new double[] {0.5724, 0.0000, -0.1180, -0.1208};
+            NDArray expected = manager.create(data);
+            Assertions.assertAlmostEquals(array.gammaln(), expected);
+            // test multi-dim
+            array = manager.create(new float[] {0.1f, 0.2f, 0.3f, 0.4f}, new Shape(2, 2));
+            expected =
+                    manager.create(
+                            new float[] {2.2527f, 1.5241f, 1.0958f, 0.7967f}, new Shape(2, 2));
+            Assertions.assertAlmostEquals(array.gammaln(), expected);
+            // test scalar
+            array = manager.create(0.8f);
+            expected = manager.create(0.1521f);
+            Assertions.assertAlmostEquals(array.gammaln(), expected);
+            // test zero-dim
+            array = manager.create(new Shape(0, 3, 3, 2));
+            Assertions.assertAlmostEquals(array.gammaln(), array);
+        }
+    }
+
+    @Test
     public void testLog() {
         try (NDManager manager = NDManager.newBaseManager()) {
             double[] data = {1.0, 2.2312, 3.584, 4.343234, 5.11111, 223.23423};


### PR DESCRIPTION
## Description ##

This PR implements several function. 

**gammaln** is the same as the log gamma function of [torch.lgamma](https://pytorch.org/docs/stable/generated/torch.lgamma.html), [mxnet.nd.gammaln](https://mxnet.apache.org/versions/1.9.1/api/python/docs/api/ndarray/ndarray.html?highlight=gammaln#mxnet.ndarray.gammaln).
It is used in the distributions package of torch and mxnet to calculate the probability density at the value, and this result can be used for the loss function calculation of the predicting probability distribution model.  This is the training process.

**sample** is the same as the sample distribution function of [torch.distributions.Distribution.sample](https://pytorch.org/docs/stable/distributions.html#torch.distributions.distribution.Distribution.sample), [mxnet.nd.sample_xxx](https://mxnet.apache.org/versions/1.9.1/api/python/docs/api/ndarray/op/index.html?highlight=sample_poisson#mxnet.ndarray.op.sample_poisson)
It is used in the ditributions package to draw samples from corresponding distribution. The samples serve as inference outputs of the model and can be converted to Forecast through TimeSeriesTranslator. This is the inference process.

**I'm not sure which java class the sample_xxx function should be placed in. I put them in the NDManager for the time being, because these functions look similar to NDManager.random functions.**