### PR TITLE
[pytorch] Fixes folder not exist bug when use external pytorch native library

### DIFF
--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
@@ -253,6 +253,7 @@ public final class LibUtils {
         String libPath = "jnilib/" + classifier + '/' + flavor + '/' + JNI_LIB_NAME;
         logger.info("Extracting {} to cache ...", libPath);
         try (InputStream is = ClassLoaderUtils.getResourceAsStream(libPath)) {
+            Files.createDirectories(dir);
             tmp = Files.createTempFile(dir, "jni", "tmp");
             Files.copy(is, tmp, StandardCopyOption.REPLACE_EXISTING);
             Utils.moveQuietly(tmp, path);


### PR DESCRIPTION
Change-Id: I03070f80a0d6a73bbf209bd1de9f31e348e7c142

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
