### PR TITLE
Fix randomColor

### DIFF
--- a/android/core/src/main/java/ai/djl/android/core/BitmapImageFactory.java
+++ b/android/core/src/main/java/ai/djl/android/core/BitmapImageFactory.java
@@ -327,7 +327,7 @@ public class BitmapImageFactory extends ImageFactory {
 
         private int randomColor() {
             return Color.rgb(
-                    RandomUtils.nextInt(255), RandomUtils.nextInt(255), RandomUtils.nextInt(255));
+                    RandomUtils.nextInt(256), RandomUtils.nextInt(256), RandomUtils.nextInt(256));
         }
 
         private int darker(int color) {


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Fix randomColor because Random.nextInt() upper bound is exclusive, upper bound has to be 256 to have values from 0 to 255.

