### PR TITLE
[spark] Set default translator factory to null for tokenizers

### DIFF
--- a/extensions/spark/src/main/scala/ai/djl/spark/task/text/HuggingFaceTextDecoder.scala
+++ b/extensions/spark/src/main/scala/ai/djl/spark/task/text/HuggingFaceTextDecoder.scala
@@ -56,6 +56,7 @@ class HuggingFaceTextDecoder(override val uid: String) extends BaseTextPredictor
 
   setDefault(inputClass, classOf[Array[Long]])
   setDefault(outputClass, classOf[String])
+  setDefault(translatorFactory, null)
 
   /**
    * Decodes String from the input ids on the provided dataset.

--- a/extensions/spark/src/main/scala/ai/djl/spark/task/text/HuggingFaceTextEncoder.scala
+++ b/extensions/spark/src/main/scala/ai/djl/spark/task/text/HuggingFaceTextEncoder.scala
@@ -56,6 +56,7 @@ class HuggingFaceTextEncoder(override val uid: String) extends BaseTextPredictor
 
   setDefault(inputClass, classOf[String])
   setDefault(outputClass, classOf[Encoding])
+  setDefault(translatorFactory, null)
 
   /**
    * Performs sentence encoding on the provided dataset.

--- a/extensions/spark/src/main/scala/ai/djl/spark/task/text/HuggingFaceTextTokenizer.scala
+++ b/extensions/spark/src/main/scala/ai/djl/spark/task/text/HuggingFaceTextTokenizer.scala
@@ -56,6 +56,7 @@ class HuggingFaceTextTokenizer(override val uid: String) extends BaseTextPredict
 
   setDefault(inputClass, classOf[String])
   setDefault(outputClass, classOf[Array[String]])
+  setDefault(translatorFactory, null)
 
   /**
    * Performs sentence tokenization on the provided dataset.


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Set default translator factory to null for tokenizers because tokenizers don't use translatorFactory.