### PR TITLE
Creates Ensembleable

### DIFF
--- a/api/src/main/java/ai/djl/modality/Classifications.java
+++ b/api/src/main/java/ai/djl/modality/Classifications.java
@@ -243,6 +243,11 @@ public class Classifications implements JsonSerializable, Ensembleable<Classific
             for (int i = 0; i < size; ++i) {
                 newProbabilities.set(i, newProbabilities.get(i) + c.probabilities.get(i));
             }
+            if (!c.classNames.equals(classNames)) {
+                throw new IllegalArgumentException(
+                        "Found a classNames mismatch during ensembling. All input Classifications"
+                                + " should have the same classNames, but some were different");
+            }
         }
         final int total = count;
         newProbabilities.replaceAll(p -> p / total);

--- a/api/src/main/java/ai/djl/translate/Ensembleable.java
+++ b/api/src/main/java/ai/djl/translate/Ensembleable.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.translate;
+
+import java.util.List;
+
+/**
+ * Represents a class that can be ensembled (or averaged).
+ *
+ * <p>Typically, ensembling is used for the output of models/translators. By averaging multiple
+ * models, it is often possible to get greater accuracy then running each model individually.
+ */
+public interface Ensembleable {
+
+    /**
+     * Finds the ensemble of a list of outputs.
+     *
+     * @param outputs the outputs to ensemble. It uses the caller class to determine how to
+     *     ensemble, but should include the caller object in the list.
+     * @return the ensembled (averaged) output
+     * @param <T> the type of object to ensemble. Usually also the type returned
+     */
+    <T extends Ensembleable> Ensembleable ensemble(List<T> outputs);
+}

--- a/api/src/main/java/ai/djl/translate/Ensembleable.java
+++ b/api/src/main/java/ai/djl/translate/Ensembleable.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.translate;
 
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -20,15 +21,30 @@ import java.util.List;
  * <p>Typically, ensembling is used for the output of models/translators. By averaging multiple
  * models, it is often possible to get greater accuracy then running each model individually.
  */
-public interface Ensembleable {
+public interface Ensembleable<T> {
+
+    /**
+     * Creates an ensembled output with a list of outputs.
+     *
+     * @param iterator the outputs to ensemble with. It uses the caller class to determine how to
+     *     ensemble.
+     * @return the ensembled (averaged) output
+     */
+    T ensembleWith(Iterator<T> iterator);
 
     /**
      * Finds the ensemble of a list of outputs.
      *
-     * @param outputs the outputs to ensemble. It uses the caller class to determine how to
-     *     ensemble, but should include the caller object in the list.
-     * @return the ensembled (averaged) output
+     * @param outputs the outputs to ensemble.
      * @param <T> the type of object to ensemble. Usually also the type returned
+     * @return the ensembled (averaged) output
      */
-    <T extends Ensembleable> Ensembleable ensemble(List<T> outputs);
+    static <T extends Ensembleable<T>> T ensemble(List<T> outputs) {
+        if (outputs.isEmpty()) {
+            return null;
+        }
+        Iterator<T> it = outputs.iterator();
+        T item = it.next();
+        return item.ensembleWith(it);
+    }
 }

--- a/api/src/test/java/ai/djl/modality/EnsembleTest.java
+++ b/api/src/test/java/ai/djl/modality/EnsembleTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.modality;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class EnsembleTest {
+
+    @Test
+    public void testEnsembleClassifications() {
+        List<String> classNames = Arrays.asList("a", "b", "c");
+        List<Classifications> list = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            double prob = i;
+            List<Double> probs = Arrays.asList(prob, prob, prob);
+            list.add(new Classifications(classNames, probs));
+        }
+        Classifications actual = list.get(0).ensemble(list);
+        Assert.assertEquals(actual.getClassNames(), classNames);
+        Assert.assertEquals(actual.getProbabilities(), Arrays.asList(1.0, 1.0, 1.0));
+    }
+}

--- a/api/src/test/java/ai/djl/modality/EnsembleTest.java
+++ b/api/src/test/java/ai/djl/modality/EnsembleTest.java
@@ -12,17 +12,23 @@
  */
 package ai.djl.modality;
 
+import ai.djl.translate.Ensembleable;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class EnsembleTest {
 
     @Test
     public void testEnsembleClassifications() {
+        Classifications actual = Ensembleable.ensemble(Collections.<Classifications>emptyList());
+        Assert.assertNull(actual);
+
         List<String> classNames = Arrays.asList("a", "b", "c");
         List<Classifications> list = new ArrayList<>();
         for (int i = 0; i < 3; i++) {
@@ -30,7 +36,8 @@ public class EnsembleTest {
             List<Double> probs = Arrays.asList(prob, prob, prob);
             list.add(new Classifications(classNames, probs));
         }
-        Classifications actual = list.get(0).ensemble(list);
+        actual = Ensembleable.ensemble(list);
+        Assert.assertNotNull(actual);
         Assert.assertEquals(actual.getClassNames(), classNames);
         Assert.assertEquals(actual.getProbabilities(), Arrays.asList(1.0, 1.0, 1.0));
     }

--- a/api/src/test/java/ai/djl/modality/EnsembleTest.java
+++ b/api/src/test/java/ai/djl/modality/EnsembleTest.java
@@ -40,5 +40,14 @@ public class EnsembleTest {
         Assert.assertNotNull(actual);
         Assert.assertEquals(actual.getClassNames(), classNames);
         Assert.assertEquals(actual.getProbabilities(), Arrays.asList(1.0, 1.0, 1.0));
+
+        Assert.assertThrows(
+                () -> {
+                    List<String> badClassNames = Arrays.asList("b", "c", "d");
+                    List<Classifications> badList = new ArrayList<>();
+                    badList.addAll(list);
+                    badList.add(new Classifications(badClassNames, Arrays.asList(1.0, 1.0, 1.0)));
+                    Ensembleable.ensemble(badList);
+                });
     }
 }


### PR DESCRIPTION
This creates a new interface Ensembleable to be used for translator outputs that can be ensembled or averaged together. The interface will later be used as part of workflows within DJL Serving.