### PR TITLE
[spark] Change image predictors to return complex struct type

### DIFF
--- a/extensions/spark/src/main/scala/ai/djl/spark/task/binary/BinaryPredictor.scala
+++ b/extensions/spark/src/main/scala/ai/djl/spark/task/binary/BinaryPredictor.scala
@@ -16,7 +16,7 @@ import ai.djl.spark.task.BasePredictor
 import ai.djl.spark.translator.binary.NpBinaryTranslatorFactory
 import org.apache.spark.ml.param.shared.{HasInputCol, HasOutputCol}
 import org.apache.spark.ml.util.Identifiable
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.{BinaryType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
 
 /**

--- a/extensions/spark/src/main/scala/ai/djl/spark/task/vision/ImageEmbedder.scala
+++ b/extensions/spark/src/main/scala/ai/djl/spark/task/vision/ImageEmbedder.scala
@@ -17,7 +17,7 @@ import ai.djl.modality.cv.translator.ImageFeatureExtractorFactory
 import org.apache.spark.ml.image.ImageSchema
 import org.apache.spark.ml.param.shared.HasOutputCol
 import org.apache.spark.ml.util.Identifiable
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.{ArrayType, ByteType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
 
 /**

--- a/extensions/spark/src/main/scala/ai/djl/spark/task/vision/InstanceSegmenter.scala
+++ b/extensions/spark/src/main/scala/ai/djl/spark/task/vision/InstanceSegmenter.scala
@@ -14,12 +14,15 @@ package ai.djl.spark.task.vision
 
 import ai.djl.modality.cv.ImageFactory
 import ai.djl.modality.cv.output.DetectedObjects
+import ai.djl.modality.cv.output.DetectedObjects.DetectedObject
 import ai.djl.modality.cv.translator.InstanceSegmentationTranslatorFactory
 import org.apache.spark.ml.image.ImageSchema
 import org.apache.spark.ml.param.shared.HasOutputCol
 import org.apache.spark.ml.util.Identifiable
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.{ArrayType, DoubleType, StringType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
+
+import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 
 /**
  * InstanceSegmenter performs instance segmentation on images.
@@ -57,13 +60,19 @@ class InstanceSegmenter(override val uid: String) extends BaseImagePredictor[Det
     iter.map(row => {
       val image = ImageFactory.getInstance().fromPixels(bgrToRgb(ImageSchema.getData(row)),
         ImageSchema.getWidth(row), ImageSchema.getHeight(row))
-      Row.fromSeq(row.toSeq :+ predictor.predict(image).toJson)
+      val prediction = predictor.predict(image)
+      val boundingBoxes = prediction.items[DetectedObject].map(item => item.getBoundingBox.toString)
+      Row.fromSeq(row.toSeq :+ Row(prediction.getClassNames.toArray,
+        prediction.getProbabilities.toArray, boundingBoxes))
     })
   }
 
   /** @inheritdoc */
   override def transformSchema(schema: StructType): StructType = {
-    val outputSchema = StructType(schema.fields :+ StructField($(outputCol), StringType))
+    val outputSchema = StructType(schema.fields :+
+      StructField($(outputCol), StructType(Seq(StructField("class_names", ArrayType(StringType)),
+        StructField("probabilities", ArrayType(DoubleType)),
+        StructField("boundingBoxes", ArrayType(StringType))))))
     outputSchema
   }
 }


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
