### PR TITLE
Add support for Apples' Metal Performance Shaders (MPS) in pytorch

### DIFF
--- a/api/src/main/java/ai/djl/Device.java
+++ b/api/src/main/java/ai/djl/Device.java
@@ -21,10 +21,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * The {@code Device} class provides the specified assignment for CPU/GPU processing on the {@code
+ * The {@code Device} class provides the specified assignment for CPU/GPU/MPS processing on the {@code
  * NDArray}.
  *
- * <p>Users can use this to specify whether to load/compute the {@code NDArray} on CPU/GPU with
+ * <p>Users can use this to specify whether to load/compute the {@code NDArray} on CPU/GPU/MPS with
  * deviceType and deviceId provided.
  *
  * @see <a href="https://d2l.djl.ai/chapter_deep-learning-computation/use-gpu.html">The D2L chapter
@@ -36,6 +36,7 @@ public final class Device {
 
     private static final Device CPU = new Device(Type.CPU, -1);
     private static final Device GPU = Device.of(Type.GPU, 0);
+    private static final Device MPS = Device.of(Type.MPS, -1);
 
     private static final Pattern DEVICE_NAME = Pattern.compile("([a-z]+)([0-9]*)");
 
@@ -45,7 +46,7 @@ public final class Device {
     /**
      * Creates a {@code Device} with basic information.
      *
-     * @param deviceType the device type, typically CPU or GPU
+     * @param deviceType the device type, typically CPU, GPU, or MPS
      * @param deviceId the deviceId on the hardware. For example, if you have multiple GPUs, you can
      *     choose which GPU to process the NDArray
      */
@@ -57,7 +58,7 @@ public final class Device {
     /**
      * Returns a {@code Device} with device type and device id.
      *
-     * @param deviceType the device type, typically CPU or GPU
+     * @param deviceType the device type, typically CPU, GPU, or MPS
      * @param deviceId the deviceId on the hardware.
      * @return a {@code Device} instance
      */
@@ -83,7 +84,7 @@ public final class Device {
     /**
      * Parses a deviceName string into a device.
      *
-     * <p>The main format of a device name string is "cpu", "gpu0", or "nc1". This is simply
+     * <p>The main format of a device name string is "cpu", "gpu0","mps", or "nc1". This is simply
      * deviceType concatenated with the deviceId. If no deviceId is used, -1 will be assumed.
      *
      * <p>There are also several simplified formats. The "-1", deviceNames corresponds to cpu.
@@ -150,6 +151,15 @@ public final class Device {
         return Type.GPU.equals(deviceType);
     }
 
+    /**
+     * Returns if the {@code Device} is MPS.
+     *
+     * @return if the {@code Device} is MPS.
+     */
+    public boolean isMps() {
+        return Type.MPS.equals(deviceType);
+    }
+
     /** {@inheritDoc} */
     @Override
     public String toString() {
@@ -209,9 +219,17 @@ public final class Device {
         return of(Type.GPU, deviceId);
     }
 
+    /**
+     * Returns the default  Metal Performance Shaders (MPS) Device.
+     *
+     * @return the default MPS Device
+     */
+    public static Device mps() { return MPS; }
+
     /** Contains device type string constants. */
     public interface Type {
         String CPU = "cpu";
         String GPU = "gpu";
+        String MPS = "mps";
     }
 }

--- a/api/src/main/java/ai/djl/Device.java
+++ b/api/src/main/java/ai/djl/Device.java
@@ -21,8 +21,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * The {@code Device} class provides the specified assignment for CPU/GPU/MPS processing on the {@code
- * NDArray}.
+ * The {@code Device} class provides the specified assignment for CPU/GPU/MPS processing on the
+ * {@code NDArray}.
  *
  * <p>Users can use this to specify whether to load/compute the {@code NDArray} on CPU/GPU/MPS with
  * deviceType and deviceId provided.
@@ -220,11 +220,13 @@ public final class Device {
     }
 
     /**
-     * Returns the default  Metal Performance Shaders (MPS) Device.
+     * Returns the default Metal Performance Shaders (MPS) Device.
      *
      * @return the default MPS Device
      */
-    public static Device mps() { return MPS; }
+    public static Device mps() {
+        return MPS;
+    }
 
     /** Contains device type string constants. */
     public interface Type {

--- a/api/src/main/java/ai/djl/Device.java
+++ b/api/src/main/java/ai/djl/Device.java
@@ -21,10 +21,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * The {@code Device} class provides the specified assignment for CPU/GPU/MPS processing on the
- * {@code NDArray}.
+ * The {@code Device} class provides the specified assignment for CPU/GPU processing on the {@code
+ * NDArray}.
  *
- * <p>Users can use this to specify whether to load/compute the {@code NDArray} on CPU/GPU/MPS with
+ * <p>Users can use this to specify whether to load/compute the {@code NDArray} on CPU/GPU with
  * deviceType and deviceId provided.
  *
  * @see <a href="https://d2l.djl.ai/chapter_deep-learning-computation/use-gpu.html">The D2L chapter
@@ -36,7 +36,6 @@ public final class Device {
 
     private static final Device CPU = new Device(Type.CPU, -1);
     private static final Device GPU = Device.of(Type.GPU, 0);
-    private static final Device MPS = Device.of(Type.MPS, -1);
 
     private static final Pattern DEVICE_NAME = Pattern.compile("([a-z]+)([0-9]*)");
 
@@ -46,7 +45,7 @@ public final class Device {
     /**
      * Creates a {@code Device} with basic information.
      *
-     * @param deviceType the device type, typically CPU, GPU, or MPS
+     * @param deviceType the device type, typically CPU or GPU
      * @param deviceId the deviceId on the hardware. For example, if you have multiple GPUs, you can
      *     choose which GPU to process the NDArray
      */
@@ -58,7 +57,7 @@ public final class Device {
     /**
      * Returns a {@code Device} with device type and device id.
      *
-     * @param deviceType the device type, typically CPU, GPU, or MPS
+     * @param deviceType the device type, typically CPU or GPU
      * @param deviceId the deviceId on the hardware.
      * @return a {@code Device} instance
      */
@@ -84,7 +83,7 @@ public final class Device {
     /**
      * Parses a deviceName string into a device.
      *
-     * <p>The main format of a device name string is "cpu", "gpu0","mps", or "nc1". This is simply
+     * <p>The main format of a device name string is "cpu", "gpu0", or "nc1". This is simply
      * deviceType concatenated with the deviceId. If no deviceId is used, -1 will be assumed.
      *
      * <p>There are also several simplified formats. The "-1", deviceNames corresponds to cpu.
@@ -151,15 +150,6 @@ public final class Device {
         return Type.GPU.equals(deviceType);
     }
 
-    /**
-     * Returns if the {@code Device} is MPS.
-     *
-     * @return if the {@code Device} is MPS.
-     */
-    public boolean isMps() {
-        return Type.MPS.equals(deviceType);
-    }
-
     /** {@inheritDoc} */
     @Override
     public String toString() {
@@ -219,19 +209,9 @@ public final class Device {
         return of(Type.GPU, deviceId);
     }
 
-    /**
-     * Returns the default Metal Performance Shaders (MPS) Device.
-     *
-     * @return the default MPS Device
-     */
-    public static Device mps() {
-        return MPS;
-    }
-
     /** Contains device type string constants. */
     public interface Type {
         String CPU = "cpu";
         String GPU = "gpu";
-        String MPS = "mps";
     }
 }

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtDeviceType.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtDeviceType.java
@@ -32,6 +32,8 @@ public final class PtDeviceType {
             return 0;
         } else if (Device.Type.GPU.equals(deviceType)) {
             return 1;
+        } else if (Device.Type.MPS.equals(deviceType)) {
+            return 13;
         } else {
             throw new IllegalArgumentException("Unsupported device: " + device.toString());
         }
@@ -49,6 +51,8 @@ public final class PtDeviceType {
                 return Device.Type.CPU;
             case 1:
                 return Device.Type.GPU;
+            case 13:
+                return Device.Type.MPS;
             default:
                 throw new IllegalArgumentException("Unsupported deviceType: " + deviceType);
         }

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtDeviceType.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtDeviceType.java
@@ -32,10 +32,10 @@ public final class PtDeviceType {
             return 0;
         } else if (Device.Type.GPU.equals(deviceType)) {
             return 1;
-        } else if (Device.Type.MPS.equals(deviceType)) {
+        } else if ("mps".equals(deviceType)) {
             return 13;
         } else {
-            throw new IllegalArgumentException("Unsupported device: " + device.toString());
+            throw new IllegalArgumentException("Unsupported device: " + device);
         }
     }
 
@@ -52,7 +52,7 @@ public final class PtDeviceType {
             case 1:
                 return Device.Type.GPU;
             case 13:
-                return Device.Type.MPS;
+                return "mps";
             default:
                 throw new IllegalArgumentException("Unsupported deviceType: " + deviceType);
         }

--- a/engines/pytorch/pytorch-engine/src/test/java/ai/djl/pytorch/integration/MpsTest.java
+++ b/engines/pytorch/pytorch-engine/src/test/java/ai/djl/pytorch/integration/MpsTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.pytorch.integration;
+
+import ai.djl.Device;
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDManager;
+import ai.djl.ndarray.types.Shape;
+
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+public class MpsTest {
+
+    @Test
+    public void testMps() {
+        if (!"aarch64".equals(System.getProperty("os.arch"))
+                || !System.getProperty("os.name").startsWith("Mac")) {
+            throw new SkipException("MPS test requires M1 macOS.");
+        }
+
+        Device device = Device.of("mps", -1);
+        try (NDManager manager = NDManager.newBaseManager(device)) {
+            NDArray array = manager.zeros(new Shape(1, 2));
+            Assert.assertEquals(array.getDevice().getDeviceType(), "mps");
+        }
+    }
+}


### PR DESCRIPTION
## Description ##
Pytorch 1.12 supports Apple’s Metal Performance Shaders (MPS) for accelerated training/inference. A simple test on HuggingFace models shows 2x-3x improvements on the inference latency over the CPU cores on an Apple M1Pro with 8 CPU and 14 GPU cores:
```
--------------------------------------------------------------------------------
Model:              roberta-hf
Device:             cpu()
Samples:            34
Model Input Length: 384
Metrics:
	Total: 140.206 ± 5.880      msec
	Inference: 138.794 ± 5.713      msec
	Preprocess: 0.441 ± 0.553      msec
	Postprocess: 0.824 ± 0.567      msec
--------------------------------------------------------------------------------
Model:              roberta-hf
Device:             mps(-1)
Samples:            34
Model Input Length: 384
Metrics:
	Total: 65.500 ± 9.166      msec
	Inference: 41.235 ± 6.198      msec
	Preprocess: 1.059 ± 0.338      msec
	Postprocess: 23.206 ± 6.794      msec

--------------------------------------------------------------------------------
```
This improvement has been requested by me in the DJL help slack channel, as well as more recently in #2018 . 

Brief description of what this PR is about

- Adds a new "MPS" device type and maps to the corresponding pytorch device type.

Some caveats:
- The "MPS" mode only works if  `torch::jit::load(path, device, map);`  is called with `device= torch::nullopt` as in torch  the model gets deserialized in 'legacy' mode, which only support CPU and GPU devices. The model get desiralized on the CPU and then can be converted to MPS. For this, in traced torch model's directory  in the file "serving.properties" the `option.mapLocation=false` should be set, which triggers this implementation already present in DJL native module.
Alternatively, the the following check can be added the pytorch-native module: https://github.com/deepjavalibrary/djl/blob/f097502b9fe7607203320c4aecee14c759e29d5e/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_inference.cc#L49-L52

``` 
if (jmap_location && (device.is_cpu() || device.is_cuda())) {
```

-  An env variable s of hould be set`PYTORCH_ENABLE_MPS_FALLBACK=1` as a work around a pytorch implementation deficiency of 'aten::index.Tensor' for MPS, see https://github.com/pytorch/pytorch/issues/77764


