### PR TITLE
fix: remove warning spam during training

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/index/NDArrayIndexer.java
+++ b/api/src/main/java/ai/djl/ndarray/index/NDArrayIndexer.java
@@ -20,9 +20,6 @@ import ai.djl.ndarray.index.full.NDIndexFullPick;
 import ai.djl.ndarray.index.full.NDIndexFullSlice;
 import ai.djl.ndarray.index.full.NDIndexFullTake;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.List;
 import java.util.Optional;
 
@@ -80,11 +77,6 @@ public abstract class NDArrayIndexer {
 
         Optional<NDIndexFullTake> fullTake = NDIndexFullTake.fromIndex(index, array.getShape());
         if (fullTake.isPresent()) {
-            Logger logger = LoggerFactory.getLogger(NDArrayIndexer.class);
-            logger.warn(
-                    "The definition of the getter by array NDIndex: get(NDIndex array) has changed"
-                        + " from pick to take.If you still want to use array index as pick, then do"
-                        + " it explicitly by get(new NDIndex().addPickDim(array));");
             return get(array, fullTake.get());
         }
 


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Requested change is in response to issue https://github.com/deepjavalibrary/djl/issues/2088, where a warning is logging constantly during training.

The log is a warning mentioning a change in default behavior. The PR removes this log, and suggests the communication of the behavior change be handled in a different way. Alternative option if this is not an acceptable solution is that we create a wrapper for the logger to consolidate certain logs, and make it so that this log appears only once.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
