### PR TITLE
[spark] Add text generation in pyspark

### DIFF
--- a/docker/spark/Dockerfile
+++ b/docker/spark/Dockerfile
@@ -25,7 +25,8 @@ ARG PROTOBUF_VERSION=3.21.9
 COPY extensions/spark/setup/dist/ dist/
 RUN pip3 install --no-cache-dir dist/djl_spark-*-py3-none-any.whl && \
     rm -rf dist
-RUN pip3 install --no-cache-dir pillow pandas numpy pyarrow
+RUN pip3 install --no-cache-dir torch==1.13.1 --index-url https://download.pytorch.org/whl/cpu
+RUN pip3 install --no-cache-dir pillow pandas numpy pyarrow 'transformers[torch]'
 
 ADD https://repo1.maven.org/maven2/ai/djl/api/${DJL_VERSION}/api-${DJL_VERSION}.jar /usr/lib/spark/jars/djl-api-${DJL_VERSION}.jar
 ADD https://repo1.maven.org/maven2/ai/djl/spark/spark/${DJL_VERSION}/spark-${DJL_VERSION}.jar /usr/lib/spark/jars/djl-spark-${DJL_VERSION}.jar

--- a/extensions/spark/setup/djl_spark/task/text/text_generator.py
+++ b/extensions/spark/setup/djl_spark/task/text/text_generator.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+#
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+# except in compliance with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+# BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for
+# the specific language governing permissions and limitations under the License.
+
+import pandas as pd
+from pyspark import SparkContext
+from pyspark.sql.functions import pandas_udf
+from pyspark.sql.types import StringType
+from typing import Iterator
+from transformers import pipeline
+
+
+class TextGenerator:
+
+    def __init__(self, input_col, output_col, engine, model_url=None, model_name=None):
+        """
+        Initializes the TextGenerator.
+
+        :param input_col: The input column
+        :param output_col: The output column
+        :param engine: The engine. Currently only PyTorch is supported.
+        :param model_url: The model URL
+        :param model_name: The model name
+        """
+        self.input_col = input_col
+        self.output_col = output_col
+        self.engine = engine
+        self.model_url = model_url
+        self.model_name = model_name
+
+    def generate(self, dataset, **kwargs):
+        """
+        Performs text generation on the provided dataset.
+
+        :param dataset: input dataset
+        :return: output dataset
+        """
+        sc = SparkContext._active_spark_context
+        if not self.model_url and not self.model_name:
+            raise ValueError("Either model_url or model_name must be provided.")
+        model_name_or_url = self.model_url if self.model_url else self.model_name
+        pipe = pipeline('text-generation', model=model_name_or_url, **kwargs)
+        bc_pipe = sc.broadcast(pipe)
+
+        @pandas_udf(StringType())
+        def predict_udf(iterator: Iterator[pd.Series]) -> Iterator[pd.Series]:
+            for s in iterator:
+                output = bc_pipe.value(s.tolist())
+                text = [o["generated_text"] for o in output[0]]
+                yield pd.Series(text)
+
+        return dataset.withColumn(self.output_col, predict_udf(self.input_col))


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Add text generation in pyspark. Since text generation models are not traceable. So it's only supported in pyspark now.