### PR TITLE
Test accumulating gradient collector

### DIFF
--- a/api/src/main/java/ai/djl/training/GradientCollector.java
+++ b/api/src/main/java/ai/djl/training/GradientCollector.java
@@ -21,6 +21,14 @@ import ai.djl.ndarray.NDArray;
  * performed within the try-with-resources are recorded and the variables marked. When {@link
  * #backward(NDArray) backward function} is called, gradients are collected w.r.t previously marked
  * variables.
+ *
+ * <p>The typical behavior is to open up a gradient collector during each batch and close it during
+ * the end of the batch. In this way, the gradient is reset between batches. If the gradient
+ * collector is left open for multiple calls to backwards, the gradients collected are accumulated
+ * and added together.
+ *
+ * <p>Due to limitations in most engines, the gradient collectors are global. This means that only
+ * one can be used at a time. If multiple are opened, an error will be thrown.
  */
 public interface GradientCollector extends AutoCloseable {
 

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtGradientCollector.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtGradientCollector.java
@@ -18,15 +18,26 @@ import ai.djl.ndarray.NDManager;
 import ai.djl.pytorch.jni.JniUtils;
 import ai.djl.training.GradientCollector;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 /** {@code PtGradientCollector} is the PyTorch implementation of {@link GradientCollector}. */
 public final class PtGradientCollector implements GradientCollector {
 
     private boolean gradModel;
+    private static AtomicBoolean isCollecting = new AtomicBoolean();
 
     /** Constructs a new {@code PtGradientCollector} instance. */
     public PtGradientCollector() {
         gradModel = JniUtils.isGradMode();
         JniUtils.setGradMode(true);
+
+        boolean wasCollecting = isCollecting.getAndSet(true);
+        if (wasCollecting) {
+            throw new IllegalStateException(
+                    "A PtGradientCollector is already collecting. Only one can be collecting at a"
+                            + " time");
+        }
+
         zeroGradients();
     }
 
@@ -73,6 +84,7 @@ public final class PtGradientCollector implements GradientCollector {
         if (!gradModel) {
             JniUtils.setGradMode(false);
         }
+        isCollecting.set(false);
         // TODO: do some clean up if necessary
     }
 }

--- a/examples/src/test/java/ai/djl/examples/training/TrainAirfoilWithTabNetTest.java
+++ b/examples/src/test/java/ai/djl/examples/training/TrainAirfoilWithTabNetTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 public class TrainAirfoilWithTabNetTest {
     @Test
     public void testTrainAirfoilWithTabNet() throws TranslateException, IOException {
+        TestRequirements.nightly();
         TestRequirements.engine("MXNet", "PyTorch");
         String[] args = new String[] {"-g", "1", "-e", "20", "-b", "32"};
         TrainingResult result = TrainAirfoilWithTabNet.runExample(args);


### PR DESCRIPTION
This adds additional documentation and testing to define the API for the gradient collector. Specifically, it focuses on the gradient accumulating behavior and adds a restriction to creating multiple simultaneous global gradient collectors.

It also raises an issue for dealing with MXNet to accumulate gradients. I investigated both the setRequiresGradient with ADD mode and backwards with retainGrads and neither was correctly implementing the gradient accumulation behavior.
As this is not a terribly significant use case, I will just leave it as a TODO until there are any users who specifically request it.
