### PR TITLE
[tokenizers] support stride in tokenizers

### DIFF
--- a/extensions/tokenizers/rust/src/lib.rs
+++ b/extensions/tokenizers/rust/src/lib.rs
@@ -378,6 +378,25 @@ pub extern "system" fn Java_ai_djl_huggingface_tokenizers_jni_TokenizersLibrary_
 }
 
 #[no_mangle]
+pub extern "system" fn Java_ai_djl_huggingface_tokenizers_jni_TokenizersLibrary_getOverflowing(
+    env: JNIEnv,
+    _: JObject,
+    handle: jlong,
+) -> jlongArray {
+    let encoding = cast_handle::<Encoding>(handle);
+    let handles = encoding
+            .get_overflowing()
+            .clone()
+            .into_iter()
+            .map(|c| to_handle(c))
+            .collect::<Vec<_>>();
+    let size = handles.len() as jsize;
+    let ret = env.new_long_array(size).unwrap();
+    env.set_long_array_region(ret, 0, &handles).unwrap();
+    ret
+}
+
+#[no_mangle]
 pub extern "system" fn Java_ai_djl_huggingface_tokenizers_jni_TokenizersLibrary_decode(
     env: JNIEnv,
     _: JObject,

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/Encoding.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/Encoding.java
@@ -24,6 +24,7 @@ public class Encoding {
     private long[] attentionMask;
     private long[] specialTokenMask;
     private CharSpan[] charTokenSpans;
+    private Encoding[] overflowing;
 
     protected Encoding(
             long[] ids,
@@ -32,7 +33,8 @@ public class Encoding {
             long[] wordIds,
             long[] attentionMask,
             long[] specialTokenMask,
-            CharSpan[] charTokenSpans) {
+            CharSpan[] charTokenSpans,
+            Encoding[] overflowing) {
         this.ids = ids;
         this.typeIds = typeIds;
         this.tokens = tokens;
@@ -40,6 +42,7 @@ public class Encoding {
         this.attentionMask = attentionMask;
         this.specialTokenMask = specialTokenMask;
         this.charTokenSpans = charTokenSpans;
+        this.overflowing = overflowing;
     }
 
     /**
@@ -103,5 +106,14 @@ public class Encoding {
      */
     public CharSpan[] getCharTokenSpans() {
         return charTokenSpans;
+    }
+
+    /**
+     * Returns an array of overflowing encodings.
+     *
+     * @return the array of overflowing encodings
+     */
+    public Encoding[] getOverflowing() {
+        return overflowing;
     }
 }

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizer.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizer.java
@@ -419,10 +419,23 @@ public final class HuggingFaceTokenizer extends NativeResource<Long> implements 
         long[] attentionMask = TokenizersLibrary.LIB.getAttentionMask(encoding);
         long[] specialTokenMask = TokenizersLibrary.LIB.getSpecialTokenMask(encoding);
         CharSpan[] charSpans = TokenizersLibrary.LIB.getTokenCharSpans(encoding);
+        long[] overflowingHandles = TokenizersLibrary.LIB.getOverflowing(encoding);
+
+        Encoding[] overflowing = new Encoding[overflowingHandles.length];
+        for (int i = 0; i < overflowingHandles.length; ++i) {
+            overflowing[i] = toEncoding(overflowingHandles[i]);
+        }
 
         TokenizersLibrary.LIB.deleteEncoding(encoding);
         return new Encoding(
-                ids, typeIds, tokens, wordIds, attentionMask, specialTokenMask, charSpans);
+                ids,
+                typeIds,
+                tokens,
+                wordIds,
+                attentionMask,
+                specialTokenMask,
+                charSpans,
+                overflowing);
     }
 
     /** {@inheritDoc} */
@@ -618,6 +631,18 @@ public final class HuggingFaceTokenizer extends NativeResource<Long> implements 
          */
         public Builder optPadToMultipleOf(int padToMultipleOf) {
             options.put("padToMultipleOf", String.valueOf(padToMultipleOf));
+            return this;
+        }
+
+        /**
+         * Sets the stride to use in overflow overlap when truncating sequences longer than the
+         * model supports.
+         *
+         * @param stride the number of tokens to overlap when truncating long sequences
+         * @return this builder
+         */
+        public Builder optStride(int stride) {
+            options.put("stride", String.valueOf(stride));
             return this;
         }
 

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/TokenizersLibrary.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/TokenizersLibrary.java
@@ -51,6 +51,8 @@ public final class TokenizersLibrary {
 
     public native CharSpan[] getTokenCharSpans(long encoding);
 
+    public native long[] getOverflowing(long encoding);
+
     public native String decode(long tokenizer, long[] ids, boolean addSpecialTokens);
 
     public native String getTruncationStrategy(long tokenizer);


### PR DESCRIPTION
## Description ##

This PR adds support for utilizing the stride parameter in truncation. Users can now pass in the stride value and get the overflowing encodings. See https://github.com/deepjavalibrary/djl/issues/1996

One thought I had is whether we should add a flag to the tokenizer that indicates whether a user wants overflows returned. I'm not sure how often these overflows are used in practice, but I imagine there are cases where tokenization results in overflow but the user doesn't care about them. We could avoid JNI calls in these situations by adding a flag. 
