### PR TITLE
[api] Fixes toDebugString() IllegalStateException if NDArray is closed

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/NDArray.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArray.java
@@ -4725,6 +4725,13 @@ public interface NDArray extends NDResource, BytesSupplier {
     NDArrayEx getNDArrayInternal();
 
     /**
+     * Returns {@code true} if this NDArray has been released.
+     *
+     * @return {@code true} if this NDArray has been released
+     */
+    boolean isReleased();
+
+    /**
      * Runs the debug string representation of this {@code NDArray}.
      *
      * @return the debug string representation of this {@code NDArray}
@@ -4755,6 +4762,9 @@ public interface NDArray extends NDResource, BytesSupplier {
      */
     default String toDebugString(
             int maxSize, int maxDepth, int maxRows, int maxColumns, boolean withContent) {
+        if (isReleased()) {
+            return "This array is already closed";
+        }
         return NDFormat.format(this, maxSize, maxDepth, maxRows, maxColumns, withContent);
     }
 

--- a/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
@@ -1179,6 +1179,12 @@ public abstract class NDArrayAdapter implements NDArray {
 
     /** {@inheritDoc} */
     @Override
+    public boolean isReleased() {
+        return isClosed;
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void close() {
         if (!isClosed) {
             manager.detachInternal(getUid());


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
