### PR TITLE
Refactor unit test TestRequirements, add missing TestRequirements

### DIFF
--- a/djl-zero/src/test/java/ai/djl/zero/cv/ImageClassificationTest.java
+++ b/djl-zero/src/test/java/ai/djl/zero/cv/ImageClassificationTest.java
@@ -33,6 +33,7 @@ public class ImageClassificationTest {
     public void testImageClassificationPretrained()
             throws IOException, ModelNotFoundException, MalformedModelException {
         Class<?>[] inputClasses = {Image.class, Path.class, URL.class, InputStream.class};
+        TestRequirements.notArm();
         TestRequirements.nightly();
 
         for (Class<?> inputClass : inputClasses) {

--- a/engines/ml/xgboost/src/test/java/ai/djl/ml/xgboost/XgbModelTest.java
+++ b/engines/ml/xgboost/src/test/java/ai/djl/ml/xgboost/XgbModelTest.java
@@ -77,9 +77,6 @@ public class XgbModelTest {
 
     @Test
     public void testLoad() throws MalformedModelException, IOException, TranslateException {
-        TestRequirements.notArm();
-        TestRequirements.notWindows();
-
         try (Model model = Model.newInstance("XGBoost")) {
             model.load(Paths.get("build/model"), "regression");
             Predictor<NDList, NDList> predictor = model.newPredictor(new NoopTranslator());
@@ -94,9 +91,6 @@ public class XgbModelTest {
 
     @Test
     public void testNDArray() {
-        TestRequirements.notArm();
-        TestRequirements.notWindows();
-
         try (XgbNDManager manager =
                 (XgbNDManager) XgbNDManager.getSystemManager().newSubManager()) {
             manager.setMissingValue(Float.NaN);

--- a/engines/mxnet/mxnet-model-zoo/src/test/java/ai/djl/mxnet/integration/MxSymbolBlockTest.java
+++ b/engines/mxnet/mxnet-model-zoo/src/test/java/ai/djl/mxnet/integration/MxSymbolBlockTest.java
@@ -43,6 +43,7 @@ import ai.djl.translate.TranslateException;
 import ai.djl.util.Pair;
 
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -53,11 +54,14 @@ import java.util.stream.Collectors;
 
 public class MxSymbolBlockTest {
 
+    @BeforeClass
+    public void setUp() {
+        TestRequirements.notArm();
+    }
+
     @Test
     public void testSymbolModelInputOutput()
             throws IOException, ModelException, TranslateException {
-        TestRequirements.notArm();
-
         Criteria<Image, Classifications> criteria =
                 Criteria.builder()
                         .setTypes(Image.class, Classifications.class)
@@ -75,8 +79,6 @@ public class MxSymbolBlockTest {
 
     @Test
     public void testForward() throws IOException, ModelException {
-        TestRequirements.notArm();
-
         Criteria<Image, Classifications> criteria =
                 Criteria.builder()
                         .setTypes(Image.class, Classifications.class)
@@ -99,8 +101,6 @@ public class MxSymbolBlockTest {
 
     @Test
     public void trainWithNewParam() throws IOException, ModelException {
-        TestRequirements.notArm();
-
         if ("MXNet".equals(Engine.getDefaultEngineName())) {
             // TODO: WARN The gradMeans (but not predictions or loss) changed during the upgrade
             // to MXNet 1.8. The issue affect only CPU, but GPU has not changed.
@@ -140,8 +140,6 @@ public class MxSymbolBlockTest {
 
     @Test
     public void trainWithExistParam() throws IOException, ModelException {
-        TestRequirements.notArm();
-
         TrainingConfig config =
                 new DefaultTrainingConfig(Loss.softmaxCrossEntropyLoss())
                         .optInitializer(Initializer.ONES, Parameter.Type.WEIGHT);
@@ -174,8 +172,6 @@ public class MxSymbolBlockTest {
 
     @Test
     public void trainWithCustomLayer() throws IOException, ModelException {
-        TestRequirements.notArm();
-
         TrainingConfig config =
                 new DefaultTrainingConfig(Loss.softmaxCrossEntropyLoss())
                         .optInitializer(Initializer.ONES, Parameter.Type.WEIGHT);
@@ -216,8 +212,6 @@ public class MxSymbolBlockTest {
     }
 
     private Pair<NDArray, NDArray> train(NDManager manager, Trainer trainer, Block block) {
-        TestRequirements.notArm();
-
         Shape inputShape = new Shape(10, 28 * 28);
         trainer.initialize(inputShape);
 

--- a/engines/paddlepaddle/paddlepaddle-engine/src/test/java/ai/djl/paddlepaddle/jni/JniUtilsTest.java
+++ b/engines/paddlepaddle/paddlepaddle-engine/src/test/java/ai/djl/paddlepaddle/jni/JniUtilsTest.java
@@ -19,14 +19,18 @@ import ai.djl.paddlepaddle.engine.PpNDArray;
 import ai.djl.testing.TestRequirements;
 
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class JniUtilsTest {
 
-    @Test
-    void createNDArray() {
+    @BeforeClass
+    public void setUp() {
         TestRequirements.notArm();
+    }
 
+    @Test
+    public void createNDArray() {
         try (NDManager manager = NDManager.newBaseManager(null, "PaddlePaddle")) {
             NDArray array = manager.zeros(new Shape(1, 2));
             float[] expected = new float[] {0, 0};
@@ -41,9 +45,7 @@ public class JniUtilsTest {
     }
 
     @Test
-    void testLoD() {
-        TestRequirements.notArm();
-
+    public void testLoD() {
         try (NDManager manager = NDManager.newBaseManager(null, "PaddlePaddle")) {
             PpNDArray array = (PpNDArray) manager.zeros(new Shape(1, 4));
             long[][] lodInfo = new long[][] {new long[] {1, 3}};

--- a/engines/paddlepaddle/paddlepaddle-model-zoo/src/test/java/ai/djl/paddlepaddle/zoo/OCRTest.java
+++ b/engines/paddlepaddle/paddlepaddle-model-zoo/src/test/java/ai/djl/paddlepaddle/zoo/OCRTest.java
@@ -29,6 +29,7 @@ import ai.djl.repository.zoo.ZooModel;
 import ai.djl.testing.TestRequirements;
 import ai.djl.translate.TranslateException;
 
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -36,10 +37,13 @@ import java.util.List;
 
 public class OCRTest {
 
+    @BeforeClass
+    public void setUp() {
+        TestRequirements.notArm();
+    }
+
     @Test
     public void testOCR() throws IOException, ModelException, TranslateException {
-        TestRequirements.notArm();
-
         // load Character model
         Predictor<Image, DetectedObjects> detector = getWordDetector();
         Predictor<Image, String> recognizer = getRecognizer();
@@ -65,8 +69,6 @@ public class OCRTest {
 
     private static Predictor<Image, DetectedObjects> getWordDetector()
             throws ModelException, IOException {
-        TestRequirements.notArm();
-
         Criteria<Image, DetectedObjects> criteria =
                 Criteria.builder()
                         .setTypes(Image.class, DetectedObjects.class)
@@ -77,8 +79,6 @@ public class OCRTest {
     }
 
     private static Predictor<Image, String> getRecognizer() throws ModelException, IOException {
-        TestRequirements.notArm();
-
         Criteria<Image, String> criteria =
                 Criteria.builder()
                         .setTypes(Image.class, String.class)

--- a/engines/tensorflow/tensorflow-model-zoo/src/test/java/ai/djl/tensorflow/integration/modality/cv/TfSsdTest.java
+++ b/engines/tensorflow/tensorflow-model-zoo/src/test/java/ai/djl/tensorflow/integration/modality/cv/TfSsdTest.java
@@ -33,6 +33,7 @@ import ai.djl.translate.TranslateException;
 import ai.djl.util.Pair;
 
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -44,10 +45,13 @@ import java.util.stream.Collectors;
 
 public class TfSsdTest {
 
+    @BeforeClass
+    public void setUp() {
+        TestRequirements.notArm();
+    }
+
     @Test
     public void testTfSSD() throws IOException, ModelException, TranslateException {
-        TestRequirements.notArm();
-
         Criteria<Image, DetectedObjects> criteria =
                 Criteria.builder()
                         .optApplication(Application.CV.OBJECT_DETECTION)
@@ -96,8 +100,6 @@ public class TfSsdTest {
 
     @Test
     public void testStringInputOutput() throws IOException, ModelException, TranslateException {
-        TestRequirements.notArm();
-
         Criteria<NDList, NDList> criteria =
                 Criteria.builder()
                         .optApplication(Application.CV.OBJECT_DETECTION)

--- a/extensions/fasttext/src/test/java/ai/djl/fasttext/CookingStackExchangeTest.java
+++ b/extensions/fasttext/src/test/java/ai/djl/fasttext/CookingStackExchangeTest.java
@@ -36,6 +36,7 @@ import ai.djl.translate.TranslateException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -53,11 +54,14 @@ public class CookingStackExchangeTest {
 
     private static final Logger logger = LoggerFactory.getLogger(CookingStackExchangeTest.class);
 
-    @Test
-    public void testTrainTextClassification() throws IOException {
+    @BeforeClass
+    public void setUp() {
         TestRequirements.notWindows(); // fastText is not supported on windows
         TestRequirements.notArm();
+    }
 
+    @Test
+    public void testTrainTextClassification() throws IOException {
         CookingStackExchange dataset = CookingStackExchange.builder().build();
 
         // setup training configuration
@@ -79,9 +83,6 @@ public class CookingStackExchangeTest {
     public void testTextClassification()
             throws IOException, MalformedModelException, ModelNotFoundException,
                     TranslateException {
-        TestRequirements.notWindows(); // fastText is not supported on windows
-        TestRequirements.notArm();
-
         Criteria<String, Classifications> criteria =
                 Criteria.builder()
                         .setTypes(String.class, Classifications.class)
@@ -105,9 +106,6 @@ public class CookingStackExchangeTest {
 
     @Test
     public void testWord2Vec() throws IOException, MalformedModelException, ModelNotFoundException {
-        TestRequirements.notWindows(); // fastText is not supported on windows
-        TestRequirements.notArm();
-
         Criteria<String, Classifications> criteria =
                 Criteria.builder()
                         .setTypes(String.class, Classifications.class)
@@ -128,8 +126,6 @@ public class CookingStackExchangeTest {
 
     @Test
     public void testBlazingText() throws IOException, ModelException {
-        TestRequirements.notWindows(); // fastText is not supported on windows
-        TestRequirements.notArm();
         TestRequirements.nightly();
 
         URL url = new URL("https://resources.djl.ai/test-models/blazingtext_classification.bin");

--- a/extensions/opencv/src/test/java/ai/djl/opencv/OpenCVImageFactoryTest.java
+++ b/extensions/opencv/src/test/java/ai/djl/opencv/OpenCVImageFactoryTest.java
@@ -27,6 +27,7 @@ import ai.djl.testing.TestRequirements;
 
 import org.opencv.core.Mat;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.awt.Color;
@@ -42,11 +43,14 @@ import java.util.List;
 
 public class OpenCVImageFactoryTest {
 
-    @Test
-    public void testImage() throws IOException {
+    @BeforeClass
+    public void setUp() {
         TestRequirements.notWindows(); // failed on Windows ServerCore container
         TestRequirements.notArm();
+    }
 
+    @Test
+    public void testImage() throws IOException {
         ImageFactory factory = ImageFactory.getInstance();
         ImageFactory defFactory = new BufferedImageFactory();
         Path path = Paths.get("../../examples/src/test/resources/kitten.jpg");
@@ -132,9 +136,6 @@ public class OpenCVImageFactoryTest {
 
     @Test
     public void testBoundingBoxes() {
-        TestRequirements.notWindows(); // failed on Windows ServerCore container
-        TestRequirements.notArm();
-
         ImageFactory factory = ImageFactory.getInstance();
         try (NDManager manager = NDManager.newBaseManager()) {
             int[][] arr =
@@ -161,8 +162,6 @@ public class OpenCVImageFactoryTest {
 
     @Test
     public void testDrawImage() throws IOException {
-        TestRequirements.notWindows(); // failed on Windows ServerCore container
-        TestRequirements.notArm();
         ImageFactory factory = ImageFactory.getInstance();
         int[] pixels = new int[64];
         int index = 0;

--- a/extensions/timeseries/src/test/java/ai/djl/timeseries/block/BlockTest.java
+++ b/extensions/timeseries/src/test/java/ai/djl/timeseries/block/BlockTest.java
@@ -20,16 +20,24 @@ import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.nn.Parameter;
 import ai.djl.testing.Assertions;
+import ai.djl.testing.TestRequirements;
 import ai.djl.training.ParameterStore;
 import ai.djl.training.initializer.Initializer;
 
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
 public class BlockTest {
+
+    @BeforeClass
+    public void setUp() {
+        // TODO: Remove this once we support PyTorch support for timeseries extension
+        TestRequirements.notArm();
+    }
 
     @Test
     public void testFeature() {

--- a/extensions/timeseries/src/test/java/ai/djl/timeseries/dataset/M5ForecastTest.java
+++ b/extensions/timeseries/src/test/java/ai/djl/timeseries/dataset/M5ForecastTest.java
@@ -21,6 +21,7 @@ import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.NDManager;
 import ai.djl.nn.Blocks;
 import ai.djl.nn.Parameter;
+import ai.djl.testing.TestRequirements;
 import ai.djl.timeseries.transform.TimeSeriesTransform;
 import ai.djl.training.DefaultTrainingConfig;
 import ai.djl.training.Trainer;
@@ -33,6 +34,7 @@ import ai.djl.training.loss.Loss;
 import ai.djl.translate.TranslateException;
 
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -40,6 +42,12 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public class M5ForecastTest {
+
+    @BeforeClass
+    public void setUp() {
+        // TODO: Remove this once we support PyTorch support for timeseries extension
+        TestRequirements.notArm();
+    }
 
     /*
      * Here for the purpose of unittest, we use the M5 forecast unittest dataset.

--- a/extensions/timeseries/src/test/java/ai/djl/timeseries/distribution/DistributionTest.java
+++ b/extensions/timeseries/src/test/java/ai/djl/timeseries/distribution/DistributionTest.java
@@ -17,10 +17,18 @@ import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.NDManager;
 import ai.djl.testing.Assertions;
+import ai.djl.testing.TestRequirements;
 
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class DistributionTest {
+
+    @BeforeClass
+    public void setUp() {
+        // TODO: Remove this once we support PyTorch support for timeseries extension
+        TestRequirements.notArm();
+    }
 
     @Test
     public void testNegativeBinomial() {

--- a/extensions/timeseries/src/test/java/ai/djl/timeseries/evaluator/RmsseTest.java
+++ b/extensions/timeseries/src/test/java/ai/djl/timeseries/evaluator/RmsseTest.java
@@ -16,16 +16,19 @@ package ai.djl.timeseries.evaluator;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.NDManager;
+import ai.djl.testing.TestRequirements;
 import ai.djl.timeseries.distribution.output.NegativeBinomialOutput;
 
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class RmsseTest {
 
-    public static void main(String[] args) {
-        RmsseTest t = new RmsseTest();
-        t.testRmsse();
+    @BeforeClass
+    public void setUp() {
+        // TODO: Remove this once we support PyTorch support for timeseries extension
+        TestRequirements.notArm();
     }
 
     @Test

--- a/extensions/timeseries/src/test/java/ai/djl/timeseries/model/DeepARTest.java
+++ b/extensions/timeseries/src/test/java/ai/djl/timeseries/model/DeepARTest.java
@@ -23,6 +23,7 @@ import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.nn.Parameter;
+import ai.djl.testing.TestRequirements;
 import ai.djl.timeseries.dataset.FieldName;
 import ai.djl.timeseries.dataset.M5Forecast;
 import ai.djl.timeseries.dataset.TimeFeaturizers;
@@ -46,6 +47,7 @@ import ai.djl.translate.TranslateException;
 import ai.djl.util.PairList;
 
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -60,9 +62,10 @@ public class DeepARTest {
     private static int predictionLength = 4;
     private static String freq = "D";
 
-    public static void main(String[] args) throws TranslateException, IOException {
-        DeepARTest test = new DeepARTest();
-        test.testPredictionTransformation();
+    @BeforeClass
+    public void setUp() {
+        // TODO: Remove this once we support PyTorch support for timeseries extension
+        TestRequirements.notArm();
     }
 
     @Test

--- a/extensions/timeseries/src/test/java/ai/djl/timeseries/transform/TransformTest.java
+++ b/extensions/timeseries/src/test/java/ai/djl/timeseries/transform/TransformTest.java
@@ -40,6 +40,7 @@ public class TransformTest {
 
     @BeforeClass
     public void setUp() {
+        // TODO: Remove this once we support PyTorch support for timeseries extension
         TestRequirements.notArm();
     }
 

--- a/extensions/timeseries/src/test/java/ai/djl/timeseries/translator/DeepARTranslatorTest.java
+++ b/extensions/timeseries/src/test/java/ai/djl/timeseries/translator/DeepARTranslatorTest.java
@@ -37,6 +37,7 @@ public class DeepARTranslatorTest {
 
     @Test
     public void testDeepARTranslator() throws IOException, TranslateException, ModelException {
+        // TODO: Remove this once we support PyTorch support for timeseries extension
         TestRequirements.notArm();
 
         String modelUrl = "https://resources.djl.ai/test-models/mxnet/timeseries/deepar.zip";

--- a/extensions/timeseries/src/test/java/ai/djl/timeseries/translator/TransformerTranslatorTest.java
+++ b/extensions/timeseries/src/test/java/ai/djl/timeseries/translator/TransformerTranslatorTest.java
@@ -37,6 +37,7 @@ public class TransformerTranslatorTest {
 
     @Test
     public void testTransformerTranslator() throws IOException, TranslateException, ModelException {
+        // TODO: Remove this once we support PyTorch support for timeseries extension
         TestRequirements.notArm();
 
         String modelUrl = "https://resources.djl.ai/test-models/mxnet/timeseries/transformer.zip";


### PR DESCRIPTION
## Description ##

Two sets of changes in this PR:
- Remove duplicate usage of TestRequirements.someRequirement() in unit tests and move them to a setUp method.
- Adds missing TestRequirements on some timeseries unit tests to not run on Arm
