### PR TITLE
A temporary solution to issue 2210 

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
@@ -404,6 +404,21 @@ public abstract class BaseNDManager implements NDManager {
 
     /** {@inheritDoc} */
     @Override
+    public void zeroGradients() {
+        for (AutoCloseable res : resources.values()) {
+            if (res instanceof NDManager) {
+                ((NDManager) res).zeroGradients();
+            } else if (res instanceof NDArray) {
+                NDArray array = (NDArray) res;
+                if (array.hasGradient()) {
+                    array.getGradient().subi(array.getGradient());
+                }
+            }
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void close() {
         if (this instanceof SystemNDManager) {
             return;

--- a/api/src/main/java/ai/djl/ndarray/NDArray.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArray.java
@@ -30,8 +30,6 @@ import java.nio.LongBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -4686,12 +4684,6 @@ public interface NDArray extends NDResource, BytesSupplier {
      * @return The inverse of gauss error of the {@code NDArray}, element-wise
      */
     NDArray erfinv();
-
-    /** {@inheritDoc} */
-    @Override
-    default List<NDArray> getResourceNDArrays() {
-        return Collections.singletonList(this);
-    }
 
     /**
      * Returns an internal representative of Native {@code NDArray}.

--- a/api/src/main/java/ai/djl/ndarray/NDList.java
+++ b/api/src/main/java/ai/djl/ndarray/NDList.java
@@ -27,7 +27,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
@@ -268,12 +267,6 @@ public class NDList extends ArrayList<NDArray> implements NDResource, BytesSuppl
     @Override
     public NDManager getManager() {
         return head().getManager();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public List<NDArray> getResourceNDArrays() {
-        return this;
     }
 
     /** {@inheritDoc} */

--- a/api/src/main/java/ai/djl/ndarray/NDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/NDManager.java
@@ -1668,6 +1668,9 @@ public interface NDManager extends AutoCloseable {
      */
     Engine getEngine();
 
+    /** Sets all the gradients within the NDManager to zero. */
+    void zeroGradients();
+
     /** {@inheritDoc} */
     @Override
     void close();

--- a/api/src/main/java/ai/djl/ndarray/NDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/NDManager.java
@@ -34,7 +34,6 @@ import java.nio.LongBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.List;
 
 /**
  * NDArray managers are used to create <I>NDArrays</I> (n-dimensional array on native engine).
@@ -1534,13 +1533,6 @@ public interface NDManager extends AutoCloseable {
      * @return the default {@link Device} of this {@code NDManager}
      */
     Device getDevice();
-
-    /**
-     * Returns all {@link NDArray}s managed by this manager (including recursively).
-     *
-     * @return all {@link NDArray}s managed by this manager (including recursively)
-     */
-    List<NDArray> getManagedArrays();
 
     /**
      * Attaches a resource to this {@code NDManager}.

--- a/api/src/main/java/ai/djl/ndarray/NDResource.java
+++ b/api/src/main/java/ai/djl/ndarray/NDResource.java
@@ -12,8 +12,6 @@
  */
 package ai.djl.ndarray;
 
-import java.util.List;
-
 /** An object which is managed by an {@link NDManager} and tracks the manager it is attached to. */
 public interface NDResource extends AutoCloseable {
 
@@ -23,13 +21,6 @@ public interface NDResource extends AutoCloseable {
      * @return the {@link NDManager} that manages this.
      */
     NDManager getManager();
-
-    /**
-     * Returns the {@link NDArray} or {@link NDArray}s contained within this resource.
-     *
-     * @return the {@link NDArray} or {@link NDArray}s contained within this resource
-     */
-    List<NDArray> getResourceNDArrays();
 
     /**
      * Attaches this {@link NDResource} to the specified {@link NDManager}.

--- a/api/src/main/java/ai/djl/training/GradientCollector.java
+++ b/api/src/main/java/ai/djl/training/GradientCollector.java
@@ -31,9 +31,6 @@ public interface GradientCollector extends AutoCloseable {
      */
     void backward(NDArray target);
 
-    /** Sets all the gradients within the engine to zero. */
-    void zeroGradients();
-
     /** {@inheritDoc} */
     @Override
     void close();

--- a/api/src/main/java/ai/djl/training/GradientCollector.java
+++ b/api/src/main/java/ai/djl/training/GradientCollector.java
@@ -21,14 +21,6 @@ import ai.djl.ndarray.NDArray;
  * performed within the try-with-resources are recorded and the variables marked. When {@link
  * #backward(NDArray) backward function} is called, gradients are collected w.r.t previously marked
  * variables.
- *
- * <p>The typical behavior is to open up a gradient collector during each batch and close it during
- * the end of the batch. In this way, the gradient is reset between batches. If the gradient
- * collector is left open for multiple calls to backwards, the gradients collected are accumulated
- * and added together.
- *
- * <p>Due to limitations in most engines, the gradient collectors are global. This means that only
- * one can be used at a time. If multiple are opened, an error will be thrown.
  */
 public interface GradientCollector extends AutoCloseable {
 

--- a/api/src/main/java/ai/djl/util/passthrough/PassthroughNDManager.java
+++ b/api/src/main/java/ai/djl/util/passthrough/PassthroughNDManager.java
@@ -293,5 +293,11 @@ public final class PassthroughNDManager implements NDManager {
 
     /** {@inheritDoc} */
     @Override
+    public void zeroGradients() {
+        throw new UnsupportedOperationException(UNSUPPORTED);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void close() {}
 }

--- a/api/src/main/java/ai/djl/util/passthrough/PassthroughNDManager.java
+++ b/api/src/main/java/ai/djl/util/passthrough/PassthroughNDManager.java
@@ -26,8 +26,6 @@ import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
-import java.util.Collections;
-import java.util.List;
 
 /** An {@link NDManager} that does nothing, for use in extensions and hybrid engines. */
 public final class PassthroughNDManager implements NDManager {
@@ -247,12 +245,6 @@ public final class PassthroughNDManager implements NDManager {
     @Override
     public Device getDevice() {
         return Device.cpu();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public List<NDArray> getManagedArrays() {
-        return Collections.emptyList();
     }
 
     /** {@inheritDoc} */

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxGradientCollector.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxGradientCollector.java
@@ -19,7 +19,7 @@ import ai.djl.ndarray.NDManager;
 import ai.djl.training.GradientCollector;
 
 /** {@code MxGradientCollector} is the MXNet implementation of {@link GradientCollector}. */
-public final class MxGradientCollector implements GradientCollector {
+public class MxGradientCollector implements GradientCollector {
 
     /**
      * Constructs an {@code MxGradientCollector} and enables training data collection for
@@ -115,16 +115,5 @@ public final class MxGradientCollector implements GradientCollector {
      */
     private void backward(NDArray array, boolean retainGraph) {
         JnaUtils.autogradBackward(new NDList(array), retainGraph ? 1 : 0);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void zeroGradients() {
-        NDManager systemManager = MxNDManager.getSystemManager();
-        for (NDArray array : systemManager.getManagedArrays()) {
-            if (array.hasGradient()) {
-                array.getGradient().subi(array.getGradient());
-            }
-        }
     }
 }

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtGradientCollector.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtGradientCollector.java
@@ -18,26 +18,15 @@ import ai.djl.ndarray.NDManager;
 import ai.djl.pytorch.jni.JniUtils;
 import ai.djl.training.GradientCollector;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 /** {@code PtGradientCollector} is the PyTorch implementation of {@link GradientCollector}. */
 public final class PtGradientCollector implements GradientCollector {
 
     private boolean gradModel;
-    private static AtomicBoolean isCollecting = new AtomicBoolean();
 
     /** Constructs a new {@code PtGradientCollector} instance. */
     public PtGradientCollector() {
         gradModel = JniUtils.isGradMode();
         JniUtils.setGradMode(true);
-
-        boolean wasCollecting = isCollecting.getAndSet(true);
-        if (wasCollecting) {
-            throw new IllegalStateException(
-                    "A PtGradientCollector is already collecting. Only one can be collecting at a"
-                            + " time");
-        }
-
         zeroGradients();
     }
 
@@ -84,7 +73,6 @@ public final class PtGradientCollector implements GradientCollector {
         if (!gradModel) {
             JniUtils.setGradMode(false);
         }
-        isCollecting.set(false);
         // TODO: do some clean up if necessary
     }
 }

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtGradientCollector.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtGradientCollector.java
@@ -14,12 +14,11 @@
 package ai.djl.pytorch.engine;
 
 import ai.djl.ndarray.NDArray;
-import ai.djl.ndarray.NDManager;
 import ai.djl.pytorch.jni.JniUtils;
 import ai.djl.training.GradientCollector;
 
 /** {@code PtGradientCollector} is the PyTorch implementation of {@link GradientCollector}. */
-public final class PtGradientCollector implements GradientCollector {
+public class PtGradientCollector implements GradientCollector {
 
     private boolean gradModel;
 
@@ -27,7 +26,6 @@ public final class PtGradientCollector implements GradientCollector {
     public PtGradientCollector() {
         gradModel = JniUtils.isGradMode();
         JniUtils.setGradMode(true);
-        zeroGradients();
     }
 
     /** {@inheritDoc} */
@@ -54,17 +52,6 @@ public final class PtGradientCollector implements GradientCollector {
      */
     private void backward(NDArray target, NDArray grad, boolean keepGraph, boolean createGraph) {
         JniUtils.backward((PtNDArray) target, (PtNDArray) grad, keepGraph, createGraph);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void zeroGradients() {
-        NDManager systemManager = PtNDManager.getSystemManager();
-        for (NDArray array : systemManager.getManagedArrays()) {
-            if (array.hasGradient()) {
-                array.getGradient().subi(array.getGradient());
-            }
-        }
     }
 
     /** {@inheritDoc} */

--- a/examples/src/test/java/ai/djl/examples/training/TrainAirfoilWithTabNetTest.java
+++ b/examples/src/test/java/ai/djl/examples/training/TrainAirfoilWithTabNetTest.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 public class TrainAirfoilWithTabNetTest {
     @Test
     public void testTrainAirfoilWithTabNet() throws TranslateException, IOException {
-        TestRequirements.nightly();
         TestRequirements.engine("MXNet", "PyTorch");
         String[] args = new String[] {"-g", "1", "-e", "20", "-b", "32"};
         TrainingResult result = TrainAirfoilWithTabNet.runExample(args);

--- a/integration/src/main/java/ai/djl/integration/tests/training/GradientCollectorIntegrationTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/training/GradientCollectorIntegrationTest.java
@@ -14,7 +14,6 @@ package ai.djl.integration.tests.training;
 
 import ai.djl.Model;
 import ai.djl.basicmodelzoo.basic.Mlp;
-import ai.djl.engine.Engine;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDArrays;
 import ai.djl.ndarray.NDList;
@@ -77,46 +76,6 @@ public class GradientCollectorIntegrationTest {
                     NDArray grad2 = lhs.getGradient();
                     Assertions.assertAlmostEquals(grad2, expected);
                 }
-            }
-        }
-    }
-
-    @Test
-    public void testZeroGradients() {
-        try (NDManager manager = NDManager.newBaseManager()) {
-            NDArray a = manager.create(0.0f);
-            a.setRequiresGradient(true);
-
-            try (GradientCollector gc = Engine.getInstance().newGradientCollector()) {
-                NDArray b = a.mul(2);
-
-                // Gradients are initially zero
-                Assert.assertEquals(a.getGradient().getFloat(), 0.0f);
-
-                // Gradients are updated by backwards
-                gc.backward(b);
-                Assert.assertEquals(a.getGradient().getFloat(), 2.0f);
-
-                // Gradients are cleared by zeroGradients
-                gc.zeroGradients();
-                Assert.assertEquals(a.getGradient().getFloat(), 0.0f);
-            }
-        }
-    }
-
-    /** Tests that the gradients do not accumulate when closing the gradient collector. */
-    @Test
-    public void testClearGradients() {
-        try (NDManager manager = NDManager.newBaseManager()) {
-            NDArray a = manager.create(0.0f);
-            a.setRequiresGradient(true);
-
-            for (int i = 0; i < 3; i++) {
-                try (GradientCollector gc = Engine.getInstance().newGradientCollector()) {
-                    NDArray b = a.mul(2);
-                    gc.backward(b);
-                }
-                Assert.assertEquals(a.getGradient().getFloat(), 2.0f);
             }
         }
     }


### PR DESCRIPTION
This PR aims to solve the issue https://github.com/deepjavalibrary/djl/issues/2210.  As mentioned in https://github.com/deepjavalibrary/djl/pull/2232, the issue originates from `zeroGradients()` call, which was added in PR https://github.com/deepjavalibrary/djl/pull/2101 in order to solve issue https://github.com/deepjavalibrary/djl/issues/2024. As attempted in PR https://github.com/deepjavalibrary/djl/pull/2232, specifying the block to a PtGradientCollector does not really solve the problem, but it is more of adding a feature. In that PR, by default, creation of PtGradientCollector doesn't call zeroGradients(), which means the zeroGradients feature introduced in PR https://github.com/deepjavalibrary/djl/pull/2101 has been effectively reverted in the solution proposed there.

Since there is currently no well designed solution to the efficiency issue mentioned in https://github.com/deepjavalibrary/djl/issues/2210, here the temporary solution is to revert PR 2111 and PR2101. To solve the original issue https://github.com/deepjavalibrary/djl/issues/2024 in the d2l book, we can just modify the example in the book to manually zero gradient, as shown below. The idea is that currently the GradientCollector does not do any additional modification after collecting the gradient from the engines. So it keeps default behaviour of each engine in terms of the gradient aggregation. Ie, for mxnet gradients are replaced, while for pytorch engine the gradients are added. This approach also maintains the room to add features of specifying how gradient is accumulated in the future. See https://github.com/deepjavalibrary/djl/pull/2232.

---
```java
    public void testClearGradients() {
        try (NDManager manager = NDManager.newBaseManager()) {
            NDArray variable = manager.create(0.0f);
            variable.setRequiresGradient(true);

            for (int i = 0; i < 3; i++) {
                manager.zeroGradients();
                try (GradientCollector gc = Engine.getInstance().newGradientCollector()) {
                    NDArray loss = variable.mul(2);
                    gc.backward(loss);
                }
                Assert.assertEquals(variable.getGradient().getFloat(), 2.0f);
            }
        }
    }
```
