### PR TITLE
[huggingface] allow creating BPE huggingface tokenizers

### DIFF
--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/TokenizersLibrary.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/TokenizersLibrary.java
@@ -24,6 +24,8 @@ public final class TokenizersLibrary {
 
     public native long createTokenizerFromString(String json);
 
+    public native long createBpeTokenizer(String vocabulary, String merges);
+
     public native void deleteTokenizer(long handle);
 
     public native long encode(long tokenizer, String text, boolean addSpecialTokens);

--- a/extensions/tokenizers/src/test/java/ai/djl/huggingface/tokenizers/BpeTokenizerBuilderTest.java
+++ b/extensions/tokenizers/src/test/java/ai/djl/huggingface/tokenizers/BpeTokenizerBuilderTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.huggingface.tokenizers;
+
+import ai.djl.training.util.DownloadUtils;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class BpeTokenizerBuilderTest {
+
+    @Test
+    public void testTokenizerCreation() throws IOException {
+        Path bpe = Paths.get("build/BPE");
+        Path vocab = bpe.resolve("vocab.json");
+        Path merges = bpe.resolve("merges.txt");
+
+        DownloadUtils.download(
+                new URL("https://huggingface.co/microsoft/layoutlmv3-base/raw/main/vocab.json"),
+                vocab,
+                null);
+        DownloadUtils.download(
+                new URL("https://huggingface.co/microsoft/layoutlmv3-base/raw/main/merges.txt"),
+                merges,
+                null);
+
+        try (HuggingFaceTokenizer tokenizer =
+                HuggingFaceTokenizer.builder().optTokenizerPath(bpe).build()) {
+            Assert.assertNotNull(tokenizer);
+        }
+    }
+}


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

This PR allows creating huggingface tokenizers using the BPE model. It also adds some entrypoint that can then be used when other models will need to be added.

Related to https://github.com/deepjavalibrary/djl/issues/2533

I will need some help, since there is some point I must have missed: I have link errors even after building the jni lib.

- If this change is a backward incompatible change, why must this change be made?
This is new functionality, the existing apis will continue to work as-is

- Interesting edge cases to note here
