### PR TITLE
Specify the block that PtGradientCollector belongs to

### DIFF
--- a/api/src/main/java/ai/djl/engine/Engine.java
+++ b/api/src/main/java/ai/djl/engine/Engine.java
@@ -15,6 +15,7 @@ package ai.djl.engine;
 import ai.djl.Device;
 import ai.djl.Model;
 import ai.djl.ndarray.NDManager;
+import ai.djl.nn.Block;
 import ai.djl.nn.SymbolBlock;
 import ai.djl.training.GradientCollector;
 import ai.djl.training.LocalParameterServer;
@@ -305,6 +306,16 @@ public abstract class Engine {
      * @return a new instance of {@link GradientCollector}
      */
     public abstract GradientCollector newGradientCollector();
+
+    /**
+     * Returns a new instance of {@link GradientCollector}.
+     *
+     * @param block the block that the gradient collector attaches
+     * @return a new instance of {@link GradientCollector}
+     */
+    public GradientCollector newGradientCollector(Block block) {
+        throw new UnsupportedOperationException("Not supported.");
+    }
 
     /**
      * Returns a new instance of {@link ParameterServer}.

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxEngine.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxEngine.java
@@ -19,6 +19,7 @@ import ai.djl.engine.EngineException;
 import ai.djl.mxnet.jna.JnaUtils;
 import ai.djl.mxnet.jna.LibUtils;
 import ai.djl.ndarray.NDManager;
+import ai.djl.nn.Block;
 import ai.djl.nn.SymbolBlock;
 import ai.djl.training.GradientCollector;
 import ai.djl.training.LocalParameterServer;
@@ -141,6 +142,12 @@ public final class MxEngine extends Engine {
     /** {@inheritDoc} */
     @Override
     public GradientCollector newGradientCollector() {
+        return new MxGradientCollector();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public GradientCollector newGradientCollector(Block block) {
         return new MxGradientCollector();
     }
 

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtEngine.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtEngine.java
@@ -17,6 +17,7 @@ import ai.djl.Model;
 import ai.djl.engine.Engine;
 import ai.djl.engine.EngineException;
 import ai.djl.ndarray.NDManager;
+import ai.djl.nn.Block;
 import ai.djl.nn.SymbolBlock;
 import ai.djl.pytorch.jni.JniUtils;
 import ai.djl.pytorch.jni.LibUtils;
@@ -144,6 +145,12 @@ public final class PtEngine extends Engine {
     @Override
     public GradientCollector newGradientCollector() {
         return new PtGradientCollector();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public GradientCollector newGradientCollector(Block block) {
+        return new PtGradientCollector(block);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
The zeroGradients() call (added in https://github.com/deepjavalibrary/djl/pull/2101 to solve https://github.com/deepjavalibrary/djl/issues/2024) when constructing PtGradientCollector() compromises the efficiency and memory usage, as shown in https://github.com/deepjavalibrary/djl/issues/2210. Thus the block has to be specified so that the zeroGradients is called only on its parameters, and the search scope is narrowed down. Another relevant PR is https://github.com/deepjavalibrary/djl/pull/2111. 

The original PtGradientCollector() is left unchanged in order to be backward compatible. A new PtGradientCollector(Block) is added so that the gradient collector is restricted to operate on a certain block. Then multiple such collectors can coexist. @zachgk I added this point to the doc, please take a look. The relevant PR https://github.com/deepjavalibrary/djl/pull/2111.

**In essence, this PR is to disable `zeroGradients()` in the default case, unless the block is specified when creating a GradientCollector.** This is because of the issues inside global search in zeroGradients.

---
To solve this issue the issue https://github.com/deepjavalibrary/djl/issues/2024 in the Dive into Deep Learning book, how the gradient is accumulated should be specified in the future, either "write" or "add". Also "retain_graph" should also be fixed. Under certain condition error should be thrown, for example, if retain_graph=false and repetative backward is called. This way the ambiguity in the defination of repetative backward call, as shown in https://github.com/deepjavalibrary/djl/issues/2024, will be clarified.

On pytorch, by default gradients are added for repetative backward call and if retain_graph=true
```python
    x1 = pt.tensor([1., 2., 3., 4.], requires_grad=True)
    x2 = pt.tensor([5., 6., 7., 8.], requires_grad=True)
    u = x1 * x2
    z = u * x1
    z.sum().backward(retain_graph=True)
    print("\n")
    print(x1.grad, x2.grad)

    z.sum().backward(retain_graph=True)
    print(x1.grad, x2.grad)

    z.sum().backward()
    print(x1.grad, x2.grad)
```
Output:
```
tensor([10., 24., 42., 64.]) tensor([ 1.,  4.,  9., 16.])
tensor([ 20.,  48.,  84., 128.]) tensor([ 2.,  8., 18., 32.])
tensor([ 30.,  72., 126., 192.]) tensor([ 3., 12., 27., 48.])
```
---
Note:
* If repetative backward needs to be called, `retain_graph=True` should be set. This is not an commenly seen usecase in practice. See also https://github.com/deepjavalibrary/djl/pull/2111.
* `Block` currently does not have a direct call feature like the following but requires `parameterStore`.
```python
m = nn.Linear(20, 30)
input = torch.randn(128, 20)
output = m(input)
```
---
Relavant stackoverflow issue:
https://stackoverflow.com/questions/70998652/djl-gradientcollector-try-with-resources-initialiser-error



