### PR TITLE
[pytorch] Changes default pytorch version to 1.13.1

### DIFF
--- a/engines/pytorch/pytorch-engine/README.md
+++ b/engines/pytorch/pytorch-engine/README.md
@@ -46,11 +46,11 @@ The following table illustrates which pytorch version that DJL supports:
 
 | PyTorch engine version | PyTorch native library version            |
 |------------------------|-------------------------------------------|
-| pytorch-engine:0.22.0  | 1.11.0, 1.12.1, 1.13.1, 2.0.0             |
-| pytorch-engine:0.21.0  | 1.11.0, 1.12.1, 1.13.1                    |
-| pytorch-engine:0.20.0  | 1.11.0, 1.12.1, 1.13.0                    |
-| pytorch-engine:0.19.0  | 1.10.0, 1.11.0, 1.12.1                    |
-| pytorch-engine:0.18.0  | 1.9.1, 1.10.0, 1.11.0                     |
+| pytorch-engine:0.22.0  | 1.11.0, 1.12.1, **1.13.1**, 2.0.0         |
+| pytorch-engine:0.21.0  | 1.11.0, 1.12.1, **1.13.1**                |
+| pytorch-engine:0.20.0  | 1.11.0, 1.12.1, **1.13.0**                |
+| pytorch-engine:0.19.0  | 1.10.0, 1.11.0, **1.12.1**                |
+| pytorch-engine:0.18.0  | 1.9.1, 1.10.0, **1.11.0**                 |
 | pytorch-engine:0.17.0  | 1.9.1, 1.10.0, 1.11.0                     |
 | pytorch-engine:0.16.0  | 1.8.1, 1.9.1, 1.10.0                      |
 | pytorch-engine:0.15.0  | pytorch-native-auto: 1.8.1, 1.9.1, 1.10.0 |

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 djl_version=0.22.1
 mxnet_version=1.9.1
-pytorch_version=2.0.0
+pytorch_version=1.13.1
 tensorflow_version=2.10.1
 tflite_version=2.6.2
 trt_version=8.4.1


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
