### PR TITLE
[docs] add DeferredTranslatorFactory to tokenizers example

### DIFF
--- a/extensions/tokenizers/README.md
+++ b/extensions/tokenizers/README.md
@@ -51,6 +51,7 @@ Then, all you need to do, is to load this model in DJL:
 Criteria<QAInput, String> criteria = Criteria.builder()
     .setTypes(QAInput.class, String.class)
     .optModelPath(Paths.get("model/nlp/question_answer/ai/djl/huggingface/pytorch/deepset/bert-base-cased-squad2/0.0.1/bert-base-cased-squad2.zip"))
+    .optTranslatorFactory(new DeferredTranslatorFactory())
     .optProgress(new ProgressBar()).build();
 ```
 


### PR DESCRIPTION
## Improve Hugging Face Tokenizers README example to make it easier to run ##

With help from @frankfliu ([discussion](https://github.com/deepjavalibrary/djl/discussions/2507#discussioncomment-5548949)), added `DeferredTranslatorFactory` to the example code in the
Hugging Face Tokenizers README so it will run as-is.