### PR TITLE
Begin publishing DJL Zero

### DIFF
--- a/djl-zero/README.md
+++ b/djl-zero/README.md
@@ -2,14 +2,29 @@
 
 ## Overview
 
-This module is a zero deep learning knowledge required wrapper over DJL. Instead of worrying about finding a model or how to train, this will provide a simple recommendation for your deep learning application. It is the easiest way to get started with DJL and get a solution for your deep learning problem.
+This module is a zero deep learning knowledge required wrapper over DJL.
+Instead of worrying about finding a model or how to train, this will provide a simple recommendation for your deep learning application.
+It is the easiest way to get started with DJL and get a solution for your deep learning problem.
+
+DJL Zero is based on the [Application](https://javadoc.io/doc/ai.djl/api/latest/ai/djl/Application.html) or the common deep learning task you wish to train.
+It features an automatic training method (if currently implemented) and an automatic recommendation for pre-trained models (if applicable for the application).
+
+The automatic training method is designed to be simple and requires only two parameters.
+First is a `Dataset`, which all can be implemented with helpers found on our [guide to creating a dataset](../docs/development/how_to_use_dataset.md).
+And second, it requires a desired `Performance`: one of `FAST`, `BALANCED`, or `ACCURATE` depending on your desired place in the model size curve.
+In general, larger models are more accurate in exchange for requiring more disk space, cost, and latency.
+
+Some applications also feature a pre-trained method.
+This will pull a model for the application from the DJL model zoo that is recommended by the DJL team.
+Depending on the application, there may also be options in terms of what performance level, classifications, output type, etc.
 
 ## List of Applications
 
 This module contains the following applications:
 
-- Image Classification - take an image and classify the main subject of the image.
-
+- [Image Classification](https://javadoc.io/doc/ai.djl/djl-zero/latest/ai/djl/zero/cv/ImageClassification.html) - take an image and classify the main subject of the image.
+- [Object Detection](https://javadoc.io/doc/ai.djl/djl-zero/latest/ai/djl/zero/cv/ObjectDetection.html) - take an image and find each object (car, bike, plant, etc.) in the image along with the bounding box around it's location
+- [Tabular Regression](https://javadoc.io/doc/ai.djl/djl-zero/latest/ai/djl/zero/tabular/TabularRegression.html) - takes input features from a row in a table and predict the value of a numeric column
 
 ## Documentation
 

--- a/djl-zero/src/main/java/ai/djl/zero/tabular/TabularRegression.java
+++ b/djl-zero/src/main/java/ai/djl/zero/tabular/TabularRegression.java
@@ -32,10 +32,10 @@ import ai.djl.zero.Performance;
 
 import java.io.IOException;
 
-/** Tabular takes a NDList as input and output an NDList (for supervised learning). */
-public final class Tabular {
+/** TabularRegression takes a NDList as input and output an NDList (for supervised learning). */
+public final class TabularRegression {
 
-    private Tabular() {}
+    private TabularRegression() {}
 
     /**
      * Trains a Model on a custom dataset. Currently, trains a TabNet Model.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -147,6 +147,7 @@ nav:
           - 'docs/serving/serving/docs/management_api.md'
           - 'docs/serving/serving/docs/plugin_management.md'
       - 'docs/serving/wlm/README.md'
+      - DJL Zero: 'djl-zero/README.md'
   - Demos:
       - Demos: 'docs/demos/README.md'
       - AWS:

--- a/tools/gradle/publish.gradle
+++ b/tools/gradle/publish.gradle
@@ -1,6 +1,7 @@
 configure([
         project(':api'),
         project(':basicdataset'),
+        project(':djl-zero'),
         project(':engines:dlr:dlr-engine'),
         project(':engines:ml:xgboost'),
         project(':engines:ml:lightgbm'),


### PR DESCRIPTION
As DJL Zero now features three applications, it probably makes sense to at least make it available through Maven Central. This change begins publishing it. It also improves the documentation and README to explain DJL Zero.

While it is added to the docs site, it is only added with a relatively low-key location within the extensions section. In the future as DJL Zero is improved, it may be worth giving it a more prominent place within the Home tab.
