### PR TITLE
if native resource closed, on demand info to identify NDArray

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/NDScope.java
+++ b/api/src/main/java/ai/djl/ndarray/NDScope.java
@@ -26,31 +26,13 @@ public class NDScope implements AutoCloseable {
 
     private static final ThreadLocal<Deque<NDScope>> SCOPE_STACK =
             ThreadLocal.withInitial(ArrayDeque::new);
-    private static boolean verboseIfResourceAlreadyClosed;
+
     private IdentityHashMap<NDArray, NDArray> resources;
 
     /** Constructs a new {@code NDScope} instance. */
     public NDScope() {
         resources = new IdentityHashMap<>();
         SCOPE_STACK.get().addLast(this);
-    }
-
-    /**
-     * If true, a verbose message is printed if a resource is already closed.
-     *
-     * @return true if the verboseIfResourceAlreadyClosed is set
-     */
-    public static boolean isVerboseIfResourceAlreadyClosed() {
-        return verboseIfResourceAlreadyClosed;
-    }
-
-    /**
-     * If true, a verbose message is printed if a resource is already closed.
-     *
-     * @param verboseIfResourceAlreadyClosed parameter to set
-     */
-    public static void setVerboseIfResourceAlreadyClosed(boolean verboseIfResourceAlreadyClosed) {
-        NDScope.verboseIfResourceAlreadyClosed = verboseIfResourceAlreadyClosed;
     }
 
     /**

--- a/api/src/main/java/ai/djl/ndarray/NDScope.java
+++ b/api/src/main/java/ai/djl/ndarray/NDScope.java
@@ -26,13 +26,31 @@ public class NDScope implements AutoCloseable {
 
     private static final ThreadLocal<Deque<NDScope>> SCOPE_STACK =
             ThreadLocal.withInitial(ArrayDeque::new);
-
+    private static boolean verboseIfResourceAlreadyClosed;
     private IdentityHashMap<NDArray, NDArray> resources;
 
     /** Constructs a new {@code NDScope} instance. */
     public NDScope() {
         resources = new IdentityHashMap<>();
         SCOPE_STACK.get().addLast(this);
+    }
+
+    /**
+     * If true, a verbose message is printed if a resource is already closed.
+     *
+     * @return true if the verboseIfResourceAlreadyClosed is set
+     */
+    public static boolean isVerboseIfResourceAlreadyClosed() {
+        return verboseIfResourceAlreadyClosed;
+    }
+
+    /**
+     * If true, a verbose message is printed if a resource is already closed.
+     *
+     * @param verboseIfResourceAlreadyClosed parameter to set
+     */
+    public static void setVerboseIfResourceAlreadyClosed(boolean verboseIfResourceAlreadyClosed) {
+        NDScope.verboseIfResourceAlreadyClosed = verboseIfResourceAlreadyClosed;
     }
 
     /**

--- a/api/src/main/java/ai/djl/util/NativeResource.java
+++ b/api/src/main/java/ai/djl/util/NativeResource.java
@@ -58,7 +58,7 @@ public abstract class NativeResource<T> implements AutoCloseable {
         T reference = handle.get();
         if (reference == null) {
             if (TRACK_RESOURCE) {
-                logger.error("Native resource is released. Closed at:", exception);
+                logger.error("Native resource " + uid + " is released. Closed at:", exception);
             }
             String message = "Native resource has been released already.";
             throw new IllegalStateException(message);

--- a/api/src/test/java/ai/djl/ndarray/NDScopeTest.java
+++ b/api/src/test/java/ai/djl/ndarray/NDScopeTest.java
@@ -45,4 +45,39 @@ public class NDScopeTest {
         Assert.assertFalse(detached.isReleased());
         detached.close();
     }
+
+    @Test(
+            expectedExceptions = java.lang.IllegalStateException.class,
+            expectedExceptionsMessageRegExp = "Native resource has been released already. ")
+    @SuppressWarnings("try")
+    public void testNDScopeNotVerboseIfResourceAlreadyClosed() {
+        NDArray ndArray;
+        try (NDManager manager = NDManager.newBaseManager()) {
+            try (NDScope scope = new NDScope()) {
+                scope.suppressNotUsedWarning();
+                ndArray = manager.create(new int[] {1});
+            }
+            ndArray.addi(1);
+        }
+    }
+
+    @Test(
+            expectedExceptions = IllegalStateException.class,
+            expectedExceptionsMessageRegExp =
+                    "Native resource has been released already. .*call stack at creation...\n"
+                            + ".*.*call stack at closing...\n"
+                            + ".*")
+    @SuppressWarnings("try")
+    public void testNDScopeVerboseIfResourceAlreadyClosed() {
+        NDScope.setVerboseIfResourceAlreadyClosed(true);
+        NDArray ndArray;
+        try (NDManager manager = NDManager.newBaseManager()) {
+            try (NDScope scope = new NDScope()) {
+                scope.suppressNotUsedWarning();
+                ndArray = manager.create(new int[] {1});
+                ndArray.setName("myArray");
+            }
+            ndArray.addi(1);
+        }
+    }
 }

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
@@ -1701,6 +1701,7 @@ public class MxNDArray extends NativeResource<Pointer> implements LazyNDArray {
     /** {@inheritDoc} */
     @Override
     public void close() {
+        onClose();
         Pointer pointer = handle.getAndSet(null);
         if (pointer != null) {
             JnaUtils.waitToRead(pointer);

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -1595,7 +1595,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public void close() {
-        this.onClose();
+        onClose();
         Long pointer = handle.getAndSet(null);
         if (pointer != null && pointer != -1) {
             JniUtils.deleteNDArray(pointer);

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -1595,6 +1595,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
     /** {@inheritDoc} */
     @Override
     public void close() {
+        this.onClose();
         Long pointer = handle.getAndSet(null);
         if (pointer != null && pointer != -1) {
             JniUtils.deleteNDArray(pointer);

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
@@ -1719,6 +1719,7 @@ public class TfNDArray extends NativeResource<TFE_TensorHandle> implements NDArr
     /** {@inheritDoc} */
     @Override
     public void close() {
+        onClose();
         TFE_TensorHandle tensorHandle = handle.getAndSet(null);
         if (tensorHandle != null && !tensorHandle.isNull()) {
             tensorHandle.close();


### PR DESCRIPTION
If you are trying to use an NDArray that is already closed you get the error message "Native resource has been released already. ".

If you know which NDArray it is - where it was created and where it was closed - you should have no problem solving the problem. But imagine the case where you are not the one trying to use the already closed NDArray, but some generic code does, maybe you have set an NDScope somewhere, so you know who closed it, but still don't know where it was created. In such cases where you do not have a clue it would be helpful if you could set a switch at compile time to get information about the NDArray:
- uid + creation time
- name
- creation stack trace
- closing stack trace

This PR adds code to provide such info if you set the switch `NDScope.setVerboseIfResourceAlreadyClosed(true);`
It is an opt-in feature: If the switch is not set, nothing changes and there is no overhead. 