### PR TITLE
Streaming Predict and streamable BytesSupplier

### DIFF
--- a/api/src/main/java/ai/djl/inference/streaming/ChunkedBytesSupplier.java
+++ b/api/src/main/java/ai/djl/inference/streaming/ChunkedBytesSupplier.java
@@ -10,7 +10,7 @@
  * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package ai.djl.modality;
+package ai.djl.inference.streaming;
 
 import ai.djl.ndarray.BytesSupplier;
 

--- a/api/src/main/java/ai/djl/inference/streaming/IteratorBytesSupplier.java
+++ b/api/src/main/java/ai/djl/inference/streaming/IteratorBytesSupplier.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.inference.streaming;
+
+import ai.djl.ndarray.BytesSupplier;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+
+/**
+ * An {@link IteratorBytesSupplier} is a streaming {@link BytesSupplier} suitable for synchronous
+ * usage.
+ */
+public class IteratorBytesSupplier implements BytesSupplier, Iterator<byte[]> {
+
+    private Iterator<BytesSupplier> sources;
+
+    /**
+     * Constructs an {@link IteratorBytesSupplier}.
+     *
+     * @param sources the source suppliers
+     */
+    public IteratorBytesSupplier(Iterator<BytesSupplier> sources) {
+        this.sources = sources;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean hasNext() {
+        return sources.hasNext();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public byte[] next() {
+        return sources.next().getAsBytes();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ByteBuffer toByteBuffer() {
+        return ByteBuffer.wrap(getAsBytes());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public byte[] getAsBytes() {
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            while (hasNext()) {
+                bos.write(next());
+            }
+            return bos.toByteArray();
+        } catch (IOException e) {
+            throw new AssertionError("Failed to read BytesSupplier", e);
+        }
+    }
+}

--- a/api/src/main/java/ai/djl/inference/streaming/PublisherBytesSupplier.java
+++ b/api/src/main/java/ai/djl/inference/streaming/PublisherBytesSupplier.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.inference.streaming;
+
+import ai.djl.ndarray.BytesSupplier;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+/**
+ * An {@link PublisherBytesSupplier} is a streaming {@link BytesSupplier} suitable for reactive
+ * asynchronous usage.
+ */
+public class PublisherBytesSupplier implements BytesSupplier {
+
+    private final List<byte[]> allData;
+    private final AtomicBoolean completed;
+    private Consumer<byte[]> subscriber;
+    private final AtomicInteger dataPushed;
+
+    /** Constructs a {@link PublisherBytesSupplier}. */
+    public PublisherBytesSupplier() {
+        allData = new ArrayList<>();
+        completed = new AtomicBoolean();
+        dataPushed = new AtomicInteger();
+    }
+
+    /**
+     * Appends content to the {@code BytesSupplier}.
+     *
+     * @param data bytes to append
+     * @param lastChunk true if this is the last chunk
+     */
+    public void appendContent(byte[] data, boolean lastChunk) {
+        synchronized (allData) {
+            allData.add(data);
+        }
+        if (lastChunk) {
+            completed.set(true);
+        }
+        pushData();
+    }
+
+    /**
+     * Adds the subscriber to the {@link BytesSupplier} to get notified about additional data.
+     *
+     * @param subscriber a consumer function that will receive bytes when new daata is added and
+     *     null when completed
+     */
+    public void subscribe(Consumer<byte[]> subscriber) {
+        if (this.subscriber != null) {
+            throw new IllegalStateException(
+                    "The PublisherBytesSupplier only allows a single Subscriber");
+        }
+        this.subscriber = subscriber;
+        pushData();
+    }
+
+    private void pushData() {
+        if (subscriber == null) {
+            return;
+        }
+
+        int dataAvailable;
+        synchronized (allData) {
+            dataAvailable = allData.size();
+        }
+
+        int sent = dataPushed.getAndSet(dataAvailable);
+        if (sent < dataAvailable) {
+            synchronized (this) {
+                for (; sent < dataAvailable; sent++) {
+                    subscriber.accept(allData.get(sent));
+                }
+                if (completed.get()) {
+                    subscriber.accept(null);
+                }
+            }
+        }
+    }
+
+    /** Waits until completed before passing thread (BLOCKS THREAD!). */
+    @SuppressWarnings("PMD.EmptyControlStatement")
+    public void waitToRead() {
+        // Block until complete!!!
+        while (!completed.get()) {
+            // Do nothing
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public byte[] getAsBytes() {
+        if (!completed.get()) {
+            throw new IllegalStateException(
+                    "PublisherByteSupplier must be completely filled before reading.");
+        }
+
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            for (byte[] data : allData) {
+                bos.write(data);
+            }
+            return bos.toByteArray();
+        } catch (IOException e) {
+            throw new AssertionError("Failed to read BytesSupplier", e);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ByteBuffer toByteBuffer() {
+        return ByteBuffer.wrap(getAsBytes());
+    }
+}

--- a/api/src/main/java/ai/djl/inference/streaming/StreamingBlock.java
+++ b/api/src/main/java/ai/djl/inference/streaming/StreamingBlock.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.inference.streaming;
+
+import ai.djl.ndarray.NDList;
+import ai.djl.nn.Block;
+import ai.djl.training.ParameterStore;
+import ai.djl.util.PairList;
+
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * A {@link Block} possessing the additional streaming forward capabilities used by {@link
+ * ai.djl.inference.Predictor#streamingPredict(Object)}.
+ */
+public interface StreamingBlock extends Block {
+
+    /**
+     * Applies the operating function of the block once, but returns the result in chunks. This
+     * method should only be called on blocks that are initialized.
+     *
+     * @param parameterStore the parameter store
+     * @param inputs the input NDList
+     * @param training true for a training forward pass (turn on dropout and layerNorm)
+     * @return the output of the forward pass
+     */
+    default Stream<NDList> forwardStream(
+            ParameterStore parameterStore, NDList inputs, boolean training) {
+        return forwardStream(parameterStore, inputs, training, null);
+    }
+
+    /**
+     * Applies the operating function of the block once, but returns the result in chunks. This
+     * method should only be called on blocks that are initialized.
+     *
+     * @param parameterStore the parameter store
+     * @param inputs the input NDList
+     * @param training true for a training forward pass (turn on dropout and layerNorm)
+     * @param params optional parameters
+     * @return the output of the forward pass
+     */
+    default Stream<NDList> forwardStream(
+            ParameterStore parameterStore,
+            NDList inputs,
+            boolean training,
+            PairList<String, Object> params) {
+        Iterator<NDList> itr = forwardStreamIter(parameterStore, inputs, training, params);
+        Spliterator<NDList> spitr = Spliterators.spliteratorUnknownSize(itr, Spliterator.NONNULL);
+        return StreamSupport.stream(spitr, false);
+    }
+
+    /**
+     * Applies the operating function of the block once, but returns the result in chunks. This
+     * method should only be called on blocks that are initialized.
+     *
+     * @param parameterStore the parameter store
+     * @param inputs the input NDList
+     * @param training true for a training forward pass (turn on dropout and layerNorm)
+     * @param params optional parameters
+     * @return the output of the forward pass
+     */
+    Iterator<NDList> forwardStreamIter(
+            ParameterStore parameterStore,
+            NDList inputs,
+            boolean training,
+            PairList<String, Object> params);
+}

--- a/api/src/main/java/ai/djl/inference/streaming/StreamingTranslator.java
+++ b/api/src/main/java/ai/djl/inference/streaming/StreamingTranslator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.inference.streaming;
+
+import ai.djl.ndarray.NDList;
+import ai.djl.translate.Translator;
+import ai.djl.translate.TranslatorContext;
+
+import java.util.stream.Stream;
+
+/**
+ * An expansion of the {@link Translator} with postProcessing for the {@link StreamingBlock} (used
+ * by {@link ai.djl.inference.Predictor#streamingPredict(Object)}.
+ *
+ * @param <I> the input type
+ * @param <O> the output type
+ */
+public interface StreamingTranslator<I, O> extends Translator<I, O> {
+
+    /**
+     * Processes the output NDList to the corresponding output object.
+     *
+     * @param ctx the toolkit used for post-processing
+     * @param list the output NDList after inference, usually immutable in engines like
+     *     PyTorch. @see <a href="https://github.com/deepjavalibrary/djl/issues/1774">Issue 1774</a>
+     * @return the output object of expected type
+     * @throws Exception if an error occurs during processing output
+     */
+    @SuppressWarnings("PMD.SignatureDeclareThrowsException")
+    O processStreamOutput(TranslatorContext ctx, Stream<NDList> list) throws Exception;
+}

--- a/api/src/main/java/ai/djl/inference/streaming/package-info.java
+++ b/api/src/main/java/ai/djl/inference/streaming/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+/**
+ * Contains classes to implement streaming inference tasks.
+ *
+ * @see ai.djl.inference.Predictor
+ */
+package ai.djl.inference.streaming;

--- a/api/src/test/java/ai/djl/inference/streaming/ChunkedBytesSupplierTest.java
+++ b/api/src/test/java/ai/djl/inference/streaming/ChunkedBytesSupplierTest.java
@@ -10,7 +10,7 @@
  * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package ai.djl.modality;
+package ai.djl.inference.streaming;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/api/src/test/java/ai/djl/inference/streaming/IteratorBytesSupplierTest.java
+++ b/api/src/test/java/ai/djl/inference/streaming/IteratorBytesSupplierTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.inference.streaming;
+
+import ai.djl.ndarray.BytesSupplier;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+public class IteratorBytesSupplierTest {
+
+    @Test
+    public void testIterate() {
+        Iterator<BytesSupplier> iterator =
+                Stream.of("a", "b", "c").map(BytesSupplier::wrap).iterator();
+        IteratorBytesSupplier supplier = new IteratorBytesSupplier(iterator);
+
+        Assert.assertTrue(supplier.hasNext());
+        Assert.assertEquals(supplier.next(), new byte[] {97});
+        Assert.assertEquals(supplier.next(), new byte[] {98});
+        Assert.assertEquals(supplier.next(), new byte[] {99});
+        Assert.assertFalse(supplier.hasNext());
+    }
+
+    @Test
+    public void testAsBytes() {
+        Iterator<BytesSupplier> iterator =
+                Stream.of("a", "b", "c").map(BytesSupplier::wrap).iterator();
+        IteratorBytesSupplier supplier = new IteratorBytesSupplier(iterator);
+
+        Assert.assertEquals(supplier.getAsBytes(), new byte[] {97, 98, 99});
+    }
+}

--- a/api/src/test/java/ai/djl/inference/streaming/PublisherBytesSupplierTest.java
+++ b/api/src/test/java/ai/djl/inference/streaming/PublisherBytesSupplierTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.inference.streaming;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class PublisherBytesSupplierTest {
+
+    @Test
+    public void test() {
+        AtomicInteger contentCount = new AtomicInteger();
+        PublisherBytesSupplier supplier = new PublisherBytesSupplier();
+
+        // Add to supplier without subscriber
+        supplier.appendContent(new byte[] {1}, false);
+        Assert.assertEquals(contentCount.get(), 0);
+
+        // Subscribing with data should trigger subscriptions
+        supplier.subscribe(
+                d -> {
+                    if (d == null) {
+                        // Do nothing on completion
+                        return;
+                    }
+                    contentCount.getAndIncrement();
+                });
+        Assert.assertEquals(contentCount.get(), 1);
+
+        // Add to supplier with subscriber
+        supplier.appendContent(new byte[] {1}, true);
+        Assert.assertEquals(contentCount.get(), 2);
+    }
+}

--- a/api/src/test/java/ai/djl/inference/streaming/package-info.java
+++ b/api/src/test/java/ai/djl/inference/streaming/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+/** Contains tests for {@link ai.djl.inference.streaming}. */
+package ai.djl.inference.streaming;

--- a/integration/src/main/java/ai/djl/integration/tests/inference/StreamingTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/inference/StreamingTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.integration.tests.inference;
+
+import ai.djl.Model;
+import ai.djl.inference.Predictor;
+import ai.djl.inference.streaming.StreamingTranslator;
+import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.types.DataType;
+import ai.djl.ndarray.types.Shape;
+import ai.djl.nn.Parameter.Type;
+import ai.djl.nn.SequentialBlock;
+import ai.djl.nn.core.Linear;
+import ai.djl.training.initializer.Initializer;
+import ai.djl.translate.TranslateException;
+import ai.djl.translate.TranslatorContext;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.DoubleStream;
+import java.util.stream.Stream;
+
+public class StreamingTest {
+
+    @Test
+    public void testSequential() throws TranslateException {
+        try (Model model = Model.newInstance("test")) {
+            SequentialBlock block = new SequentialBlock();
+            block.add(Linear.builder().setUnits(1).build());
+            block.add(Linear.builder().setUnits(1).build());
+            model.setBlock(block);
+
+            block.setInitializer(Initializer.ONES, Type.WEIGHT);
+            block.initialize(model.getNDManager(), DataType.FLOAT64, new Shape(1, 1));
+
+            try (Predictor<Double, DoubleStream> predictor =
+                    model.newPredictor(new TestTranslator())) {
+                List<Double> results =
+                        predictor.streamingPredict(1.0).boxed().collect(Collectors.toList());
+                Assert.assertEquals(results, Arrays.asList(1.0, 1.0));
+            }
+        }
+    }
+
+    private static class TestTranslator implements StreamingTranslator<Double, DoubleStream> {
+
+        /** {@inheritDoc} */
+        @Override
+        public NDList processInput(TranslatorContext ctx, Double input) {
+            return new NDList(ctx.getNDManager().create(input));
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public DoubleStream processOutput(TranslatorContext ctx, NDList list) {
+            return Arrays.stream(list.singletonOrThrow().toDoubleArray());
+        }
+
+        @Override
+        public DoubleStream processStreamOutput(TranslatorContext ctx, Stream<NDList> list) {
+            return list.mapToDouble(l -> l.singletonOrThrow().getDouble());
+        }
+    }
+}


### PR DESCRIPTION
This is to replace #2447 to add support for an iterable streaming version of predict. It creates a StreamingBlock and a streamingTranslator. Then, both are added as part of a new call on Predictor.

In addition, it also adds two new BytesSupplier: a pull based IterableBytesSupplier and a asynchronous Pub-Sub based PublisherBytesSupplier.