### PR TITLE
Fixes PyTorch Java optimizers

### DIFF
--- a/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_optim.cc
+++ b/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_optim.cc
@@ -22,7 +22,6 @@ JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_adamUpdate(JNIEnv*
     jfloat weight_decay, jfloat rescale_grad, jfloat clip_grad, jfloat beta1, jfloat beta2, jfloat eps,
     jboolean adamw) {
   API_BEGIN()
-  torch::autograd::AutoGradMode no_autograd_guard{false};
   const auto* weight_ptr = reinterpret_cast<torch::Tensor*>(jweight);
   const auto grad = reinterpret_cast<torch::Tensor*>(jgrad)->clone();
   const auto* mean_ptr = reinterpret_cast<torch::Tensor*>(jmean);
@@ -52,7 +51,6 @@ JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_sgdUpdate(JNIEnv* 
     jfloat momentum) {
   API_BEGIN()
   // disable gradient calculation
-  torch::autograd::AutoGradMode no_autograd_guard{false};
   const auto* weight_ptr = reinterpret_cast<torch::Tensor*>(jweight);
   // use clone to avoid input grad change
   auto grad = reinterpret_cast<torch::Tensor*>(jgrad)->clone();

--- a/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_system.cc
+++ b/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_system.cc
@@ -58,6 +58,9 @@ JNIEXPORT void JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchSetGradMode(
   API_BEGIN()
 #if !defined(__ANDROID__)
   c10::GradMode::set_enabled(enable);
+  if (!enable) {
+    torch::autograd::AutoGradMode no_autograd_guard{false};
+  }
 #endif
   API_END()
 }


### PR DESCRIPTION
PyTorch requires calling "no_autograd_guard{false}" in order to allow the in-place operations required for an optimizer. This moves that call from each individual optimizer into a single call at the end of the gradient collector. This now makes it possible to implement a Java optimizer (like is done in the D2l book).

To verify this, a new test is added that checks that a Java optimizer with in-place operations will work.

Resolves the concerns raised in #2220 by @blue-me.