### PR TITLE
Add support for unique, bmm, xlogy

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/NDArray.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArray.java
@@ -1528,6 +1528,14 @@ public interface NDArray extends NDResource, BytesSupplier {
     NDArray pow(NDArray other);
 
     /**
+     * Computes this * log(other).
+     *
+     * @param other other the other {@code NDArray}
+     * @return the result {@code NDArray}
+     */
+    NDArray xlogy(NDArray other);
+
+    /**
      * Adds a number to this {@code NDArray} element-wise in place.
      *
      * <p>Examples
@@ -4291,6 +4299,14 @@ public interface NDArray extends NDResource, BytesSupplier {
      * @return the result {@code NDArray}
      */
     NDArray matMul(NDArray other);
+
+    /**
+     * Batch product matrix of this {@code NDArray} and the other {@code NDArray}.
+     *
+     * @param other the other {@code NDArray} to perform matrix product with
+     * @return the result {@code NDArray}
+     */
+    NDArray batchMatMul(NDArray other);
 
     /**
      * Clips (limit) the values in this {@code NDArray}.

--- a/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
@@ -1026,6 +1026,18 @@ public abstract class NDArrayAdapter implements NDArray {
 
     /** {@inheritDoc} */
     @Override
+    public NDArray batchMatMul(NDArray other) {
+        throw new UnsupportedOperationException();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray xlogy(NDArray other) {
+        throw new UnsupportedOperationException();
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public NDArray clip(Number min, Number max) {
         return getAlternativeArray().clip(min, max);
     }

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
@@ -1454,6 +1454,18 @@ public class MxNDArray extends NativeResource<Pointer> implements LazyNDArray {
 
     /** {@inheritDoc} */
     @Override
+    public NDArray batchMatMul(NDArray other) {
+        throw new UnsupportedOperationException();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray xlogy(NDArray other) {
+        throw new UnsupportedOperationException();
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public NDArray clip(Number min, Number max) {
         MxOpParams params = new MxOpParams();
         params.addParam("a_min", min);

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -593,6 +593,15 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
 
     /** {@inheritDoc} */
     @Override
+    public NDArray xlogy(NDArray other) {
+        if (isScalar() || other.isScalar()) {
+            throw new IllegalArgumentException("scalar is not allowed for xlogy()");
+        }
+        return JniUtils.xlogy(this, manager.from(other));
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public PtNDArray addi(Number n) {
         try (NDArray number = manager.create(n)) {
             return addi(number);
@@ -1355,6 +1364,15 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
             throw new IllegalArgumentException("scalar is not allowed for matMul()");
         }
         return JniUtils.matmul(this, manager.from(other));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray batchMatMul(NDArray other) {
+        if (isScalar() || other.isScalar()) {
+            throw new IllegalArgumentException("scalar is not allowed for batchMatMul()");
+        }
+        return JniUtils.bmm(this, manager.from(other));
     }
 
     /** {@inheritDoc} */

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
@@ -806,6 +806,18 @@ public final class JniUtils {
                 PyTorchLibrary.LIB.torchMatmul(ndArray1.getHandle(), ndArray2.getHandle()));
     }
 
+    public static PtNDArray bmm(PtNDArray ndArray1, PtNDArray ndArray2) {
+        return new PtNDArray(
+                ndArray1.getManager(),
+                PyTorchLibrary.LIB.torchBmm(ndArray1.getHandle(), ndArray2.getHandle()));
+    }
+
+    public static PtNDArray xlogy(PtNDArray ndArray1, PtNDArray ndArray2) {
+        return new PtNDArray(
+                ndArray1.getManager(),
+                PyTorchLibrary.LIB.torchXLogY(ndArray1.getHandle(), ndArray2.getHandle()));
+    }
+
     public static PtNDArray dot(PtNDArray ndArray1, PtNDArray ndArray2) {
         if (ndArray1.getShape().dimension() == 1) {
             return new PtNDArray(

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
@@ -145,6 +145,10 @@ final class PyTorchLibrary {
 
     native long torchMatmul(long self, long other);
 
+    native long torchBmm(long self, long other);
+
+    native long torchXLogY(long self, long other);
+
     native long torchDot(long self, long other);
 
     native long torchLogicalAnd(long self, long other);

--- a/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_torch_pointwise.cc
+++ b/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_torch_pointwise.cc
@@ -10,6 +10,7 @@
  * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
+
 #include "ai_djl_pytorch_jni_PyTorchLibrary.h"
 #include "djl_pytorch_jni_exception.h"
 #include "djl_pytorch_utils.h"
@@ -158,6 +159,26 @@ JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchMatmul(
   const auto* self_ptr = reinterpret_cast<torch::Tensor*>(jself);
   const auto* other_ptr = reinterpret_cast<torch::Tensor*>(jother);
   const auto* result_ptr = new torch::Tensor(self_ptr->matmul(*other_ptr));
+  return reinterpret_cast<uintptr_t>(result_ptr);
+  API_END_RETURN()
+}
+
+JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchBmm(
+    JNIEnv* env, jobject jthis, jlong jself, jlong jother) {
+  API_BEGIN()
+  const auto* self_ptr = reinterpret_cast<torch::Tensor*>(jself);
+  const auto* other_ptr = reinterpret_cast<torch::Tensor*>(jother);
+  const auto* result_ptr = new torch::Tensor(self_ptr->bmm(*other_ptr));
+  return reinterpret_cast<uintptr_t>(result_ptr);
+  API_END_RETURN()
+}
+
+JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchXLogY(
+    JNIEnv* env, jobject jthis, jlong jself, jlong jother) {
+  API_BEGIN()
+  const auto* self_ptr = reinterpret_cast<torch::Tensor*>(jself);
+  const auto* other_ptr = reinterpret_cast<torch::Tensor*>(jother);
+  const auto* result_ptr = new torch::Tensor(self_ptr->xlogy(*other_ptr));
   return reinterpret_cast<uintptr_t>(result_ptr);
   API_END_RETURN()
 }

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
@@ -1545,6 +1545,16 @@ public class TfNDArray extends NativeResource<TFE_TensorHandle> implements NDArr
         }
     }
 
+    @Override
+    public NDArray batchMatMul(NDArray other) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public NDArray xlogy(NDArray other) {
+        throw new UnsupportedOperationException();
+    }
+
     /** {@inheritDoc} */
     @Override
     public NDArray clip(Number min, Number max) {

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayElementArithmeticOpTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayElementArithmeticOpTest.java
@@ -17,6 +17,7 @@ import ai.djl.integration.util.TestUtils;
 import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDArrays;
 import ai.djl.ndarray.NDManager;
+import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.nn.Blocks;
 import ai.djl.nn.Parameter;
@@ -487,6 +488,16 @@ public class NDArrayElementArithmeticOpTest {
     }
 
     @Test
+    public void testBatchMatMul() {
+        try (NDManager manager = NDManager.newBaseManager(TestUtils.getEngine())) {
+            NDArray lhs = manager.randomNormal(0f, 1f, new Shape(10, 5, 4), DataType.FLOAT32);
+            NDArray rhs = manager.randomNormal(0f, 1f, new Shape(10, 4, 3), DataType.FLOAT32);
+            NDArray output = lhs.batchMatMul(rhs);
+            Assert.assertEquals(output.getShape(), new Shape(10, 5, 3));
+        }
+    }
+
+    @Test
     public void testDivScalar() {
         try (NDManager manager = NDManager.newBaseManager(TestUtils.getEngine())) {
             NDArray dividend = manager.create(new float[] {6, 9, 12, 15, 0});
@@ -692,6 +703,17 @@ public class NDArrayElementArithmeticOpTest {
                     manager, NDArrays::pow, (x, y) -> (float) Math.pow(x, y), false);
             testReverseScalarCornerCase(
                     manager, NDArrays::powi, (x, y) -> (float) Math.pow(x, y), true);
+        }
+    }
+
+    @Test
+    public void testXLogYNDArray() {
+        try (NDManager manager = NDManager.newBaseManager(TestUtils.getEngine())) {
+            NDArray array = manager.create(new float[] {6, 12, 2, 0});
+            NDArray other = manager.create(new float[] {3, 1, 2, 3});
+            NDArray result = array.xlogy(other);
+            NDArray expected = manager.create(new float[] {6.5917f, 0f, 1.3863f, 0f});
+            Assertions.assertAlmostEquals(result, expected);
         }
     }
 


### PR DESCRIPTION
## Description ##

Added support for Tensor.unique (for tests). Solves issue https://github.com/deepjavalibrary/djl/issues/2407
Added support for Tensor.bmm and Tensor.xlogy (pytorch impls only). Solves issue https://github.com/deepjavalibrary/djl/issues/2349

The unique feature in this PR is not as updated as that in PR https://github.com/deepjavalibrary/djl/pull/2417