### PR TITLE
memory leak in Pt indexing

### DIFF
--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
@@ -379,7 +379,7 @@ public final class JniUtils {
                 Long max = ((NDIndexSlice) elem).getMax();
                 Long step = ((NDIndexSlice) elem).getStep();
                 int nullSliceBin = (min == null ? 1 : 0) * 2 + (max == null ? 1 : 0);
-                // nullSliceBin encodes whether the slice ends {min, max} is null:
+                // nullSliceBin encodes whether the slice end {min, max} is null:
                 // is_null == 1, ! is_null == 0;
                 // 0b11 == 3, 0b10 = 2, ...
                 // If {min, max} is null, then its value is ineffective, thus set to -1.

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
@@ -362,7 +362,6 @@ public final class JniUtils {
         if (ndArray == null) {
             return ndArray;
         }
-        PtNDArray result;
         List<NDIndexElement> indices = index.getIndices();
         long torchIndexHandle = PyTorchLibrary.LIB.torchIndexInit(indices.size());
         try {
@@ -417,15 +416,11 @@ public final class JniUtils {
             if (indices.size() == index.getEllipsisIndex()) {
                 PyTorchLibrary.LIB.torchIndexAppendNoneEllipsis(torchIndexHandle, true);
             }
-            result =
-                    new PtNDArray(
-                            manager,
-                            PyTorchLibrary.LIB.torchIndexAdvGet(
-                                    ndArray.getHandle(), torchIndexHandle));
+            long ret = PyTorchLibrary.LIB.torchIndexAdvGet(ndArray.getHandle(), torchIndexHandle);
+            return new PtNDArray(manager, ret);
         } finally {
             PyTorchLibrary.LIB.torchDeleteIndex(torchIndexHandle);
         }
-        return result;
     }
 
     @SuppressWarnings("OptionalGetWithoutIsPresent")

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
@@ -214,6 +214,8 @@ final class PyTorchLibrary {
 
     native void torchDeleteTensor(long handle);
 
+    native void torchDeleteIndex(long handle);
+
     native void torchDeleteModule(long handle);
 
     native void torchDeleteIValue(long handle);

--- a/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_tensor.cc
+++ b/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_tensor.cc
@@ -135,7 +135,6 @@ JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexAdvGet(
   const auto* tensor_ptr = reinterpret_cast<torch::Tensor*>(jhandle);
   auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex>*>(jtorch_index_handle);
   torch::Tensor* ret_ptr = new torch::Tensor(tensor_ptr->index(*index_ptr));
-  delete index_ptr;
   return reinterpret_cast<uintptr_t>(ret_ptr);
   API_END_RETURN()
 }
@@ -309,6 +308,14 @@ JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchDeleteTensor(
   API_BEGIN()
   const auto* tensor_ptr = reinterpret_cast<torch::Tensor*>(jhandle);
   delete tensor_ptr;
+  API_END()
+}
+
+JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchDeleteIndex(
+    JNIEnv* env, jobject jthis, jlong jtorch_index_handle) {
+  API_BEGIN()
+  auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex>*>(jtorch_index_handle);
+  delete index_ptr;
   API_END()
 }
 

--- a/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_tensor.cc
+++ b/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_tensor.cc
@@ -135,6 +135,7 @@ JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchIndexAdvGet(
   const auto* tensor_ptr = reinterpret_cast<torch::Tensor*>(jhandle);
   auto* index_ptr = reinterpret_cast<std::vector<torch::indexing::TensorIndex>*>(jtorch_index_handle);
   torch::Tensor* ret_ptr = new torch::Tensor(tensor_ptr->index(*index_ptr));
+  delete index_ptr;
   return reinterpret_cast<uintptr_t>(ret_ptr);
   API_END_RETURN()
 }


### PR DESCRIPTION
## Description ##

A patch to the memory leak issue https://github.com/deepjavalibrary/djl/issues/2283, https://github.com/deepjavalibrary/djl/issues/2283, https://github.com/deepjavalibrary/djl/issues/2289
As pointed out in https://github.com/deepjavalibrary/djl/issues/2283, the native resources allocated by `ai.djl.pytorch.jni.PyTorchLibrary#torchIndexInit` was not released. This pr fixes it.
