### PR TITLE
[api] Fixes typo in javadoc

### DIFF
--- a/api/src/main/java/ai/djl/nn/AbstractBaseBlock.java
+++ b/api/src/main/java/ai/djl/nn/AbstractBaseBlock.java
@@ -313,7 +313,7 @@ public abstract class AbstractBaseBlock implements Block {
      * Overwrite this to load additional metadata with the parameter values.
      *
      * <p>If you overwrite {@link AbstractBlock#saveMetadata(DataOutputStream)} or need to provide
-     * backward compatibility to older binary formats, you prabably need to overwrite this. This
+     * backward compatibility to older binary formats, you probably need to overwrite this. This
      * default implementation checks if the version number fits, if not it throws an {@link
      * MalformedModelException}. After that it restores the input shapes.
      *


### PR DESCRIPTION
Fixes #2285

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
