### PR TITLE
[spark] Change spark dependencies to api

### DIFF
--- a/extensions/spark/build.gradle
+++ b/extensions/spark/build.gradle
@@ -8,9 +8,9 @@ dependencies {
     api project(":api")
     api project(":extensions:tokenizers")
     api project(":extensions:audio")
-    implementation "org.apache.spark:spark-core_2.12:${spark_version}"
-    implementation "org.apache.spark:spark-sql_2.12:${spark_version}"
-    implementation "org.apache.spark:spark-mllib_2.12:${spark_version}"
+    api "org.apache.spark:spark-core_2.12:${spark_version}"
+    api "org.apache.spark:spark-sql_2.12:${spark_version}"
+    api "org.apache.spark:spark-mllib_2.12:${spark_version}"
 
     testImplementation project(":testing")
     testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_slf4j_version}"

--- a/extensions/spark/build.gradle
+++ b/extensions/spark/build.gradle
@@ -33,6 +33,8 @@ tasks.register('formatPython') {
 publishing {
     publications {
         maven(MavenPublication) {
+            groupId 'ai.djl.spark'
+            artifactId 'spark_2.12'
             pom {
                 name = "Apache Spark integration for DJL"
                 description = "Apache Spark integration for DJL"


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Change spark dependencies to api so that these dependencies can be exported to downstream apps.