### PR TITLE
[example] Add missing dependency to `timeseries`

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -55,6 +55,10 @@
             <groupId>ai.djl</groupId>
             <artifactId>model-zoo</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ai.djl.timeseries</groupId>
+            <artifactId>timeseries</artifactId>
+        </dependency>
         <!-- MXNet -->
         <dependency>
             <groupId>ai.djl.mxnet</groupId>


### PR DESCRIPTION
## Description ##

Added missing maven dependency to `timeseries` as several examples depend on that.

Current state prevents maven to compile due to the missing dependency.