### PR TITLE
Load inputShapes in the loadMetadata method of Linear block

### DIFF
--- a/api/src/main/java/ai/djl/nn/AbstractBaseBlock.java
+++ b/api/src/main/java/ai/djl/nn/AbstractBaseBlock.java
@@ -175,13 +175,13 @@ public abstract class AbstractBaseBlock implements Block {
     @Override
     public void initialize(NDManager manager, DataType dataType, Shape... inputShapes) {
         beforeInitialize(inputShapes);
-        // block has inputShape and params have arrays not null
+        // Block inputShape is null or params arrays are null
         if (!isInitialized()) {
-            // set the params' shape to be inputShapes
+            // Set the shape of parameter to be inputShapes
             prepare(inputShapes);
         }
         for (Parameter parameter : getDirectParameters().values()) {
-            // attach arrays to params if params are null; requires gradient
+            // Attach arrays to params if params are null; set require gradient if required
             parameter.initialize(manager, dataType);
         }
         initializeChildBlocks(manager, dataType, inputShapes);

--- a/api/src/main/java/ai/djl/nn/core/Linear.java
+++ b/api/src/main/java/ai/djl/nn/core/Linear.java
@@ -58,7 +58,7 @@ public class Linear extends AbstractBlock {
 
     private long units;
     private long inputFeatures;
-
+    private Shape inputShape;
     private Parameter weight;
     private Parameter bias;
 
@@ -105,8 +105,7 @@ public class Linear extends AbstractBlock {
     @Override
     public PairList<String, Shape> describeInput() {
         return new PairList<>(
-                Collections.singletonList("linearInput"),
-                Collections.singletonList(inputShapes[0]));
+                Collections.singletonList("linearInput"), Collections.singletonList(inputShape));
     }
 
     /** {@inheritDoc} */
@@ -116,9 +115,7 @@ public class Linear extends AbstractBlock {
         Preconditions.checkArgument(inputShapes.length == 1, "Linear block only support 1 input");
         Shape inputShape = inputShapes[0];
         inputFeatures = inputShape.get(inputShape.dimension() - 1);
-        if (this.inputShapes == null) {
-            this.inputShapes = inputShapes;
-        }
+        this.inputShape = inputShape.slice(0, inputShape.dimension() - 1);
     }
 
     /** {@inheritDoc} */
@@ -136,7 +133,7 @@ public class Linear extends AbstractBlock {
     protected void saveMetadata(DataOutputStream os) throws IOException {
         os.writeLong(units);
         os.writeLong(inputFeatures);
-        os.write(inputShapes[0].getEncoded());
+        os.write(inputShape.getEncoded());
     }
 
     /** {@inheritDoc} */
@@ -167,10 +164,7 @@ public class Linear extends AbstractBlock {
             default:
                 throw new MalformedModelException("Unsupported encoding version: " + loadVersion);
         }
-        if (inputShapes == null) {
-            // Load inputShapes from parameter file if Block has not been initialized
-            inputShapes = new Shape[] {Shape.decode(is)};
-        }
+        inputShape = Shape.decode(is);
     }
 
     /**

--- a/api/src/main/java/ai/djl/nn/core/Linear.java
+++ b/api/src/main/java/ai/djl/nn/core/Linear.java
@@ -113,9 +113,9 @@ public class Linear extends AbstractBlock {
     protected void beforeInitialize(Shape... inputShapes) {
         super.beforeInitialize(inputShapes);
         Preconditions.checkArgument(inputShapes.length == 1, "Linear block only support 1 input");
-        Shape inputShape = inputShapes[0];
-        inputFeatures = inputShape.get(inputShape.dimension() - 1);
-        this.inputShape = inputShape.slice(0, inputShape.dimension() - 1);
+        Shape input = inputShapes[0];
+        inputFeatures = input.get(input.dimension() - 1);
+        inputShape = input.slice(0, input.dimension() - 1);
     }
 
     /** {@inheritDoc} */
@@ -165,6 +165,7 @@ public class Linear extends AbstractBlock {
                 throw new MalformedModelException("Unsupported encoding version: " + loadVersion);
         }
         inputShape = Shape.decode(is);
+        inputShapes = new Shape[] {inputShape};
     }
 
     /**


### PR DESCRIPTION
This aims to solve the issue https://github.com/deepjavalibrary/djl/issues/2446
As pointed out there in the issue, the loadMetadata method in Linear missed the inputShapes (plural). In this PR it is added.
