### PR TITLE
Fix dlr-native build script

### DIFF
--- a/engines/dlr/dlr-native/build.sh
+++ b/engines/dlr/dlr-native/build.sh
@@ -10,7 +10,7 @@ elif [[ -n $(command -v sysctl) ]]; then
     NUM_PROC=$(sysctl -n hw.ncpu)
 fi
 
-VERSION=v"$(cat ../../gradle.properties | awk -F '=' '/dlr_version/ {print $2}')"
+VERSION=v"$(cat ../../../gradle.properties | awk -F '=' '/dlr_version/ {print $2}')"
 
 if [ ! -d "neo-ai-dlr" ];
 then


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Fix dlr-native build script. The gradle.properties should be 3 levels up instead of 2.