### PR TITLE
enhance huggingface text embedding translator to support max length padding

### DIFF
--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/translator/TextEmbeddingTranslator.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/translator/TextEmbeddingTranslator.java
@@ -68,8 +68,7 @@ public class TextEmbeddingTranslator implements Translator<String, float[]> {
         NDManager manager = ctx.getNDManager();
         NDArray inputAttentionMask = manager.create(attentionMask).toType(DataType.FLOAT32, true);
         long[] shape = embeddings.getShape().getShape();
-        inputAttentionMask = inputAttentionMask.tile(shape[shape.length - 1]);
-        inputAttentionMask = inputAttentionMask.reshape(embeddings.getShape());
+        inputAttentionMask = inputAttentionMask.expandDims(-1).broadcast(shape);
         NDArray inputAttentionMaskSum = inputAttentionMask.sum(AXIS);
         NDArray clamp = inputAttentionMaskSum.clip(1e-9, 1e12);
         NDArray prod = embeddings.mul(inputAttentionMask);


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

## Description ##

Current huggingface text embedding can work if not padding to max length. For padding to max length, the output will be wrong. Check details on https://github.com/deepjavalibrary/djl/issues/2041

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
