### PR TITLE
[api]Fix typo in javadoc of Block and AbstractBlock

### DIFF
--- a/api/src/main/java/ai/djl/nn/AbstractBlock.java
+++ b/api/src/main/java/ai/djl/nn/AbstractBlock.java
@@ -131,7 +131,7 @@ public abstract class AbstractBlock extends AbstractBaseBlock {
     }
 
     /**
-     * Adds a parameter to this block. If parameters are added with this method, intialization of
+     * Adds a parameter to this block. If parameters are added with this method, initialization of
      * the parameter works out of the box
      *
      * @param <P> the specific parameter subclass

--- a/api/src/main/java/ai/djl/nn/Block.java
+++ b/api/src/main/java/ai/djl/nn/Block.java
@@ -61,7 +61,7 @@ import java.util.function.Predicate;
  * <p>We provide helpers for creating two common structures of blocks. For blocks that call children
  * in a chain, use {@link SequentialBlock}. If a blocks calls all of the children in parallel and
  * then combines their results, use {@link ParallelBlock}. For blocks that do not fit these
- * strcutures, you should directly extend the {@link AbstractBlock} class.
+ * structures, you should directly extend the {@link AbstractBlock} class.
  *
  * <p>A block does not necessarily have to have children and parameters. For example, {@link
  * SequentialBlock}, and {@link ParallelBlock} don't have any parameters, but do have child blocks.
@@ -95,7 +95,7 @@ import java.util.function.Predicate;
  * ai.djl.ndarray.NDArray} that are initialized according to the {@link Initializer} set. At this
  * stage, the block is expecting a specific type of input, and is ready to be trained.
  *
- * <p>Training is when we starting feeding the training data as input to the block, get the output,
+ * <p>Training is when we are starting feeding the training data as input to the block, get the output,
  * and try to update parameters to learn. For more information about training, please refer the
  * javadoc at {@link ai.djl.training.Trainer}. At the end of training, a block represents a
  * fully-trained model.

--- a/api/src/main/java/ai/djl/nn/Block.java
+++ b/api/src/main/java/ai/djl/nn/Block.java
@@ -95,9 +95,9 @@ import java.util.function.Predicate;
  * ai.djl.ndarray.NDArray} that are initialized according to the {@link Initializer} set. At this
  * stage, the block is expecting a specific type of input, and is ready to be trained.
  *
- * <p>Training is when we are starting feeding the training data as input to the block, get the output,
- * and try to update parameters to learn. For more information about training, please refer the
- * javadoc at {@link ai.djl.training.Trainer}. At the end of training, a block represents a
+ * <p>Training is when we are starting feeding the training data as input to the block, get the
+ * output, and try to update parameters to learn. For more information about training, please refer
+ * the javadoc at {@link ai.djl.training.Trainer}. At the end of training, a block represents a
  * fully-trained model.
  *
  * @see <a


### PR DESCRIPTION
Fix typo
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
