### PR TITLE
Set seed in TransferFreshFruitTest for consistent results

### DIFF
--- a/examples/src/test/java/ai/djl/examples/training/TransferFreshFruitTest.java
+++ b/examples/src/test/java/ai/djl/examples/training/TransferFreshFruitTest.java
@@ -13,6 +13,7 @@
 package ai.djl.examples.training;
 
 import ai.djl.ModelException;
+import ai.djl.engine.Engine;
 import ai.djl.examples.training.transferlearning.TransferFreshFruit;
 import ai.djl.testing.TestRequirements;
 import ai.djl.training.TrainingResult;
@@ -32,6 +33,7 @@ public class TransferFreshFruitTest {
         TestRequirements.engine("PyTorch");
 
         String[][] args = {{}, {"-p"}};
+        Engine.getInstance().setRandomSeed(1234);
         TrainingResult result;
         for (String[] arg : args) {
             result = TransferFreshFruit.runExample(arg);


### PR DESCRIPTION
## Description ##

Set random seed in unit test to ensure consistent test results. Without this, `./gradlew build` can sometimes fail locally if the accuracy dips below specified threshold in test.
