### PR TITLE
[fix] DynamicBuffer position error when expand for the firtst time

### DIFF
--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/utils/DynamicBuffer.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/utils/DynamicBuffer.java
@@ -33,13 +33,13 @@ public class DynamicBuffer {
      */
     public DynamicBuffer put(float f) {
         ++length;
+        buffer.put(f);
         if (buffer.capacity() == length) {
             FloatBuffer buf = buffer;
             buf.rewind();
             buffer = FloatBuffer.allocate(length * 2);
             buffer.put(buf);
         }
-        buffer.put(f);
         return this;
     }
 

--- a/basicdataset/src/test/java/ai/djl/basicdataset/DatasetUtilsTest.java
+++ b/basicdataset/src/test/java/ai/djl/basicdataset/DatasetUtilsTest.java
@@ -13,6 +13,7 @@
 package ai.djl.basicdataset;
 
 import ai.djl.Device;
+import ai.djl.basicdataset.tabular.utils.DynamicBuffer;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.NDManager;
@@ -24,6 +25,9 @@ import ai.djl.translate.Batchifier;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.nio.FloatBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 public class DatasetUtilsTest {
@@ -160,5 +164,35 @@ public class DatasetUtilsTest {
                         fromDef[i].singletonOrThrow(), fromStack[i].singletonOrThrow());
             }
         }
+    }
+
+    @Test
+    public void testDynamicBuffer() {
+        DynamicBuffer bb = new DynamicBuffer();
+        // Do not expand
+        for (int i = 0; i < 128; i++) {
+            bb.put((float) i);
+        }
+        FloatBuffer buf = bb.getBuffer();
+        Assert.assertEquals(buf.limit(), 128);
+        Assert.assertEquals(buf.get(127), 127f);
+
+        bb = new DynamicBuffer();
+        // expand 1 time
+        for (int i = 0; i < 129; i++) {
+            bb.put((float) i);
+        }
+        buf = bb.getBuffer();
+        Assert.assertEquals(buf.limit(), 129);
+        Assert.assertEquals(buf.get(128), 128f);
+
+        bb = new DynamicBuffer();
+        // expand 2 times
+        for (int i = 0; i < 257; i++) {
+            bb.put((float) i);
+        }
+        buf = bb.getBuffer();
+        Assert.assertEquals(buf.limit(), 257);
+        Assert.assertEquals(buf.get(256), 256f);
     }
 }

--- a/basicdataset/src/test/java/ai/djl/basicdataset/DatasetUtilsTest.java
+++ b/basicdataset/src/test/java/ai/djl/basicdataset/DatasetUtilsTest.java
@@ -26,8 +26,6 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.nio.FloatBuffer;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Locale;
 
 public class DatasetUtilsTest {


### PR DESCRIPTION
## Description ##

When the DynamicBuffer exapnd for the first time, its FloatBuffer.position would incorrectly increase by 1 resulting in an error in the location of subsequent data.

**details** 
This can reproduce the error
```java
DynamicBuffer bb = new DynamicBuffer();
for (int i = 0; i < 129; i++) {
    bb.put((float) i);
}
FloatBuffer buf = bb.getBuffer();
float value = buf.get(128); // This value should be 128f but got 0f.
```
This problem arises because DynamicBuffer expands when it is about to be full but not yet full, and adds the content before the expansion to the expanded Buffer, **but because it is not yet full, the last position before the expansion of the element is not filled, and it is also added to the new Buffer**, resulting in the position error of subsequent elements