### PR TITLE
Add lost package for Codespaces Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,9 @@
 ARG VARIANT=11
 FROM mcr.microsoft.com/vscode/devcontainers/java:${VARIANT}
 
+# Allow to use the VARIANT after FROM
+ARG VARIANT
+
 # [Optional] Install Maven or Gradle
 ARG INSTALL_MAVEN="false"
 ARG MAVEN_VERSION=3.6.3
@@ -13,6 +16,11 @@ RUN if [ "${INSTALL_MAVEN}" = "true" ]; then su vscode -c "source /usr/local/sdk
 ARG INSTALL_NODE="true"
 ARG NODE_VERSION="lts/*"
 RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# Install the lost package `fontconfig` for VARIANT 11
+RUN if [ "${VARIANT}" = "11" ]; then \
+    apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends fontconfig; fi
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
## Description ##

- The package `fontconfig` is lost in Codespace Dockerfile configured with `VARIANT 11` (i.e.`mcr.microsoft.com/vscode/devcontainers/java:11`), which will cause issue #2256.
- This PR adds the lost package for the `VARIANT 11` in the Dockerfile.

