### PR TITLE
Handle error when forget to initialize a child block

### DIFF
--- a/api/src/main/java/ai/djl/nn/Parameter.java
+++ b/api/src/main/java/ai/djl/nn/Parameter.java
@@ -120,7 +120,8 @@ public class Parameter implements AutoCloseable {
      */
     public NDArray getArray() {
         if (!isInitialized()) {
-            throw new IllegalStateException("The array has not been initialized");
+            throw new UninitializeParameterException(
+                    this, "The array for parameter \"" + getName() + "\" has not been initialized");
         }
         return array;
     }

--- a/api/src/main/java/ai/djl/nn/Parameter.java
+++ b/api/src/main/java/ai/djl/nn/Parameter.java
@@ -121,7 +121,7 @@ public class Parameter implements AutoCloseable {
     public NDArray getArray() {
         if (!isInitialized()) {
             throw new UninitializedParameterException(
-                    this, "The array for parameter \"" + getName() + "\" has not been initialized");
+                    "The array for parameter \"" + getName() + "\" has not been initialized");
         }
         return array;
     }

--- a/api/src/main/java/ai/djl/nn/Parameter.java
+++ b/api/src/main/java/ai/djl/nn/Parameter.java
@@ -120,7 +120,7 @@ public class Parameter implements AutoCloseable {
      */
     public NDArray getArray() {
         if (!isInitialized()) {
-            throw new UninitializeParameterException(
+            throw new UninitializedParameterException(
                     this, "The array for parameter \"" + getName() + "\" has not been initialized");
         }
         return array;

--- a/api/src/main/java/ai/djl/nn/UninitializeParameterException.java
+++ b/api/src/main/java/ai/djl/nn/UninitializeParameterException.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.nn;
+
+/** Thrown to indicate that a {@link Parameter} was not initialized. */
+public class UninitializeParameterException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+    private final Parameter parameter;
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to {@link #initCause}.
+     *
+     * @param parameter the parameter that was not initialized
+     * @param message the detail message that is saved for later retrieval by the {@link
+     *     #getMessage()} method
+     */
+    public UninitializeParameterException(Parameter parameter, String message) {
+        super(message);
+        this.parameter = parameter;
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * <p>Note that the detail message associated with {@code cause} is <i>not</i> automatically
+     * incorporated in this exception's detail message.
+     *
+     * @param parameter the parameter that was not initialized
+     * @param message the detail message that is saved for later retrieval by the {@link
+     *     #getMessage()} method
+     * @param cause the cause that is saved for later retrieval by the {@link #getCause()} method. A
+     *     {@code null} value is permitted, and indicates that the cause is nonexistent or unknown
+     */
+    public UninitializeParameterException(Parameter parameter, String message, Throwable cause) {
+        super(message, cause);
+        this.parameter = parameter;
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code
+     * (cause==null ? null : cause.toString())} which typically contains the class and detail
+     * message of {@code cause}. This constructor is useful for exceptions that are little more than
+     * wrappers for other throwables. For example, {@link java.security.PrivilegedActionException}.
+     *
+     * @param parameter the parameter that was not initialized
+     * @param cause the cause that is saved for later retrieval by the {@link #getCause()} method. A
+     *     {@code null} value is permitted, and indicates that the cause is nonexistent or unknown
+     */
+    public UninitializeParameterException(Parameter parameter, Throwable cause) {
+        super(cause);
+        this.parameter = parameter;
+    }
+
+    /**
+     * Returns the parameter that was not initialized.
+     *
+     * @return the parameter that was not initialized
+     */
+    public Parameter getParameter() {
+        return parameter;
+    }
+}

--- a/api/src/main/java/ai/djl/nn/UninitializedParameterException.java
+++ b/api/src/main/java/ai/djl/nn/UninitializedParameterException.java
@@ -16,19 +16,16 @@ package ai.djl.nn;
 public class UninitializedParameterException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
-    private final Parameter parameter;
 
     /**
      * Constructs a new exception with the specified detail message. The cause is not initialized,
      * and may subsequently be initialized by a call to {@link #initCause}.
      *
-     * @param parameter the parameter that was not initialized
      * @param message the detail message that is saved for later retrieval by the {@link
      *     #getMessage()} method
      */
-    public UninitializedParameterException(Parameter parameter, String message) {
+    public UninitializedParameterException(String message) {
         super(message);
-        this.parameter = parameter;
     }
 
     /**
@@ -37,15 +34,13 @@ public class UninitializedParameterException extends RuntimeException {
      * <p>Note that the detail message associated with {@code cause} is <i>not</i> automatically
      * incorporated in this exception's detail message.
      *
-     * @param parameter the parameter that was not initialized
      * @param message the detail message that is saved for later retrieval by the {@link
      *     #getMessage()} method
      * @param cause the cause that is saved for later retrieval by the {@link #getCause()} method. A
      *     {@code null} value is permitted, and indicates that the cause is nonexistent or unknown
      */
-    public UninitializedParameterException(Parameter parameter, String message, Throwable cause) {
+    public UninitializedParameterException(String message, Throwable cause) {
         super(message, cause);
-        this.parameter = parameter;
     }
 
     /**
@@ -54,21 +49,10 @@ public class UninitializedParameterException extends RuntimeException {
      * message of {@code cause}. This constructor is useful for exceptions that are little more than
      * wrappers for other throwables. For example, {@link java.security.PrivilegedActionException}.
      *
-     * @param parameter the parameter that was not initialized
      * @param cause the cause that is saved for later retrieval by the {@link #getCause()} method. A
      *     {@code null} value is permitted, and indicates that the cause is nonexistent or unknown
      */
-    public UninitializedParameterException(Parameter parameter, Throwable cause) {
+    public UninitializedParameterException(Throwable cause) {
         super(cause);
-        this.parameter = parameter;
-    }
-
-    /**
-     * Returns the parameter that was not initialized.
-     *
-     * @return the parameter that was not initialized
-     */
-    public Parameter getParameter() {
-        return parameter;
     }
 }

--- a/api/src/main/java/ai/djl/nn/UninitializedParameterException.java
+++ b/api/src/main/java/ai/djl/nn/UninitializedParameterException.java
@@ -13,7 +13,7 @@
 package ai.djl.nn;
 
 /** Thrown to indicate that a {@link Parameter} was not initialized. */
-public class UninitializeParameterException extends RuntimeException {
+public class UninitializedParameterException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
     private final Parameter parameter;
@@ -26,7 +26,7 @@ public class UninitializeParameterException extends RuntimeException {
      * @param message the detail message that is saved for later retrieval by the {@link
      *     #getMessage()} method
      */
-    public UninitializeParameterException(Parameter parameter, String message) {
+    public UninitializedParameterException(Parameter parameter, String message) {
         super(message);
         this.parameter = parameter;
     }
@@ -43,7 +43,7 @@ public class UninitializeParameterException extends RuntimeException {
      * @param cause the cause that is saved for later retrieval by the {@link #getCause()} method. A
      *     {@code null} value is permitted, and indicates that the cause is nonexistent or unknown
      */
-    public UninitializeParameterException(Parameter parameter, String message, Throwable cause) {
+    public UninitializedParameterException(Parameter parameter, String message, Throwable cause) {
         super(message, cause);
         this.parameter = parameter;
     }
@@ -58,7 +58,7 @@ public class UninitializeParameterException extends RuntimeException {
      * @param cause the cause that is saved for later retrieval by the {@link #getCause()} method. A
      *     {@code null} value is permitted, and indicates that the cause is nonexistent or unknown
      */
-    public UninitializeParameterException(Parameter parameter, Throwable cause) {
+    public UninitializedParameterException(Parameter parameter, Throwable cause) {
         super(cause);
         this.parameter = parameter;
     }

--- a/api/src/main/java/ai/djl/training/Trainer.java
+++ b/api/src/main/java/ai/djl/training/Trainer.java
@@ -21,6 +21,7 @@ import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.nn.Parameter;
+import ai.djl.nn.UninitializeParameterException;
 import ai.djl.training.dataset.Batch;
 import ai.djl.training.dataset.Dataset;
 import ai.djl.training.evaluator.Evaluator;
@@ -121,7 +122,20 @@ public class Trainer implements AutoCloseable {
                 .forEach(
                         pair -> {
                             for (Device device : devices) {
-                                parameterStore.getValue(pair.getValue(), device, true);
+                                try {
+                                    parameterStore.getValue(pair.getValue(), device, true);
+                                } catch (UninitializeParameterException e) {
+                                    throw new IllegalStateException(
+                                            "Failed to initialize parameter: "
+                                                    + pair.getKey()
+                                                    + ".\n"
+                                                    + "If you are defining a Block extending"
+                                                    + " AbstractBlock, check that you are"
+                                                    + " initializing all child blocks as part of"
+                                                    + " the overload for"
+                                                    + " AbstractBlock.initializeChildBlocks().",
+                                            e);
+                                }
                             }
                         });
     }

--- a/api/src/main/java/ai/djl/training/Trainer.java
+++ b/api/src/main/java/ai/djl/training/Trainer.java
@@ -21,7 +21,7 @@ import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.nn.Parameter;
-import ai.djl.nn.UninitializeParameterException;
+import ai.djl.nn.UninitializedParameterException;
 import ai.djl.training.dataset.Batch;
 import ai.djl.training.dataset.Dataset;
 import ai.djl.training.evaluator.Evaluator;
@@ -124,7 +124,7 @@ public class Trainer implements AutoCloseable {
                             for (Device device : devices) {
                                 try {
                                     parameterStore.getValue(pair.getValue(), device, true);
-                                } catch (UninitializeParameterException e) {
+                                } catch (UninitializedParameterException e) {
                                     throw new IllegalStateException(
                                             "Failed to initialize parameter: "
                                                     + pair.getKey()


### PR DESCRIPTION
This throws an error with a much clearer error message in case someone fails to initialize a child block. It should help greatly reduce the time it takes to debug the error in this situation.