### PR TITLE
Handle RuntimeException on ImageFactory::newInstance

### DIFF
--- a/api/src/main/java/ai/djl/modality/cv/ImageFactory.java
+++ b/api/src/main/java/ai/djl/modality/cv/ImageFactory.java
@@ -17,7 +17,6 @@ import ai.djl.ndarray.NDArray;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.RuntimeException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -51,9 +50,7 @@ public abstract class ImageFactory {
                 Class<? extends ImageFactory> clazz =
                         Class.forName(FACTORIES[i]).asSubclass(ImageFactory.class);
                 return clazz.getConstructor().newInstance();
-            } catch (ReflectiveOperationException e) {
-                logger.trace("", e);
-            } catch (RuntimeException e) {
+            } catch (ReflectiveOperationException | ExceptionInInitializerError e) {
                 logger.trace("", e);
             }
         }

--- a/api/src/main/java/ai/djl/modality/cv/ImageFactory.java
+++ b/api/src/main/java/ai/djl/modality/cv/ImageFactory.java
@@ -17,6 +17,7 @@ import ai.djl.ndarray.NDArray;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.RuntimeException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -51,6 +52,8 @@ public abstract class ImageFactory {
                         Class.forName(FACTORIES[i]).asSubclass(ImageFactory.class);
                 return clazz.getConstructor().newInstance();
             } catch (ReflectiveOperationException e) {
+                logger.trace("", e);
+            } catch (RuntimeException e) {
                 logger.trace("", e);
             }
         }


### PR DESCRIPTION
In M1 mac, `ai.djl.opencv.OpenCVImageFactory` is not supported yet but when Initialization of ImageFactory class, it tries to initialize that first and cause the Exception. 

This makes not able to use this class also when I implemented the new supported way.

To solve this bug, I think to handle UnsupportedException on ImageFactory::newInstance() is the best way. 
Due UnsupportedException is private on `nu.pattern.OpenCV`, Handle of its super class will be the solution.