### PR TITLE
Fix bug in OD TF saved model example

### DIFF
--- a/examples/src/main/java/ai/djl/examples/inference/ObjectDetectionWithTensorflowSavedModel.java
+++ b/examples/src/main/java/ai/djl/examples/inference/ObjectDetectionWithTensorflowSavedModel.java
@@ -88,7 +88,7 @@ public final class ObjectDetectionWithTensorflowSavedModel {
                         .setTypes(Image.class, DetectedObjects.class)
                         .optModelUrls(modelUrl)
                         // saved_model.pb file is in the subfolder of the model archive file
-                        .optModelName("ssd_mobilenet_v2_320x320_coco17_tpu-8/saved_model")
+                        .optModelName("saved_model")
                         .optTranslator(new MyTranslator())
                         .optEngine("TensorFlow")
                         .optProgress(new ProgressBar())


### PR DESCRIPTION
## Description ##
Fixes an issue with the model path in the criteria for this example. Seems like this example has been broken since https://github.com/deepjavalibrary/djl/commit/51b38b6b165aece86cb9952b3122abe25f8d428b, which added functionality that resolves to a subdir if only 1 exists under the top level modeldir. 


