### PR TITLE
[spark] Change Spark extension API

### DIFF
--- a/extensions/spark/src/main/scala/ai/djl/spark/task/BasePredictor.scala
+++ b/extensions/spark/src/main/scala/ai/djl/spark/task/BasePredictor.scala
@@ -12,11 +12,14 @@
  */
 package ai.djl.spark.task
 
+import ai.djl.spark.ModelLoader
 import ai.djl.translate.Translator
 import org.apache.spark.ml.Transformer
 import org.apache.spark.ml.param.{Param, ParamMap}
 import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, Dataset, Row}
 
 /**
  * BasePredictor is the base class of predictors.
@@ -27,31 +30,14 @@ abstract class BasePredictor[A, B](override val uid: String) extends Transformer
 
   def this() = this(Identifiable.randomUID("BasePredictor"))
 
-  final val inputCols = new Param[Array[String]](this, "inputCols", "The input columns")
-  final val outputCols = new Param[Array[String]](this, "outputCols", "The output columns")
   final val engine = new Param[String](this, "engine", "The engine")
   final val modelUrl = new Param[String](this, "modelUrl", "The model URL")
   final val inputClass = new Param[Class[A]](this, "inputClass", "The input class")
   final val outputClass = new Param[Class[B]](this, "outputClass", "The output class")
   final val translator = new Param[Translator[A, B]](this, "translator", "The translator")
 
-  /**
-   * Sets the inputCols parameter.
-   *
-   * @param value the value of the parameter
-   */
-  def setInputCols(value: Array[String]): this.type = set(inputCols, value)
-
-  setDefault(inputCols, Array("*"))
-
-  /**
-   * Sets the outputCols parameter.
-   *
-   * @param value the value of the parameter
-   */
-  def setOutputCols(value: Array[String]): this.type = set(outputCols, value)
-
-  setDefault(inputCols, Array("value"))
+  protected var model: ModelLoader[A, B] = _
+  protected var outputSchema: StructType = _
 
   /**
    * Sets the engine parameter.
@@ -60,12 +46,16 @@ abstract class BasePredictor[A, B](override val uid: String) extends Transformer
    */
   def setEngine(value: String): this.type = set(engine, value)
 
+  setDefault(engine, null)
+
   /**
    * Sets the modelUrl parameter.
    *
    * @param value the value of the parameter
    */
   def setModelUrl(value: String): this.type = set(modelUrl, value)
+
+  setDefault(modelUrl, null)
 
   /**
    * Sets the input class.
@@ -89,8 +79,16 @@ abstract class BasePredictor[A, B](override val uid: String) extends Transformer
   def setTranslator(value: Translator[A, B]): this.type = set(translator, value)
 
   /** @inheritdoc */
-  override def transformSchema(schema: StructType) = schema
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    model = new ModelLoader[A, B]($(engine), $(modelUrl), $(inputClass), $(outputClass))
+    outputSchema = transformSchema(dataset.schema)
+    val outputDf = dataset.toDF()
+      .mapPartitions(transformRows)(RowEncoder.apply(outputSchema))
+    outputDf
+  }
 
   /** @inheritdoc */
   override def copy(paramMap: ParamMap) = this
+
+  protected def transformRows(iter: Iterator[Row]): Iterator[Row]
 }

--- a/extensions/spark/src/main/scala/ai/djl/spark/task/text/TextPredictor.scala
+++ b/extensions/spark/src/main/scala/ai/djl/spark/task/text/TextPredictor.scala
@@ -14,16 +14,19 @@ package ai.djl.spark.task.text
 
 import ai.djl.spark.task.BasePredictor
 import org.apache.spark.ml.util.Identifiable
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{StringType, StructField}
 
 /**
- * TextPredictor performs prediction on text.
+ * TextPredictor is the base class for text predictors.
  *
  * @param uid An immutable unique ID for the object and its derivatives.
  */
-abstract class TextPredictor[B](override val uid: String) extends BasePredictor[Row, B] {
+abstract class TextPredictor[A, B](override val uid: String) extends BasePredictor[A, B] {
 
   def this() = this(Identifiable.randomUID("TextPredictor"))
 
-  setDefault(inputClass, classOf[Row])
+  def validateInputType(input: StructField): Unit = {
+    require(input.dataType == StringType,
+      s"Input column ${input.name} type must be StringType but got ${input.dataType}.")
+  }
 }

--- a/extensions/spark/src/main/scala/ai/djl/spark/task/vision/ImageClassifier.scala
+++ b/extensions/spark/src/main/scala/ai/djl/spark/task/vision/ImageClassifier.scala
@@ -13,23 +13,46 @@
 package ai.djl.spark.task.vision
 
 import ai.djl.modality.Classifications
+import ai.djl.modality.Classifications.Classification
 import ai.djl.spark.translator.vision.ImageClassificationTranslator
-import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.ml.param.Param
+import org.apache.spark.ml.param.shared.HasOutputCol
 import org.apache.spark.ml.util.Identifiable
-import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
+import org.apache.spark.sql.types.{ArrayType, DoubleType, MapType, StringType, StructField, StructType}
+import org.apache.spark.sql.{DataFrame, Dataset, Row}
+
+import scala.collection.mutable
 
 /**
  * ImageClassifier performs image classification on images.
  *
  * @param uid An immutable unique ID for the object and its derivatives.
  */
-class ImageClassifier(override val uid: String) extends ImagePredictor[Classifications] {
+class ImageClassifier(override val uid: String) extends ImagePredictor[Classifications]
+  with HasOutputCol {
 
   def this() = this(Identifiable.randomUID("ImageClassifier"))
 
+  final val topK = new Param[Int](this, "topK", "The number of classes to return")
+
+  /**
+   * Sets the outputCol parameter.
+   *
+   * @param value the value of the parameter
+   */
+  def setOutputCol(value: String): this.type = set(outputCol, value)
+
+  /**
+   * Sets the topK parameter.
+   *
+   * @param value the value of the parameter
+   */
+  def setTopK(value: Int): this.type = set(topK, value)
+
   setDefault(outputClass, classOf[Classifications])
   setDefault(translator, new ImageClassificationTranslator())
+  setDefault(topK, 5)
 
   /**
    * Performs image classification on the provided dataset.
@@ -42,8 +65,28 @@ class ImageClassifier(override val uid: String) extends ImagePredictor[Classific
   }
 
   /** @inheritdoc */
-  override def transformSchema(schema: StructType) = schema
+  override protected def transformRows(iter: Iterator[Row]): Iterator[Row] = {
+    val predictor = model.newPredictor($(translator))
+    iter.map(row => {
+      val prediction = predictor.predict(row)
+      val top = mutable.LinkedHashMap[String, Double]()
+      val it: java.util.Iterator[Classification] = prediction.topK($(topK)).iterator()
+      while (it.hasNext) {
+        val t = it.next()
+        top += (t.getClassName -> t.getProbability)
+      }
+      new GenericRowWithSchema(row.toSeq.toArray
+        ++ Array[Any](Row(prediction.getClassNames.toArray, prediction.getProbabilities.toArray, top)),
+        outputSchema)
+    })
+  }
 
   /** @inheritdoc */
-  override def copy(paramMap: ParamMap) = this
+  override def transformSchema(schema: StructType): StructType = {
+    val outputSchema = StructType(schema.fields ++
+      Array(StructField($(outputCol), StructType(Seq(StructField("class_names", ArrayType(StringType)),
+        StructField("probabilities", ArrayType(DoubleType)),
+        StructField("topK", MapType(StringType, DoubleType)))))))
+    outputSchema
+  }
 }

--- a/extensions/spark/src/main/scala/ai/djl/spark/translator/text/TextEmbeddingTranslator.scala
+++ b/extensions/spark/src/main/scala/ai/djl/spark/translator/text/TextEmbeddingTranslator.scala
@@ -14,19 +14,20 @@ package ai.djl.spark.translator.text
 
 import ai.djl.ndarray.NDList
 import ai.djl.translate.{Batchifier, Translator, TranslatorContext}
-import org.apache.spark.sql.Row
 
-/** A [[ai.djl.translate.Translator]] for Spark Text Embedding tasks. */
+/** A [[ai.djl.translate.Translator]] for Text Embedding tasks in Spark. */
 @SerialVersionUID(1L)
-class TextEmbeddingTranslator extends Translator[Row, Array[Float]] with Serializable {
+class TextEmbeddingTranslator extends Translator[String, Array[Float]] with Serializable {
 
   /** @inheritdoc */
-  override def processInput(ctx: TranslatorContext, input: Row): NDList = {
-    new NDList(ctx.getNDManager.create(input.getString(0)).expandDims(0))
+  override def processInput(ctx: TranslatorContext, input: String): NDList = {
+    new NDList(ctx.getNDManager.create(input).expandDims(0))
   }
 
   /** @inheritdoc */
-  override def processOutput(ctx: TranslatorContext, list: NDList): Array[Float] = list.singletonOrThrow.get(0).toFloatArray
+  override def processOutput(ctx: TranslatorContext, list: NDList): Array[Float] = {
+    list.singletonOrThrow.get(0).toFloatArray
+  }
 
   /** @inheritdoc */
   override def getBatchifier: Batchifier = null

--- a/extensions/spark/src/main/scala/ai/djl/spark/translator/vision/ImageClassificationTranslator.scala
+++ b/extensions/spark/src/main/scala/ai/djl/spark/translator/vision/ImageClassificationTranslator.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.Row
 
 import java.util
 
-/** A [[ai.djl.translate.Translator]] for Spark Image Classification tasks. */
+/** A [[ai.djl.translate.Translator]] for Image Classification tasks in Spark. */
 @SerialVersionUID(1L)
 class ImageClassificationTranslator extends Translator[Row, Classifications] with Serializable {
 


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Change Spark extension API

- Implement HasInputCol/HasInputCols, HasOutputCol/HasOutputCols in each specific task
- Add prediction column to the input dataframe instead of replacing the columns
- ImageClassifier output struct type output
- TextTokenizer output struct type output