### PR TITLE
Fix memory leak in mxnet layerNorm().

### DIFF
--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayEx.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayEx.java
@@ -668,10 +668,7 @@ class MxNDArrayEx implements NDArrayEx {
                 getManager()
                         .invoke(
                                 "_npx_layer_norm",
-                                new NDList(
-                                        reshapedInput,
-                                        reshapedGamma,
-                                        reshapedBeta),
+                                new NDList(reshapedInput, reshapedGamma, reshapedBeta),
                                 params)
                         .get(0)
                         .reshape(input.getShape()));

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayEx.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayEx.java
@@ -656,14 +656,22 @@ class MxNDArrayEx implements NDArrayEx {
                                                         - normalizedShape.dimension()))
                                 .add(normalizedShape.size()));
 
+        // Cause of gamma and betta attached to model manager we must attach them to input NDManager
+        // to avoid memory leak.
+        final NDArray reshapedGamma = gamma.reshape(normalizedShape.size());
+        final NDArray reshapedBeta = beta.reshape(normalizedShape.size());
+        final NDManager inputManager = input.getManager();
+        reshapedBeta.attach(inputManager);
+        reshapedGamma.attach(inputManager);
+
         return new NDList(
                 getManager()
                         .invoke(
                                 "_npx_layer_norm",
                                 new NDList(
                                         reshapedInput,
-                                        gamma.reshape(normalizedShape.size()),
-                                        beta.reshape(normalizedShape.size())),
+                                        reshapedGamma,
+                                        reshapedBeta),
                                 params)
                         .get(0)
                         .reshape(input.getShape()));


### PR DESCRIPTION
Memory leaks in mxnet NDArrays when using layerNorm() because of reshaping parameters right in the model NDManager.
