### PR TITLE
Adds back support for getting managed Arrays

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
@@ -31,9 +31,12 @@ import java.nio.LongBuffer;
 import java.nio.ShortBuffer;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /** {@code BaseNDManager} is the default implementation of {@link NDManager}. */
 public abstract class BaseNDManager implements NDManager {
@@ -262,6 +265,30 @@ public abstract class BaseNDManager implements NDManager {
 
     /** {@inheritDoc} */
     @Override
+    public List<NDArray> getManagedArrays() {
+        return Stream.concat(
+                        // Main resources
+                        resources.values().stream()
+                                .flatMap(
+                                        r -> {
+                                            if (r instanceof NDResource) {
+                                                return ((NDResource) r)
+                                                        .getResourceNDArrays().stream();
+                                            } else if (r instanceof NDManager) {
+                                                return ((NDManager) r).getManagedArrays().stream();
+                                            } else {
+                                                return Stream.empty();
+                                            }
+                                        }),
+
+                        // Temp resouces
+                        tempResources.values().stream()
+                                .flatMap(tr -> tr.resource.getResourceNDArrays().stream()))
+                .collect(Collectors.toList());
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public String toString() {
         String parentName = parent == null ? "No Parent" : parent.getName();
         return "Name: "
@@ -277,9 +304,6 @@ public abstract class BaseNDManager implements NDManager {
     /** {@inheritDoc} */
     @Override
     public synchronized void attachInternal(String resourceId, AutoCloseable resource) {
-        if (this instanceof SystemNDManager) {
-            return;
-        }
         if (capped.get()) {
             throw new IllegalStateException("NDManager is capped for addition of resources.");
         }
@@ -289,9 +313,6 @@ public abstract class BaseNDManager implements NDManager {
     /** {@inheritDoc} */
     @Override
     public synchronized void attachUncappedInternal(String resourceId, AutoCloseable resource) {
-        if (this instanceof SystemNDManager) {
-            return;
-        }
         if (closed.get()) {
             throw new IllegalStateException("NDManager has been closed already.");
         }
@@ -318,7 +339,8 @@ public abstract class BaseNDManager implements NDManager {
     public void tempAttachInternal(
             NDManager originalManager, String resourceId, NDResource resource) {
         if (this instanceof SystemNDManager) {
-            return;
+            throw new IllegalStateException(
+                    "System manager cannot be temp attached because it can't be closed..");
         }
         if (closed.get()) {
             throw new IllegalStateException("NDManager has been closed already.");
@@ -329,9 +351,6 @@ public abstract class BaseNDManager implements NDManager {
     /** {@inheritDoc} */
     @Override
     public synchronized void detachInternal(String resourceId) {
-        if (this instanceof SystemNDManager) {
-            return;
-        }
         if (closed.get()) {
             // This may happen in the middle of BaseNDManager.close()
             return;
@@ -360,24 +379,11 @@ public abstract class BaseNDManager implements NDManager {
 
     /** {@inheritDoc} */
     @Override
-    public void zeroGradients() {
-        for (AutoCloseable res : resources.values()) {
-            if (res instanceof NDManager) {
-                ((NDManager) res).zeroGradients();
-            } else if (res instanceof NDArray) {
-                NDArray array = (NDArray) res;
-                if (array.hasGradient()) {
-                    array.getGradient().subi(array.getGradient());
-                }
-            }
-        }
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void close() {
         if (this instanceof SystemNDManager) {
-            return;
+            throw new IllegalStateException(
+                    "The SystemNDManager can not be closed. It is global and lives for the duration"
+                            + " of the process");
         }
         if (!closed.getAndSet(true)) {
             for (AutoCloseable closeable : resources.values()) {

--- a/api/src/main/java/ai/djl/ndarray/NDArray.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArray.java
@@ -30,6 +30,8 @@ import java.nio.LongBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -4714,6 +4716,12 @@ public interface NDArray extends NDResource, BytesSupplier {
      * @return The inverse of gauss error of the {@code NDArray}, element-wise
      */
     NDArray erfinv();
+
+    /** {@inheritDoc} */
+    @Override
+    default List<NDArray> getResourceNDArrays() {
+        return Collections.singletonList(this);
+    }
 
     /**
      * Returns an internal representative of Native {@code NDArray}.

--- a/api/src/main/java/ai/djl/ndarray/NDList.java
+++ b/api/src/main/java/ai/djl/ndarray/NDList.java
@@ -28,6 +28,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
@@ -295,6 +296,12 @@ public class NDList extends ArrayList<NDArray> implements NDResource, BytesSuppl
     @Override
     public NDManager getManager() {
         return head().getManager();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<NDArray> getResourceNDArrays() {
+        return this;
     }
 
     /** {@inheritDoc} */

--- a/api/src/main/java/ai/djl/ndarray/NDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/NDManager.java
@@ -35,6 +35,7 @@ import java.nio.LongBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.List;
 
 /**
  * NDArray managers are used to create <I>NDArrays</I> (n-dimensional array on native engine).
@@ -1570,6 +1571,13 @@ public interface NDManager extends AutoCloseable {
     Device getDevice();
 
     /**
+     * Returns all {@link NDArray}s managed by this manager (including recursively).
+     *
+     * @return all {@link NDArray}s managed by this manager (including recursively)
+     */
+    List<NDArray> getManagedArrays();
+
+    /**
      * Attaches a resource to this {@code NDManager}.
      *
      * <p>The attached resource will be closed when this {@code NDManager} is closed.
@@ -1702,9 +1710,6 @@ public interface NDManager extends AutoCloseable {
      * @return the {@link Engine} associated with this manager
      */
     Engine getEngine();
-
-    /** Sets all the gradients within the NDManager to zero. */
-    void zeroGradients();
 
     /** {@inheritDoc} */
     @Override

--- a/api/src/main/java/ai/djl/ndarray/NDResource.java
+++ b/api/src/main/java/ai/djl/ndarray/NDResource.java
@@ -12,6 +12,8 @@
  */
 package ai.djl.ndarray;
 
+import java.util.List;
+
 /** An object which is managed by an {@link NDManager} and tracks the manager it is attached to. */
 public interface NDResource extends AutoCloseable {
 
@@ -21,6 +23,13 @@ public interface NDResource extends AutoCloseable {
      * @return the {@link NDManager} that manages this.
      */
     NDManager getManager();
+
+    /**
+     * Returns the {@link NDArray} or {@link NDArray}s contained within this resource.
+     *
+     * @return the {@link NDArray} or {@link NDArray}s contained within this resource
+     */
+    List<NDArray> getResourceNDArrays();
 
     /**
      * Attaches this {@link NDResource} to the specified {@link NDManager}.

--- a/api/src/main/java/ai/djl/training/GradientCollector.java
+++ b/api/src/main/java/ai/djl/training/GradientCollector.java
@@ -21,6 +21,14 @@ import ai.djl.ndarray.NDArray;
  * performed within the try-with-resources are recorded and the variables marked. When {@link
  * #backward(NDArray) backward function} is called, gradients are collected w.r.t previously marked
  * variables.
+ *
+ * <p>The typical behavior is to open up a gradient collector during each batch and close it during
+ * the end of the batch. In this way, the gradient is reset between batches. If the gradient
+ * collector is left open for multiple calls to backwards, the gradients collected are accumulated
+ * and added together.
+ *
+ * <p>Due to limitations in most engines, the gradient collectors are global. This means that only
+ * one can be used at a time. If multiple are opened, an error will be thrown.
  */
 public interface GradientCollector extends AutoCloseable {
 
@@ -30,6 +38,9 @@ public interface GradientCollector extends AutoCloseable {
      * @param target the target NDArray to calculate the gradient w.r.t head
      */
     void backward(NDArray target);
+
+    /** Sets all the gradients within the engine to zero. */
+    void zeroGradients();
 
     /** {@inheritDoc} */
     @Override

--- a/api/src/main/java/ai/djl/util/passthrough/PassthroughNDManager.java
+++ b/api/src/main/java/ai/djl/util/passthrough/PassthroughNDManager.java
@@ -28,6 +28,8 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
 
 /** An {@link NDManager} that does nothing, for use in extensions and hybrid engines. */
 public final class PassthroughNDManager implements NDManager {
@@ -256,6 +258,12 @@ public final class PassthroughNDManager implements NDManager {
 
     /** {@inheritDoc} */
     @Override
+    public List<NDArray> getManagedArrays() {
+        return Collections.emptyList();
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void attachInternal(String resourceId, AutoCloseable resource) {
         throw new UnsupportedOperationException(UNSUPPORTED);
     }
@@ -296,12 +304,6 @@ public final class PassthroughNDManager implements NDManager {
     @Override
     public Engine getEngine() {
         return null;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void zeroGradients() {
-        throw new UnsupportedOperationException(UNSUPPORTED);
     }
 
     /** {@inheritDoc} */

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxGradientCollector.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxGradientCollector.java
@@ -19,7 +19,7 @@ import ai.djl.ndarray.NDManager;
 import ai.djl.training.GradientCollector;
 
 /** {@code MxGradientCollector} is the MXNet implementation of {@link GradientCollector}. */
-public class MxGradientCollector implements GradientCollector {
+public final class MxGradientCollector implements GradientCollector {
 
     /**
      * Constructs an {@code MxGradientCollector} and enables training data collection for
@@ -115,5 +115,16 @@ public class MxGradientCollector implements GradientCollector {
      */
     private void backward(NDArray array, boolean retainGraph) {
         JnaUtils.autogradBackward(new NDList(array), retainGraph ? 1 : 0);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void zeroGradients() {
+        NDManager systemManager = MxNDManager.getSystemManager();
+        for (NDArray array : systemManager.getManagedArrays()) {
+            if (array.hasGradient()) {
+                array.getGradient().subi(array.getGradient());
+            }
+        }
     }
 }

--- a/engines/mxnet/mxnet-model-zoo/src/test/java/ai/djl/mxnet/integration/modality/nlp/WordEmbeddingTest.java
+++ b/engines/mxnet/mxnet-model-zoo/src/test/java/ai/djl/mxnet/integration/modality/nlp/WordEmbeddingTest.java
@@ -32,7 +32,6 @@ public class WordEmbeddingTest {
     @Test
     public void testGlove() throws IOException, ModelException, EmbeddingException {
         TestRequirements.notArm();
-        TestRequirements.engine("MXNet");
 
         Criteria<String, NDList> criteria =
                 Criteria.builder()

--- a/examples/src/test/java/ai/djl/examples/training/TrainAirfoilWithTabNetTest.java
+++ b/examples/src/test/java/ai/djl/examples/training/TrainAirfoilWithTabNetTest.java
@@ -25,7 +25,6 @@ public class TrainAirfoilWithTabNetTest {
 
     @Test
     public void testTrainAirfoilWithTabNet() throws TranslateException, IOException {
-        TestRequirements.nightly();
         TestRequirements.engine("MXNet", "PyTorch");
         String[] args = {"-g", "1", "-e", "20", "-b", "32"};
         if (!Boolean.getBoolean("nightly")) {

--- a/examples/src/test/java/ai/djl/examples/training/TrainAirfoilWithTabNetTest.java
+++ b/examples/src/test/java/ai/djl/examples/training/TrainAirfoilWithTabNetTest.java
@@ -25,6 +25,7 @@ public class TrainAirfoilWithTabNetTest {
 
     @Test
     public void testTrainAirfoilWithTabNet() throws TranslateException, IOException {
+        TestRequirements.nightly();
         TestRequirements.engine("MXNet", "PyTorch");
         String[] args = {"-g", "1", "-e", "20", "-b", "32"};
         if (!Boolean.getBoolean("nightly")) {

--- a/integration/src/main/java/ai/djl/integration/tests/training/GradientCollectorIntegrationTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/training/GradientCollectorIntegrationTest.java
@@ -82,23 +82,90 @@ public class GradientCollectorIntegrationTest {
         }
     }
 
+    @Test
+    public void testZeroGradients() {
+        try (NDManager manager = NDManager.newBaseManager(TestUtils.getEngine())) {
+            NDArray a = manager.create(0.0f);
+            a.setRequiresGradient(true);
+
+            Engine engine = Engine.getEngine(TestUtils.getEngine());
+            try (GradientCollector gc = engine.newGradientCollector()) {
+                NDArray b = a.mul(2);
+
+                // Gradients are initially zero
+                Assert.assertEquals(a.getGradient().getFloat(), 0.0f);
+
+                // Gradients are updated by backwards
+                gc.backward(b);
+                Assert.assertEquals(a.getGradient().getFloat(), 2.0f);
+
+                // Gradients are cleared by zeroGradients
+                gc.zeroGradients();
+                Assert.assertEquals(a.getGradient().getFloat(), 0.0f);
+            }
+        }
+    }
+
     /** Tests that the gradients do not accumulate when closing the gradient collector. */
     @Test
     public void testClearGradients() {
+        // TODO: Currently not supported by PyTorch. See PtGradientCollector
+        TestUtils.requiresNotEngine("PyTorch");
         try (NDManager manager = NDManager.newBaseManager(TestUtils.getEngine())) {
-            NDArray variable = manager.create(0.0f);
-            variable.setRequiresGradient(true);
+            NDArray a = manager.create(0.0f);
+            a.setRequiresGradient(true);
 
-            Engine engine = manager.getEngine();
+            Engine engine = Engine.getEngine(TestUtils.getEngine());
             for (int i = 0; i < 3; i++) {
-                manager.zeroGradients();
                 try (GradientCollector gc = engine.newGradientCollector()) {
-                    NDArray loss = variable.mul(2);
-                    gc.backward(loss);
+                    NDArray b = a.mul(2);
+                    gc.backward(b);
                 }
-                Assert.assertEquals(variable.getGradient().getFloat(), 2.0f);
+                Assert.assertEquals(a.getGradient().getFloat(), 2.0f);
             }
         }
+    }
+
+    /** Tests that the gradients do accumulate within the same gradient collector. */
+    @Test
+    public void testAccumulateGradients() {
+        // TODO: MXNet support for accumulating gradients does not currently work
+        TestUtils.requiresNotEngine("MXNet");
+        try (NDManager manager = NDManager.newBaseManager(TestUtils.getEngine())) {
+            NDArray a = manager.create(0.0f);
+            a.setRequiresGradient(true);
+
+            Engine engine = Engine.getEngine(TestUtils.getEngine());
+            try (GradientCollector gc = engine.newGradientCollector()) {
+                for (int i = 1; i <= 3; i++) {
+                    NDArray b = a.mul(2);
+                    gc.backward(b);
+                    Assert.assertEquals(a.getGradient().getFloat(), 2.0f * i);
+                }
+            }
+        }
+    }
+
+    /**
+     * Ensures that a gradient collector does not start when one is already created because they are
+     * global.
+     */
+    @Test
+    @SuppressWarnings({"try", "PMD.UseTryWithResources"})
+    public void testMultipleGradientCollectors() {
+        Assert.assertThrows(
+                () -> {
+                    GradientCollector gc2 = null;
+                    Engine engine = Engine.getEngine(TestUtils.getEngine());
+                    try (GradientCollector gc = engine.newGradientCollector()) {
+                        gc2 = engine.newGradientCollector();
+                        gc2.close();
+                    } finally {
+                        if (gc2 != null) {
+                            gc2.close();
+                        }
+                    }
+                });
     }
 
     @Test

--- a/integration/src/main/java/ai/djl/integration/util/TestUtils.java
+++ b/integration/src/main/java/ai/djl/integration/util/TestUtils.java
@@ -48,6 +48,20 @@ public final class TestUtils {
                 "This test requires one of the engines: " + Arrays.toString(engines));
     }
 
+    /**
+     * Requires a test have any engines except for those listed.
+     *
+     * @param engines the engine(s) to not run the test on
+     */
+    public static void requiresNotEngine(String... engines) {
+        for (String e : engines) {
+            if (engineName.equals(e)) {
+                throw new SkipException(
+                        "This test requires not using the engines: " + Arrays.toString(engines));
+            }
+        }
+    }
+
     public static Device[] getDevices(int maxGpus) {
         Engine engine = Engine.getEngine(engineName);
         if (!engine.hasCapability(StandardCapabilities.CUDNN) && "MXNet".equals(engineName)) {

--- a/testing/src/main/java/ai/djl/testing/TestRequirements.java
+++ b/testing/src/main/java/ai/djl/testing/TestRequirements.java
@@ -16,7 +16,6 @@ import ai.djl.engine.Engine;
 
 import org.testng.SkipException;
 
-import java.util.Arrays;
 import java.util.Calendar;
 
 /**
@@ -26,6 +25,7 @@ import java.util.Calendar;
  * SkipException}.
  */
 public final class TestRequirements {
+
     private TestRequirements() {}
 
     /** Requires a test runs as part of the nightly suite, but not standard local or CI builds. */
@@ -46,37 +46,6 @@ public final class TestRequirements {
     public static void notOffline() {
         if (Boolean.getBoolean("offline")) {
             throw new SkipException("This test can not run while offline");
-        }
-    }
-
-    /**
-     * Requires a test only with the allowed engine(s).
-     *
-     * @param engines the engine(s) to run the test with
-     */
-    public static void engine(String... engines) {
-        String engineName = Engine.getDefaultEngineName();
-        for (String e : engines) {
-            if (engineName.equals(e)) {
-                return;
-            }
-        }
-        throw new SkipException(
-                "This test requires one of the engines: " + Arrays.toString(engines));
-    }
-
-    /**
-     * Requires a test have any engines except for those listed.
-     *
-     * @param engines the engine(s) to not run the test on
-     */
-    public static void notEngine(String... engines) {
-        String engineName = Engine.getDefaultEngineName();
-        for (String e : engines) {
-            if (engineName.equals(e)) {
-                throw new SkipException(
-                        "This test requires not using the engines: " + Arrays.toString(engines));
-            }
         }
     }
 


### PR DESCRIPTION
The support was removed as part of "A temporary solution to issue 2210  (#2304)". This then reverts that commit while making a smaller change. It keeps the tests designating the desired behavior but notes the problematic engines that fail them.