### PR TITLE
[ci] Speed up continuous build by not uploading jacoco report

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -91,7 +91,9 @@ jobs:
         if: always()
         with:
           name: reports
-          path: ${{ github.workspace }}/**/build/reports/**/*
+          path: |
+            ${{ github.workspace }}/**/build/reports/**/*
+            !${{ github.workspace }}/**/build/reports/jacoco/*
       - name: upload to codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
