### PR TITLE
[fix] ci fails looking for v3 reverting to v2

### DIFF
--- a/.github/workflows/nightly_android.yml
+++ b/.github/workflows/nightly_android.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: 'corretto'
           java-version: 11
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/gradle-build-action@v2
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:


### PR DESCRIPTION
## Description ##

Android Continuous action is failing due to being unable to find v3 of gradle/gradle-build-action, reverting to gradle/gradle-build-action@v2, referencing https://github.com/gradle/gradle-build-action it looks like latest release is still v2, so we will monitor

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
