### PR TITLE
[api] Allow to show NDArray content in Debugger 2

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/internal/NDFormat.java
+++ b/api/src/main/java/ai/djl/ndarray/internal/NDFormat.java
@@ -83,6 +83,7 @@ public abstract class NDFormat {
             sb.append(" hasGradient");
         }
         if (!withContent) {
+            sb.append("\nTo enable array display, check the \"Development Guideline->Debug\".\n");
             return sb.toString();
         }
 
@@ -114,9 +115,7 @@ public abstract class NDFormat {
             int maxDepth,
             int maxRows,
             int maxColumns) {
-        init(array);
         sb.append(LF);
-
         long size = array.size();
         long dimension = array.getShape().dimension();
         if (size == 0) {
@@ -130,6 +129,7 @@ public abstract class NDFormat {
         } else if (dimension > maxDepth) {
             sb.append("[ Exceed max print dimension ]");
         } else {
+            init(array);
             dump(sb, array, 0, true, maxRows, maxColumns);
         }
         return sb.toString();

--- a/api/src/main/java/ai/djl/ndarray/internal/NDFormat.java
+++ b/api/src/main/java/ai/djl/ndarray/internal/NDFormat.java
@@ -83,7 +83,7 @@ public abstract class NDFormat {
             sb.append(" hasGradient");
         }
         if (!withContent) {
-            sb.append("\nTo enable array display, check the \"Development Guideline->Debug\".\n");
+            sb.append("\nCheck the \"Development Guideline\"->Debug to enable array display.\n");
             return sb.toString();
         }
 

--- a/api/src/test/java/ai/djl/ndarray/internal/NDFormatTest.java
+++ b/api/src/test/java/ai/djl/ndarray/internal/NDFormatTest.java
@@ -136,4 +136,14 @@ public class NDFormatTest {
             Assert.assertEquals(str, "ND: (3) cpu() float64" + LF + "[  1.,   2., 100.]" + LF);
         }
     }
+
+    @Test
+    public void testLargeArray() {
+        try (NDManager manager = NDManager.newBaseManager()) {
+            NDArray large = manager.arange(0f, 100000000f).reshape(100, 100, 100, 100);
+            String str = large.toString();
+            Assert.assertEquals(
+                    str, "ND: (100, 100, 100, 100) cpu() float32\n[ Exceed max print size ]");
+        }
+    }
 }

--- a/docs/development/development_guideline.md
+++ b/docs/development/development_guideline.md
@@ -157,8 +157,8 @@ You can create your own NDArray renderer as follows:
 ![](img/custom_debug_view.png)
 
 Opening the IDE Settings/Preferences (`⌘ ,`), in *Java Type Renderer* section, you can enable array display by:
-- Change the "Use following expression" field to [toDebugString(true)](https://javadoc.io/static/ai.djl/api/0.19.0/ai/djl/ndarray/NDArray.html#toDebugString(boolean)) to show NDArray content
-- Change the "Use following expression" field to something like [toDebugString(100, 10, 10, 20, true)](https://javadoc.io/static/ai.djl/api/0.19.0/ai/djl/ndarray/NDArray.html#toDebugString(int,int,int,int,boolean))
+- Change the "Use following expression" field to `toDebugString(true)` to show NDArray content.
+- Change the "Use following expression" field to something like `toDebugString(100, 10, 10, 20, true)`.
 if you want to adjust the range of NDArray's debug output.
 - Check the "On-demand" option, if you want the IntelliJ to render the NDArray only on clicking the variable.
 

--- a/docs/development/development_guideline.md
+++ b/docs/development/development_guideline.md
@@ -156,7 +156,7 @@ IntelliJ allows you to [customize the data view in the Debug Tools](https://www.
 You can create your own NDArray renderer as follows:
 ![](img/custom_debug_view.png)
 
-Opening the IDE settings (`⌘ ,`), in *Java Type Renderer* section, you can:
+Opening the IDE settings (`⌘ ,`), in *Java Type Renderer* section, you can enable array display by:
 - Change the "Use following expression" field to [toDebugString(true)](https://javadoc.io/static/ai.djl/api/0.19.0/ai/djl/ndarray/NDArray.html#toDebugString-int-int-int-int-) to show NDArray content
 - Change the "Use following expression" field to something like [toDebugString(100, 10, 10, 20, true)](https://javadoc.io/static/ai.djl/api/0.19.0/ai/djl/ndarray/NDArray.html#toDebugString-int-int-int-int-)
 if you want to adjust the range of NDArray's debug output.

--- a/docs/development/development_guideline.md
+++ b/docs/development/development_guideline.md
@@ -156,9 +156,9 @@ IntelliJ allows you to [customize the data view in the Debug Tools](https://www.
 You can create your own NDArray renderer as follows:
 ![](img/custom_debug_view.png)
 
-Opening the IDE settings (`⌘ ,`), in *Java Type Renderer* section, you can enable array display by:
-- Change the "Use following expression" field to [toDebugString(true)](https://javadoc.io/static/ai.djl/api/0.19.0/ai/djl/ndarray/NDArray.html#toDebugString-int-int-int-int-) to show NDArray content
-- Change the "Use following expression" field to something like [toDebugString(100, 10, 10, 20, true)](https://javadoc.io/static/ai.djl/api/0.19.0/ai/djl/ndarray/NDArray.html#toDebugString-int-int-int-int-)
+Opening the IDE Settings/Preferences (`⌘ ,`), in *Java Type Renderer* section, you can enable array display by:
+- Change the "Use following expression" field to [toDebugString(true)](https://javadoc.io/static/ai.djl/api/0.19.0/ai/djl/ndarray/NDArray.html#toDebugString(boolean)) to show NDArray content
+- Change the "Use following expression" field to something like [toDebugString(100, 10, 10, 20, true)](https://javadoc.io/static/ai.djl/api/0.19.0/ai/djl/ndarray/NDArray.html#toDebugString(int,int,int,int,boolean))
 if you want to adjust the range of NDArray's debug output.
 - Check the "On-demand" option, if you want the IntelliJ to render the NDArray only on clicking the variable.
 

--- a/docs/development/development_guideline.md
+++ b/docs/development/development_guideline.md
@@ -156,12 +156,11 @@ IntelliJ allows you to [customize the data view in the Debug Tools](https://www.
 You can create your own NDArray renderer as follows:
 ![](img/custom_debug_view.png)
 
-Please make sure to:
-
-- Check the "On-demand" option, which causes IntelliJ to only render the NDArray when you click on the variable.
+Opening the IDE settings, in *Java Type Renderer* section, you can:
 - Change the "Use following expression" field to [toDebugString(true)](https://javadoc.io/static/ai.djl/api/0.19.0/ai/djl/ndarray/NDArray.html#toDebugString-int-int-int-int-) to show NDArray content
 - Change the "Use following expression" field to something like [toDebugString(100, 10, 10, 20, true)](https://javadoc.io/static/ai.djl/api/0.19.0/ai/djl/ndarray/NDArray.html#toDebugString-int-int-int-int-)
 if you want to adjust the range of NDArray's debug output.
+- Check the "On-demand" option, if you want the IntelliJ to render the NDArray only on clicking the variable.
 
 ## Common Problems
 

--- a/docs/development/development_guideline.md
+++ b/docs/development/development_guideline.md
@@ -159,8 +159,8 @@ You can create your own NDArray renderer as follows:
 Please make sure to:
 
 - Check the "On-demand" option, which causes IntelliJ to only render the NDArray when you click on the variable.
-- Change the "Use following expression" field to `toDebugString(true)` to show NDArray content
-- Change the "Use following expression" field to something like `toDebugString(1000, 10, 10, 20, true)`
+- Change the "Use following expression" field to [toDebugString(true)](https://javadoc.io/static/ai.djl/api/0.19.0/ai/djl/ndarray/NDArray.html#toDebugString-int-int-int-int-) to show NDArray content
+- Change the "Use following expression" field to something like [toDebugString(100, 10, 10, 20, true)](https://javadoc.io/static/ai.djl/api/0.19.0/ai/djl/ndarray/NDArray.html#toDebugString-int-int-int-int-)
 if you want to adjust the range of NDArray's debug output.
 
 ## Common Problems

--- a/docs/development/development_guideline.md
+++ b/docs/development/development_guideline.md
@@ -156,7 +156,7 @@ IntelliJ allows you to [customize the data view in the Debug Tools](https://www.
 You can create your own NDArray renderer as follows:
 ![](img/custom_debug_view.png)
 
-Opening the IDE settings, in *Java Type Renderer* section, you can:
+Opening the IDE settings (`⌘ ,`), in *Java Type Renderer* section, you can:
 - Change the "Use following expression" field to [toDebugString(true)](https://javadoc.io/static/ai.djl/api/0.19.0/ai/djl/ndarray/NDArray.html#toDebugString-int-int-int-int-) to show NDArray content
 - Change the "Use following expression" field to something like [toDebugString(100, 10, 10, 20, true)](https://javadoc.io/static/ai.djl/api/0.19.0/ai/djl/ndarray/NDArray.html#toDebugString-int-int-int-int-)
 if you want to adjust the range of NDArray's debug output.


### PR DESCRIPTION
## Description ##

The previous solution still suffers from a slowing down when printing the string outside the debugger mode. Here the solution is to utillize the existing pruning mechanism, and put the execution of `init(array)` also under the condition that the array is not too large.

A testing code is added.