### PR TITLE
Update SpProcessor.java

### DIFF
--- a/extensions/sentencepiece/src/main/java/ai/djl/sentencepiece/SpProcessor.java
+++ b/extensions/sentencepiece/src/main/java/ai/djl/sentencepiece/SpProcessor.java
@@ -17,7 +17,7 @@ import ai.djl.sentencepiece.jni.SentencePieceLibrary;
 import ai.djl.util.NativeResource;
 
 /** The processor holder for SentencePiece. */
-final class SpProcessor extends NativeResource<Long> {
+public final class SpProcessor extends NativeResource<Long> {
 
     private static RuntimeException libraryStatus;
 


### PR DESCRIPTION
fix: the class need be 'public'

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
