### PR TITLE
[api] Fail model loading if specified translator not found

### DIFF
--- a/api/src/main/java/ai/djl/translate/ServingTranslatorFactory.java
+++ b/api/src/main/java/ai/djl/translate/ServingTranslatorFactory.java
@@ -92,6 +92,8 @@ public class ServingTranslatorFactory implements TranslatorFactory {
             translator.setArguments(arguments);
             logger.info("Using translator: {}", translator.getClass().getName());
             return (Translator<I, O>) translator;
+        } else if (className != null) {
+            throw new TranslateException("Failed to load translator: " + className);
         }
         return (Translator<I, O>) loadDefaultTranslator(arguments);
     }


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
