### PR TITLE
[ci] Upgrade github action gradle plugin to v3

### DIFF
--- a/.github/workflows/nightly_android.yml
+++ b/.github/workflows/nightly_android.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: 'corretto'
           java-version: 11
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
