### PR TITLE
[ci] Avoid re-publish serving tarball

### DIFF
--- a/.github/workflows/serving_publish.yml
+++ b/.github/workflows/serving_publish.yml
@@ -86,7 +86,9 @@ jobs:
         run: |
           ./gradlew :benchmark:dZ :benchmark:createDeb -Pstaging
           DJL_VERSION=$(cat gradle.properties | awk -F '=' '/djl_version/ {print $2}')
+          if [[ $(aws s3 ls s3://djl-ai/publish/djl-serving/serving-$DJL_VERSION.tar | wc -l) -eq 0 ]]; \
+            then aws s3 cp benchmark/build/distributions/*.tar s3://djl-ai/publish/djl-bench/${DJL_VERSION}/; \
+            else echo serving tarball published already!; fi
           aws s3 cp benchmark/build/distributions/*.deb s3://djl-ai/publish/djl-bench/${DJL_VERSION}/
-          aws s3 cp benchmark/build/distributions/*.tar s3://djl-ai/publish/djl-bench/${DJL_VERSION}/
           aws s3 cp benchmark/build/distributions/*.zip s3://djl-ai/publish/djl-bench/${DJL_VERSION}/
           aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/djl-bench/${DJL_VERSION}/*"


### PR DESCRIPTION
Upload new serving tarball will break homebrew djl-serving package signature

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
