### PR TITLE
[doc] Remove `block` which seems to provide no purpose

### DIFF
--- a/jupyter/tutorial/01_create_your_first_network.ipynb
+++ b/jupyter/tutorial/01_create_your_first_network.ipynb
@@ -167,9 +167,7 @@
     "block.add(Activation::relu);\n",
     "block.add(Linear.builder().setUnits(64).build());\n",
     "block.add(Activation::relu);\n",
-    "block.add(Linear.builder().setUnits(outputSize).build());\n",
-    "\n",
-    "block"
+    "block.add(Linear.builder().setUnits(outputSize).build());"
    ]
   },
   {


### PR DESCRIPTION
## Description ##

Removed `block` from a code block which seems to be placed by mistake. Needs to be removed when using copy & paste anyway.
