### PR TITLE
Creates the TabularTranslator

### DIFF
--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/CsvDataset.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/CsvDataset.java
@@ -46,7 +46,7 @@ public class CsvDataset extends TabularDataset {
 
     /** {@inheritDoc} */
     @Override
-    protected String getCell(long rowIndex, String featureName) {
+    public String getCell(long rowIndex, String featureName) {
         CSVRecord record = csvRecords.get(Math.toIntExact(rowIndex));
         return record.get(featureName);
     }

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/ListFeatures.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/ListFeatures.java
@@ -22,17 +22,14 @@ public class ListFeatures extends ArrayList<String> {
     private static final long serialVersionUID = 1L;
 
     /**
-     * Constructs a {@link ListFeatures} from a source list.
+     * Constructs a {@code ListFeatures} instance.
      *
-     * @param source the source list
+     * @see ArrayList#ArrayList()
      */
-    public ListFeatures(List<String> source) {
-        super(source.size());
-        addAll(source);
-    }
+    public ListFeatures() {}
 
     /**
-     * Constructs a {@link ListFeatures}.
+     * Constructs a {@code ListFeatures} instance.
      *
      * @param initialCapacity the initial capacity of the list
      * @throws IllegalArgumentException if the specified initial capacity is negative
@@ -43,16 +40,17 @@ public class ListFeatures extends ArrayList<String> {
     }
 
     /**
-     * Constructs a {@link ListFeatures}.
+     * Constructs a {@code ListFeatures} instance from a source list.
      *
-     * @see ArrayList#ArrayList()
+     * @param source the source list
      */
-    public ListFeatures() {
-        super();
+    public ListFeatures(List<String> source) {
+        super(source.size());
+        addAll(source);
     }
 
     /**
-     * Constructs a {@link ListFeatures}.
+     * Constructs a {@code ListFeatures} instance.
      *
      * @param c the collection whose elements are to be placed into this list
      * @throws NullPointerException if the specified collection is null

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/ListFeatures.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/ListFeatures.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.basicdataset.tabular;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/** An extension of the {@link ArrayList} for use in the {@link TabularTranslator}. */
+public class ListFeatures extends ArrayList<String> {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a {@link ListFeatures} from a source list.
+     *
+     * @param source the source list
+     */
+    public ListFeatures(List<String> source) {
+        super(source.size());
+        addAll(source);
+    }
+
+    /**
+     * Constructs a {@link ListFeatures}.
+     *
+     * @param initialCapacity the initial capacity of the list
+     * @throws IllegalArgumentException if the specified initial capacity is negative
+     * @see ArrayList#ArrayList(int)
+     */
+    public ListFeatures(int initialCapacity) {
+        super(initialCapacity);
+    }
+
+    /**
+     * Constructs a {@link ListFeatures}.
+     *
+     * @see ArrayList#ArrayList()
+     */
+    public ListFeatures() {
+        super();
+    }
+
+    /**
+     * Constructs a {@link ListFeatures}.
+     *
+     * @param c the collection whose elements are to be placed into this list
+     * @throws NullPointerException if the specified collection is null
+     * @see ArrayList#ArrayList(Collection)
+     */
+    public ListFeatures(Collection<? extends String> c) {
+        super(c);
+    }
+}

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/MapFeatures.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/MapFeatures.java
@@ -21,16 +21,14 @@ public class MapFeatures extends ConcurrentHashMap<String, String> {
     private static final long serialVersionUID = 1L;
 
     /**
-     * Constructs a {@link MapFeatures}.
+     * Constructs a {@code MapFeatures} instance.
      *
      * @see ConcurrentHashMap#ConcurrentHashMap()
      */
-    public MapFeatures() {
-        super();
-    }
+    public MapFeatures() {}
 
     /**
-     * Constructs a {@link MapFeatures}.
+     * Constructs a {@code MapFeatures} instance.
      *
      * @param initialCapacity The implementation performs internal sizing to accommodate this many
      *     elements.
@@ -42,7 +40,7 @@ public class MapFeatures extends ConcurrentHashMap<String, String> {
     }
 
     /**
-     * Constructs a {@link MapFeatures}.
+     * Constructs a {@code MapFeatures} instance.
      *
      * @param m the map
      * @see ConcurrentHashMap#ConcurrentHashMap(Map)
@@ -52,7 +50,7 @@ public class MapFeatures extends ConcurrentHashMap<String, String> {
     }
 
     /**
-     * Constructs a {@link MapFeatures}.
+     * Constructs a {@code MapFeatures} instance.
      *
      * @param initialCapacity the initial capacity. The implementation performs internal sizing to
      *     accommodate this many elements, given the specified load factor.

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/MapFeatures.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/MapFeatures.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.basicdataset.tabular;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** An extension of the {@link ConcurrentHashMap} for use in the {@link TabularTranslator}. */
+public class MapFeatures extends ConcurrentHashMap<String, String> {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a {@link MapFeatures}.
+     *
+     * @see ConcurrentHashMap#ConcurrentHashMap()
+     */
+    public MapFeatures() {
+        super();
+    }
+
+    /**
+     * Constructs a {@link MapFeatures}.
+     *
+     * @param initialCapacity The implementation performs internal sizing to accommodate this many
+     *     elements.
+     * @throws IllegalArgumentException if the initial capacity of elements is negative
+     * @see ConcurrentHashMap#ConcurrentHashMap(int)
+     */
+    public MapFeatures(int initialCapacity) {
+        super(initialCapacity);
+    }
+
+    /**
+     * Constructs a {@link MapFeatures}.
+     *
+     * @param m the map
+     * @see ConcurrentHashMap#ConcurrentHashMap(Map)
+     */
+    public MapFeatures(Map<? extends String, ? extends String> m) {
+        super(m);
+    }
+
+    /**
+     * Constructs a {@link MapFeatures}.
+     *
+     * @param initialCapacity the initial capacity. The implementation performs internal sizing to
+     *     accommodate this many elements, given the specified load factor.
+     * @param loadFactor the load factor (table density) for establishing the initial table size
+     * @throws IllegalArgumentException if the initial capacity of elements is negative or the load
+     *     factor is nonpositive
+     * @see ConcurrentHashMap#ConcurrentHashMap(int, float)
+     */
+    public MapFeatures(int initialCapacity, float loadFactor) {
+        super(initialCapacity, loadFactor);
+    }
+
+    /**
+     * Constructs a {@link MapFeatures}.
+     *
+     * @param initialCapacity the initial capacity. The implementation performs internal sizing to
+     *     accommodate this many elements, given the specified load factor.
+     * @param loadFactor the load factor (table density) for establishing the initial table size
+     * @param concurrencyLevel the estimated number of concurrently updating threads. The
+     *     implementation may use this value as a sizing hint.
+     * @throws IllegalArgumentException if the initial capacity is negative or the load factor or
+     *     concurrencyLevel are nonpositive
+     * @see ConcurrentHashMap#ConcurrentHashMap(int, float, int)
+     */
+    public MapFeatures(int initialCapacity, float loadFactor, int concurrencyLevel) {
+        super(initialCapacity, loadFactor, concurrencyLevel);
+    }
+
+    /**
+     * Creates a {@link MapFeatures} from a source list.
+     *
+     * @param source the source list
+     * @return a new {@link MapFeatures}
+     */
+    public static MapFeatures fromMap(Map<String, String> source) {
+        MapFeatures map = new MapFeatures(source.size());
+        map.putAll(source);
+        return map;
+    }
+}

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/MovieLens100k.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/MovieLens100k.java
@@ -93,7 +93,7 @@ public final class MovieLens100k extends CsvDataset {
 
     /** {@inheritDoc} */
     @Override
-    protected String getCell(long rowIndex, String featureName) {
+    public String getCell(long rowIndex, String featureName) {
         CSVRecord record = csvRecords.get(Math.toIntExact(rowIndex));
         if (HeaderEnum.rating.toString().equals(featureName)) {
             return record.get(HeaderEnum.rating);

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularDataset.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularDataset.java
@@ -21,6 +21,7 @@ import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.training.dataset.RandomAccessDataset;
 import ai.djl.training.dataset.Record;
+import ai.djl.translate.TranslatorOptions;
 
 import java.nio.FloatBuffer;
 import java.util.ArrayList;
@@ -69,6 +70,24 @@ public abstract class TabularDataset extends RandomAccessDataset {
      */
     public int getLabelSize() {
         return labels.size();
+    }
+
+    /**
+     * Returns the dataset features.
+     *
+     * @return the dataset features
+     */
+    public List<Feature> getFeatures() {
+        return features;
+    }
+
+    /**
+     * Returns the dataset labels.
+     *
+     * @return the dataset labels
+     */
+    public List<Feature> getLabels() {
+        return labels;
     }
 
     /** {@inheritDoc} */
@@ -130,7 +149,13 @@ public abstract class TabularDataset extends RandomAccessDataset {
      * @param featureName the feature or column of the cell
      * @return the value of the cell at that row and column
      */
-    protected abstract String getCell(long rowIndex, String featureName);
+    public abstract String getCell(long rowIndex, String featureName);
+
+    /** {@inheritDoc} */
+    @Override
+    public TranslatorOptions matchingTranslatorOptions() {
+        return new TabularTranslator(features, labels).getExpansions();
+    }
 
     /**
      * Used to build a {@link TabularDataset}.

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularResults.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularResults.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.basicdataset.tabular;
+
+import java.util.List;
+
+/** A list of results from running a tabular model. */
+public class TabularResults {
+
+    private List<TabularResult> results;
+
+    /**
+     * Constructs a {@link TabularResults} with the given results.
+     *
+     * @param results the results
+     */
+    public TabularResults(List<TabularResult> results) {
+        this.results = results;
+    }
+
+    /**
+     * Returns the result for the given feature index.
+     *
+     * @param index the feature/label index
+     * @return the result
+     */
+    public TabularResult getFeature(int index) {
+        return results.get(index);
+    }
+
+    /**
+     * Returns the result for the given feature name.
+     *
+     * @param name the feature/label name
+     * @return the result
+     */
+    public TabularResult getFeature(String name) {
+        for (TabularResult result : results) {
+            if (result.getName().equals(name)) {
+                return result;
+            }
+        }
+        throw new IllegalArgumentException(
+                "The TabularResults does not contain a result with name " + name);
+    }
+
+    /**
+     * Returns all of the {@link TabularResult}.
+     *
+     * @return all of the {@link TabularResult}
+     */
+    public List<TabularResult> getAll() {
+        return results;
+    }
+
+    /**
+     * Returns the number of results.
+     *
+     * @return the number of results
+     */
+    public int size() {
+        return results.size();
+    }
+
+    /** A single result corresponding to a single feature. */
+    public static class TabularResult {
+        private String name;
+        private Object result;
+
+        /**
+         * Constructs the result.
+         *
+         * @param name the feature name
+         * @param result the computed feature result
+         */
+        public TabularResult(String name, Object result) {
+            this.name = name;
+            this.result = result;
+        }
+
+        /**
+         * Returns the result (feature) name.
+         *
+         * @return the result (feature) name
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * Returns the computed result.
+         *
+         * @return the computed result
+         */
+        public Object getResult() {
+            return result;
+        }
+    }
+}

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularResults.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularResults.java
@@ -73,7 +73,8 @@ public class TabularResults {
     }
 
     /** A single result corresponding to a single feature. */
-    public static class TabularResult {
+    public static final class TabularResult {
+
         private String name;
         private Object result;
 

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularTranslator.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularTranslator.java
@@ -36,7 +36,7 @@ public class TabularTranslator implements Translator<ListFeatures, TabularResult
     private List<Feature> labels;
 
     /**
-     * Constructs a {@link TabularTranslator} with the given features and labels.
+     * Constructs a {@code TabularTranslator} with the given features and labels.
      *
      * @param features the features for inputs
      * @param labels the labels for outputs

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularTranslator.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularTranslator.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.basicdataset.tabular;
+
+import ai.djl.Model;
+import ai.djl.basicdataset.tabular.TabularResults.TabularResult;
+import ai.djl.basicdataset.tabular.utils.DynamicBuffer;
+import ai.djl.basicdataset.tabular.utils.Feature;
+import ai.djl.basicdataset.tabular.utils.Featurizer;
+import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.types.Shape;
+import ai.djl.translate.Translator;
+import ai.djl.translate.TranslatorContext;
+import ai.djl.translate.TranslatorOptions;
+
+import java.nio.FloatBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/** A {@link Translator} that can be used for {@link ai.djl.Application.Tabular} tasks. */
+public class TabularTranslator implements Translator<ListFeatures, TabularResults> {
+
+    private List<Feature> features;
+    private List<Feature> labels;
+
+    /**
+     * Constructs a {@link TabularTranslator} with the given features and labels.
+     *
+     * @param features the features for inputs
+     * @param labels the labels for outputs
+     */
+    public TabularTranslator(List<Feature> features, List<Feature> labels) {
+        this.features = features;
+        this.labels = labels;
+    }
+
+    /**
+     * Constructs a tabular translator for a model.
+     *
+     * @param model the model
+     * @param arguments the arguments to build the translator with
+     */
+    @SuppressWarnings("PMD.UnusedFormalParameter") // TODO: Remove when implementing function
+    public TabularTranslator(Model model, Map<String, ?> arguments) {
+        throw new UnsupportedOperationException(
+                "Constructing the TabularTranslator from arguments is not currently supported");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public TabularResults processOutput(TranslatorContext ctx, NDList list) throws Exception {
+        List<TabularResult> results = new ArrayList<>(labels.size());
+        float[] data = list.singletonOrThrow().toFloatArray();
+        int dataIndex = 0;
+        for (Feature label : labels) {
+            Featurizer featurizer = label.getFeaturizer();
+            int dataRequired = featurizer.dataRequired();
+            Object deFeaturized =
+                    featurizer.deFeaturize(
+                            Arrays.copyOfRange(data, dataIndex, dataIndex + dataRequired));
+            results.add(new TabularResult(label.getName(), deFeaturized));
+            dataIndex += dataRequired;
+        }
+        return new TabularResults(results);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDList processInput(TranslatorContext ctx, ListFeatures input) throws Exception {
+        if (input.size() != features.size()) {
+            throw new IllegalArgumentException(
+                    "The TabularTranslator expects "
+                            + features.size()
+                            + " arguments but received "
+                            + input.size());
+        }
+
+        DynamicBuffer bb = new DynamicBuffer();
+        for (int i = 0; i < features.size(); i++) {
+            String value = input.get(i);
+            features.get(i).getFeaturizer().featurize(bb, value);
+        }
+        FloatBuffer buf = bb.getBuffer();
+        return new NDList(ctx.getNDManager().create(buf, new Shape(bb.getLength())));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public TranslatorOptions getExpansions() {
+        return new TabularTranslatorFactory().withTranslator(this);
+    }
+
+    /**
+     * Returns the features for the translator.
+     *
+     * @return the features for the translator
+     */
+    public List<Feature> getFeatures() {
+        return features;
+    }
+
+    /**
+     * Returns the labels for the translator.
+     *
+     * @return the labels for the translator
+     */
+    public List<Feature> getLabels() {
+        return labels;
+    }
+}

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularTranslatorFactory.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularTranslatorFactory.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.basicdataset.tabular;
+
+import ai.djl.Model;
+import ai.djl.basicdataset.tabular.utils.Feature;
+import ai.djl.modality.Classifications;
+import ai.djl.ndarray.NDList;
+import ai.djl.translate.ExpansionTranslatorFactory;
+import ai.djl.translate.PostProcessor;
+import ai.djl.translate.PreProcessor;
+import ai.djl.translate.Translator;
+import ai.djl.translate.TranslatorContext;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+/** A {@link ai.djl.translate.TranslatorFactory} to extend the {@link TabularTranslator}. */
+public class TabularTranslatorFactory
+        extends ExpansionTranslatorFactory<ListFeatures, TabularResults> {
+
+    /** {@inheritDoc} */
+    @Override
+    protected Translator<ListFeatures, TabularResults> buildBaseTranslator(
+            Model model, Map<String, ?> arguments) {
+        return new TabularTranslator(model, arguments);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Class<ListFeatures> getBaseInputType() {
+        return ListFeatures.class;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Class<TabularResults> getBaseOutputType() {
+        return TabularResults.class;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected Map<Type, Function<PreProcessor<ListFeatures>, PreProcessor<?>>>
+            getPreprocessorExpansions() {
+        Map<Type, Function<PreProcessor<ListFeatures>, PreProcessor<?>>> expansions =
+                new ConcurrentHashMap<>();
+        expansions.put(MapFeatures.class, MapPreProcessor::new);
+        return expansions;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected Map<Type, Function<PostProcessor<TabularResults>, PostProcessor<?>>>
+            getPostprocessorExpansions() {
+        Map<Type, Function<PostProcessor<TabularResults>, PostProcessor<?>>> expansions =
+                new ConcurrentHashMap<>();
+        expansions.put(Classifications.class, ClassificationsTabularPostProcessor::new);
+        expansions.put(Float.class, RegressionTabularPostProcessor::new);
+        return expansions;
+    }
+
+    static class MapPreProcessor implements PreProcessor<MapFeatures> {
+
+        private TabularTranslator preProcessor;
+
+        MapPreProcessor(PreProcessor<ListFeatures> preProcessor) {
+            if (!(preProcessor instanceof TabularTranslator)) {
+                throw new IllegalArgumentException(
+                        "The MapPreProcessor for the TabularTranslatorFactory expects a"
+                                + " TabularTranslator, but received "
+                                + preProcessor.getClass().getName());
+            }
+            this.preProcessor = (TabularTranslator) preProcessor;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public NDList processInput(TranslatorContext ctx, MapFeatures input) throws Exception {
+            ListFeatures list = new ListFeatures(preProcessor.getFeatures().size());
+            for (Feature feature : preProcessor.getFeatures()) {
+                if (input.containsKey(feature.getName())) {
+                    list.add(input.get(feature.getName()));
+                } else {
+                    throw new IllegalArgumentException(
+                            "The input to the TabularTranslator is missing the feature: "
+                                    + feature.getName());
+                }
+            }
+            return preProcessor.processInput(ctx, list);
+        }
+    }
+
+    static class ClassificationsTabularPostProcessor implements PostProcessor<Classifications> {
+
+        private PostProcessor<TabularResults> postProcessor;
+
+        ClassificationsTabularPostProcessor(PostProcessor<TabularResults> postProcessor) {
+            this.postProcessor = postProcessor;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public Classifications processOutput(TranslatorContext ctx, NDList list) throws Exception {
+            TabularResults results = postProcessor.processOutput(ctx, list);
+
+            if (results.size() != 1) {
+                throw new IllegalStateException(
+                        "The ClassificationsTabularPostProcessor expected the model to produce one"
+                                + " output, but instead it produced "
+                                + results.size());
+            }
+
+            Object result = results.getFeature(0).getResult();
+            if (result instanceof Classifications) {
+                return (Classifications) result;
+            }
+            throw new IllegalStateException(
+                    "The ClassificationsTabularPostProcessor expected the model to produce a"
+                            + " Classifications, but instead it produced "
+                            + result.getClass().getName());
+        }
+    }
+
+    static class RegressionTabularPostProcessor implements PostProcessor<Float> {
+
+        private PostProcessor<TabularResults> postProcessor;
+
+        RegressionTabularPostProcessor(PostProcessor<TabularResults> postProcessor) {
+            this.postProcessor = postProcessor;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public Float processOutput(TranslatorContext ctx, NDList list) throws Exception {
+            TabularResults results = postProcessor.processOutput(ctx, list);
+
+            if (results.size() != 1) {
+                throw new IllegalStateException(
+                        "The RegressionTabularPostProcessor expected the model to produce one"
+                                + " output, but instead it produced "
+                                + results.size());
+            }
+
+            Object result = results.getFeature(0).getResult();
+            if (result instanceof Float) {
+                return (Float) result;
+            }
+            throw new IllegalStateException(
+                    "The RegressionTabularPostProcessor expected the model to produce a float, but"
+                            + " instead it produced "
+                            + result.getClass().getName());
+        }
+    }
+}

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularTranslatorFactory.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularTranslatorFactory.java
@@ -71,7 +71,7 @@ public class TabularTranslatorFactory
         return expansions;
     }
 
-    static class MapPreProcessor implements PreProcessor<MapFeatures> {
+    static final class MapPreProcessor implements PreProcessor<MapFeatures> {
 
         private TabularTranslator preProcessor;
 
@@ -102,7 +102,8 @@ public class TabularTranslatorFactory
         }
     }
 
-    static class ClassificationsTabularPostProcessor implements PostProcessor<Classifications> {
+    static final class ClassificationsTabularPostProcessor
+            implements PostProcessor<Classifications> {
 
         private PostProcessor<TabularResults> postProcessor;
 
@@ -133,7 +134,7 @@ public class TabularTranslatorFactory
         }
     }
 
-    static class RegressionTabularPostProcessor implements PostProcessor<Float> {
+    static final class RegressionTabularPostProcessor implements PostProcessor<Float> {
 
         private PostProcessor<TabularResults> postProcessor;
 

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/utils/Feature.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/utils/Feature.java
@@ -12,6 +12,8 @@
  */
 package ai.djl.basicdataset.tabular.utils;
 
+import ai.djl.basicdataset.tabular.utils.Featurizer.DataFeaturizer;
+
 import java.util.Map;
 
 /** A class contains feature name and its {@code Featurizer}. */
@@ -27,6 +29,17 @@ public final class Feature {
      * @param featurizer the {@code Featurizer}
      */
     public Feature(String name, Featurizer featurizer) {
+        this.name = name;
+        this.featurizer = featurizer;
+    }
+
+    /**
+     * Constructs a {@code Feature} instance.
+     *
+     * @param name the feature name
+     * @param featurizer the {@code Featurizer}
+     */
+    public Feature(String name, DataFeaturizer featurizer) {
         this.name = name;
         this.featurizer = featurizer;
     }

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/utils/Featurizer.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/utils/Featurizer.java
@@ -22,4 +22,40 @@ public interface Featurizer {
      * @param input the string input
      */
     void featurize(DynamicBuffer buf, String input);
+
+    /**
+     * Returns the length of the data array required by {@link #deFeaturize(float[])}.
+     *
+     * @return the length of the data array required by {@link #deFeaturize(float[])}
+     */
+    int dataRequired();
+
+    /**
+     * Converts the output data for a label back into the Java type.
+     *
+     * @param data the data vector correspondign to the feature
+     * @return a Java type (depending on the {@link Featurizer}) representing the data.
+     */
+    Object deFeaturize(float[] data);
+
+    /**
+     * A {@link Featurizer} that only supports the data featurize operations, but not the full
+     * deFeaturize operations used by labels.
+     */
+    interface DataFeaturizer extends Featurizer {
+
+        /** {@inheritDoc} */
+        @Override
+        default int dataRequired() {
+            throw new IllegalStateException(
+                    "DataFeaturizers only support featurize, not deFeaturize");
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        default Object deFeaturize(float[] data) {
+            throw new IllegalStateException(
+                    "DataFeaturizers only support featurize, not deFeaturize");
+        }
+    }
 }

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/utils/Featurizers.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/utils/Featurizers.java
@@ -173,10 +173,10 @@ public final class Featurizers {
     }
 
     private abstract static class BaseStringFeaturizer implements Featurizer {
+
         protected Map<String, Integer> map;
         protected List<String> classNames;
 
-        @SuppressWarnings("PMD.ConstructorCallsOverridableMethod")
         public BaseStringFeaturizer(Map<String, Integer> map) {
             this.map = map;
             if (map != null) {
@@ -184,11 +184,13 @@ public final class Featurizers {
             }
         }
 
+        /** {@inheritDoc} */
         @Override
         public int dataRequired() {
             return map.size();
         }
 
+        /** {@inheritDoc} */
         @Override
         public Object deFeaturize(float[] data) {
             List<Double> probabilities = new ArrayList<>(data.length);
@@ -198,7 +200,7 @@ public final class Featurizers {
             return new Classifications(classNames, probabilities);
         }
 
-        protected void buildClassNames() {
+        protected final void buildClassNames() {
             classNames = Arrays.asList(new String[map.size()]);
             for (Map.Entry<String, Integer> entry : map.entrySet()) {
                 classNames.set(entry.getValue(), entry.getKey());
@@ -272,6 +274,7 @@ public final class Featurizers {
             buf.put(value);
         }
 
+        /** {@inheritDoc} */
         @Override
         public Object deFeaturize(float[] data) {
             if (classNames.size() != map.size()) {
@@ -292,7 +295,7 @@ public final class Featurizers {
         String datePattern;
 
         /**
-         * Constructs a {@link EpochDayFeaturizer}.
+         * Constructs a {@code EpochDayFeaturizer}.
          *
          * @param datePattern the pattern that dates are found in the data table column
          */
@@ -315,11 +318,13 @@ public final class Featurizers {
             buf.put(day);
         }
 
+        /** {@inheritDoc} */
         @Override
         public int dataRequired() {
             return 1;
         }
 
+        /** {@inheritDoc} */
         @Override
         public Object deFeaturize(float[] data) {
             return LocalDate.ofEpochDay(Math.round(data[0]));

--- a/basicdataset/src/test/java/ai/djl/basicdataset/AmesRandomAccessTest.java
+++ b/basicdataset/src/test/java/ai/djl/basicdataset/AmesRandomAccessTest.java
@@ -14,6 +14,8 @@ package ai.djl.basicdataset;
 
 import ai.djl.Model;
 import ai.djl.basicdataset.tabular.AmesRandomAccess;
+import ai.djl.basicdataset.tabular.ListFeatures;
+import ai.djl.inference.Predictor;
 import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.NDManager;
 import ai.djl.nn.Blocks;
@@ -27,11 +29,13 @@ import ai.djl.training.dataset.Record;
 import ai.djl.training.initializer.Initializer;
 import ai.djl.training.loss.Loss;
 import ai.djl.translate.TranslateException;
+import ai.djl.translate.Translator;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 /*
  * 80 features
@@ -84,6 +88,15 @@ public class AmesRandomAccessTest {
                 Assert.assertEquals(batch.getData().size(), 1);
                 Assert.assertEquals(batch.getLabels().size(), 1);
                 batch.close();
+            }
+
+            Translator<ListFeatures, Float> translator =
+                    amesRandomAccess
+                            .matchingTranslatorOptions()
+                            .option(ListFeatures.class, Float.class);
+            try (Predictor<ListFeatures, Float> predictor = model.newPredictor(translator)) {
+                Float result = predictor.predict(new ListFeatures(Arrays.asList("0", "1", "NA")));
+                Assert.assertEquals(result, 0.0f);
             }
         }
     }

--- a/basicdataset/src/test/java/ai/djl/basicdataset/tabular/TabularTranslatorFactoryTest.java
+++ b/basicdataset/src/test/java/ai/djl/basicdataset/tabular/TabularTranslatorFactoryTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.basicdataset.tabular;
+
+import ai.djl.Model;
+import ai.djl.modality.Classifications;
+import ai.djl.modality.Output;
+import ai.djl.modality.cv.Image;
+import ai.djl.translate.BasicTranslator;
+import ai.djl.translate.Translator;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TabularTranslatorFactoryTest {
+    private TabularTranslatorFactory factory;
+
+    @BeforeClass
+    public void setUp() {
+        factory = new TabularTranslatorFactory();
+    }
+
+    @Test
+    public void testGetSupportedTypes() {
+        Assert.assertEquals(factory.getSupportedTypes().size(), 6);
+    }
+
+    // TODO: This test requires implementing the TabularTranslator constructor from arguments
+    @Test(enabled = false)
+    public void testNewInstance() {
+        Map<String, String> arguments = new HashMap<>();
+        try (Model model = Model.newInstance("test")) {
+            Translator<ListFeatures, TabularResults> translator1 =
+                    factory.newInstance(ListFeatures.class, TabularResults.class, model, arguments);
+            Assert.assertTrue(translator1 instanceof TabularTranslator);
+
+            Translator<MapFeatures, Classifications> translator2 =
+                    factory.newInstance(MapFeatures.class, Classifications.class, model, arguments);
+            Assert.assertTrue(translator2 instanceof BasicTranslator);
+
+            Translator<ListFeatures, Float> translator3 =
+                    factory.newInstance(ListFeatures.class, Float.class, model, arguments);
+            Assert.assertTrue(translator3 instanceof BasicTranslator);
+
+            Assert.assertThrows(
+                    IllegalArgumentException.class,
+                    () -> factory.newInstance(Image.class, Output.class, model, arguments));
+        }
+    }
+}

--- a/basicdataset/src/test/java/ai/djl/basicdataset/tabular/package-info.java
+++ b/basicdataset/src/test/java/ai/djl/basicdataset/tabular/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+/** Contains tests for {@link ai.djl.basicdataset.tabular}. */
+package ai.djl.basicdataset.tabular;

--- a/djl-zero/src/main/java/ai/djl/zero/tabular/TabularRegression.java
+++ b/djl-zero/src/main/java/ai/djl/zero/tabular/TabularRegression.java
@@ -13,9 +13,9 @@
 package ai.djl.zero.tabular;
 
 import ai.djl.Model;
+import ai.djl.basicdataset.tabular.ListFeatures;
 import ai.djl.basicdataset.tabular.TabularDataset;
 import ai.djl.basicmodelzoo.tabular.TabNet;
-import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.nn.Block;
 import ai.djl.repository.zoo.ZooModel;
@@ -26,8 +26,8 @@ import ai.djl.training.TrainingConfig;
 import ai.djl.training.dataset.Dataset;
 import ai.djl.training.listener.TrainingListener;
 import ai.djl.training.loss.TabNetRegressionLoss;
-import ai.djl.translate.NoopTranslator;
 import ai.djl.translate.TranslateException;
+import ai.djl.translate.Translator;
 import ai.djl.zero.Performance;
 
 import java.io.IOException;
@@ -49,7 +49,8 @@ public final class TabularRegression {
      * @throws IOException if the dataset could not be loaded
      * @throws TranslateException if the translator has errors
      */
-    public static ZooModel<NDList, NDList> train(TabularDataset dataset, Performance performance)
+    public static ZooModel<ListFeatures, Float> train(
+            TabularDataset dataset, Performance performance)
             throws IOException, TranslateException {
         Dataset[] splitDataset = dataset.randomSplit(8, 2);
         Dataset trainDataset = splitDataset[0];
@@ -92,6 +93,8 @@ public final class TabularRegression {
             EasyTrain.fit(trainer, 20, trainDataset, validateDataset);
         }
 
-        return new ZooModel<>(model, new NoopTranslator());
+        Translator<ListFeatures, Float> translator =
+                dataset.matchingTranslatorOptions().option(ListFeatures.class, Float.class);
+        return new ZooModel<>(model, translator);
     }
 }

--- a/examples/src/main/java/ai/djl/examples/training/transferlearning/TrainAmazonReviewRanking.java
+++ b/examples/src/main/java/ai/djl/examples/training/transferlearning/TrainAmazonReviewRanking.java
@@ -18,7 +18,7 @@ import ai.djl.ModelException;
 import ai.djl.basicdataset.tabular.CsvDataset;
 import ai.djl.basicdataset.tabular.utils.DynamicBuffer;
 import ai.djl.basicdataset.tabular.utils.Feature;
-import ai.djl.basicdataset.tabular.utils.Featurizer;
+import ai.djl.basicdataset.tabular.utils.Featurizer.DataFeaturizer;
 import ai.djl.engine.Engine;
 import ai.djl.examples.training.util.Arguments;
 import ai.djl.metric.Metrics;
@@ -212,7 +212,7 @@ public final class TrainAmazonReviewRanking {
                 .addTrainingListeners(listener);
     }
 
-    private static final class BertFeaturizer implements Featurizer {
+    private static final class BertFeaturizer implements DataFeaturizer {
 
         private final BertFullTokenizer tokenizer;
         private final int maxLength;

--- a/extensions/tablesaw/src/main/java/ai/djl/tablesaw/TablesawDataset.java
+++ b/extensions/tablesaw/src/main/java/ai/djl/tablesaw/TablesawDataset.java
@@ -35,7 +35,7 @@ public class TablesawDataset extends TabularDataset {
 
     /** {@inheritDoc} */
     @Override
-    protected String getCell(long rowIndex, String featureName) {
+    public String getCell(long rowIndex, String featureName) {
         Row row = table.row(Math.toIntExact(rowIndex));
         return row.getString(featureName);
     }

--- a/extensions/timeseries/src/main/java/ai/djl/timeseries/dataset/TimeFeaturizer.java
+++ b/extensions/timeseries/src/main/java/ai/djl/timeseries/dataset/TimeFeaturizer.java
@@ -17,6 +17,7 @@ import ai.djl.basicdataset.tabular.utils.DynamicBuffer;
 import ai.djl.basicdataset.tabular.utils.Featurizer;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 /**
  * An interface that convert String to {@link LocalDateTime} as the start field of {@link
@@ -38,4 +39,16 @@ public interface TimeFeaturizer extends Featurizer {
      * @return the parsed {@link LocalDateTime}
      */
     LocalDateTime featurize(String input);
+
+    /** {@inheritDoc} */
+    @Override
+    default int dataRequired() {
+        return 2;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    default Object deFeaturize(float[] data) {
+        return LocalDateTime.ofEpochSecond((long) data[0], (int) data[1], ZoneOffset.UTC);
+    }
 }


### PR DESCRIPTION
This creates a standard TabularTranslator based on the Featurizer and Feature interface. Accompanying it is an ExpansionTranslatorFactory so it has two possible inputs (MapFeatures or ListFeatures) and three outputs (TabularResults, Regression, and Classification).

The MapFeatures and ListFeatures are created to help avoid complications with class lookups. Otherwise, it would require weird unchecked casting: (Class<List<String>>)(Class<?>)List.class.

As part of this, it also expands the Featurizer to also include capabilities for deFeaturizing. The helper of DataFeaturizer is still around for Featurizers that don't support the label deFeaturization.
