### PR TITLE
LightGBM inference result matches input type

### DIFF
--- a/engines/ml/lightgbm/src/test/java/ai/djl/ml/lightgbm/LgbmModelTest.java
+++ b/engines/ml/lightgbm/src/test/java/ai/djl/ml/lightgbm/LgbmModelTest.java
@@ -55,7 +55,7 @@ public class LgbmModelTest {
             try (NDManager manager = NDManager.newBaseManager()) {
                 NDArray array = manager.ones(new Shape(10, 4));
                 NDList output = predictor.predict(new NDList(array));
-                Assert.assertEquals(output.singletonOrThrow().getDataType(), DataType.FLOAT64);
+                Assert.assertEquals(output.singletonOrThrow().getDataType(), DataType.FLOAT32);
                 Assert.assertEquals(output.singletonOrThrow().getShape().size(), 10);
             }
         }


### PR DESCRIPTION
This makes the LightGBM inference return the same as the input type (either float32 or float64) rather than always returning float64 per the API.

In addition, it adds a bit nicer handling for creation from a Buffer in that it will also accept either a FloatBuffer or a DoubleBuffer.
