### PR TITLE
[api] Add 0 padding to cuda version if lower than 10.x

### DIFF
--- a/api/src/main/java/ai/djl/util/cuda/CudaUtils.java
+++ b/api/src/main/java/ai/djl/util/cuda/CudaUtils.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.lang.management.MemoryUsage;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 /** A class containing CUDA utility methods. */
@@ -100,7 +101,7 @@ public final class CudaUtils {
         int version = getCudaVersion();
         int major = version / 1000;
         int minor = (version / 10) % 10;
-        return String.valueOf(major) + minor;
+        return String.format(Locale.ROOT, "%02d", major) + minor;
     }
 
     /**


### PR DESCRIPTION
Fixes #2581

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
