### PR TITLE
[dataset] Makes TestDataset constructor protected

### DIFF
--- a/basicdataset/src/main/java/ai/djl/basicdataset/nlp/TextDataset.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/nlp/TextDataset.java
@@ -197,7 +197,7 @@ public abstract class TextDataset extends RandomAccessDataset {
         protected Usage usage;
 
         /** Constructs a new builder. */
-        Builder() {
+        protected Builder() {
             repository = BasicDatasets.REPOSITORY;
             groupId = BasicDatasets.GROUP_ID;
             usage = Usage.TRAIN;


### PR DESCRIPTION
Fixes #2269

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
