### PR TITLE
[api] Makes PredictorContext constructor public

### DIFF
--- a/api/src/main/java/ai/djl/inference/Predictor.java
+++ b/api/src/main/java/ai/djl/inference/Predictor.java
@@ -363,7 +363,8 @@ public class Predictor<I, O> implements AutoCloseable {
         private NDManager ctxManager;
         private Map<String, Object> attachments;
 
-        protected PredictorContext() {
+        /** Constructs a new {@code PredictorContext} instance. */
+        public PredictorContext() {
             ctxManager = manager.newSubManager();
             ctxManager.setName("predictor ctx");
             attachments = new ConcurrentHashMap<>();


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
