### PR TITLE
LSTM : padding when the size of input is 2

### DIFF
--- a/api/src/main/java/ai/djl/nn/recurrent/LSTM.java
+++ b/api/src/main/java/ai/djl/nn/recurrent/LSTM.java
@@ -77,6 +77,16 @@ public class LSTM extends RecurrentBlock {
             // cell
             inputs.add(input.getManager().zeros(stateShape));
         }
+        if (inputs.size() == 2) {
+            int batchIndex = batchFirst ? 0 : 1;
+            Shape stateShape =
+                    new Shape(
+                            (long) numLayers * getNumDirections(),
+                            input.size(batchIndex),
+                            stateSize);
+            // cell
+            inputs.add(input.getManager().zeros(stateShape));
+        }
         NDList outputs =
                 ex.lstm(
                         input,


### PR DESCRIPTION
This is a bug fix patch.

LSTM requires two inputs.
Tested with https://d2l.djl.ai/chapter_recurrent-modern/lstm.html and https://d2l.djl.ai/chapter_recurrent-modern/deep-rnn.html
