### PR TITLE
[pytorch] No longer search java.library.path

### DIFF
--- a/engines/pytorch/pytorch-engine/README.md
+++ b/engines/pytorch/pytorch-engine/README.md
@@ -78,6 +78,23 @@ System.setProperty("PYTORCH_PRECXX11", "true");
 If you don't have network access, you can add a offline native library package based on your platform
 to avoid downloading the native libraries at runtime.
 
+### Load your own PyTorch native library
+
+If you installed PyTorch with python pip wheel, and you want to use your installed PyTorch,
+you can set `PYTORCH_LIBRARY_PATH` environment variable, DJL will load your PyTorch native
+library for the location you pointed to. You might also need set `PYTORCH_VERSION` and
+`PYTORCH_FLAVOR` environment variable so DJL will use matching JNI for your PyTorch.
+
+```shell
+export PYTORCH_LIBRARY_PATH=/usr/lib/python3.10/site-packages/torch/lib
+
+# Use latest PyTorch version that engine supported if PYTORCH_VERSION not set
+export PYTORCH_VERSION=1.XX.X
+
+# Use cpu-precxx11 if PYTORCH_FLAVOR not set
+export PYTORCH_FLAVOR=cpu
+```
+
 ### macOS
 For macOS, you can use the following library:
 

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/LibUtils.java
@@ -182,14 +182,6 @@ public final class LibUtils {
     private static LibTorch findOverrideLibrary() {
         String libPath = Utils.getEnvOrSystemProperty("PYTORCH_LIBRARY_PATH");
         if (libPath != null) {
-            LibTorch lib = findLibraryInPath(libPath);
-            if (lib != null) {
-                return lib;
-            }
-        }
-
-        libPath = System.getProperty("java.library.path");
-        if (libPath != null) {
             return findLibraryInPath(libPath);
         }
         return null;


### PR DESCRIPTION
archlinux install pytorch in /usr/lib64/ folder, we should only
load libtorch.so when user explicitly set PYTORCH_LIBRARY_PATH.

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
