### PR TITLE
Fix tabnet predictor

### DIFF
--- a/api/src/main/java/ai/djl/training/loss/TabNetClassificationLoss.java
+++ b/api/src/main/java/ai/djl/training/loss/TabNetClassificationLoss.java
@@ -42,6 +42,6 @@ public final class TabNetClassificationLoss extends Loss {
     public NDArray evaluate(NDList labels, NDList predictions) {
         return Loss.softmaxCrossEntropyLoss()
                 .evaluate(labels, new NDList(predictions.get(0)))
-                .add(predictions.get(1));
+                .add(predictions.get(1).mean());
     }
 }

--- a/api/src/main/java/ai/djl/training/loss/TabNetRegressionLoss.java
+++ b/api/src/main/java/ai/djl/training/loss/TabNetRegressionLoss.java
@@ -46,6 +46,6 @@ public class TabNetRegressionLoss extends Loss {
                 .sub(predictions.get(0))
                 .square()
                 .mean()
-                .add(predictions.get(1));
+                .add(predictions.get(1).mean());
     }
 }

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularDataset.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularDataset.java
@@ -106,6 +106,21 @@ public abstract class TabularDataset extends RandomAccessDataset {
     }
 
     /**
+     * Returns the direct designated features (either data or label features) from a row.
+     *
+     * @param index the index of the requested data item
+     * @param selected the features to pull from the row
+     * @return the direct features
+     */
+    public List<String> getRowDirect(long index, List<Feature> selected) {
+        List<String> results = new ArrayList<>(selected.size());
+        for (Feature feature : selected) {
+            results.add(getCell(index, feature.getName()));
+        }
+        return results;
+    }
+
+    /**
      * Returns the designated features (either data or label features) from a row.
      *
      * @param manager the manager used to create the arrays

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularTranslator.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/TabularTranslator.java
@@ -62,7 +62,7 @@ public class TabularTranslator implements Translator<ListFeatures, TabularResult
     @Override
     public TabularResults processOutput(TranslatorContext ctx, NDList list) throws Exception {
         List<TabularResult> results = new ArrayList<>(labels.size());
-        float[] data = list.singletonOrThrow().toFloatArray();
+        float[] data = list.head().toFloatArray();
         int dataIndex = 0;
         for (Feature label : labels) {
             Featurizer featurizer = label.getFeaturizer();

--- a/model-zoo/src/main/java/ai/djl/basicmodelzoo/tabular/TabNet.java
+++ b/model-zoo/src/main/java/ai/djl/basicmodelzoo/tabular/TabNet.java
@@ -444,8 +444,7 @@ public final class TabNet extends AbstractBlock {
             NDArray sparseLoss =
                     mask.singletonOrThrow()
                             .mul(-1)
-                            .mul(NDArrays.add(mask.singletonOrThrow(), 1e-10).log())
-                            .mean();
+                            .mul(NDArrays.add(mask.singletonOrThrow(), 1e-10).log());
             NDList x1 = featureTransformer.forward(parameterStore, new NDList(x), training);
             return new NDList(x1.singletonOrThrow(), sparseLoss);
         }


### PR DESCRIPTION
Fixes the tabnet model which pre-calculates loss to return the loss per element rather than the mean. Otherwise, it can't be unbatched.

Also, adds helper getRowDirect to make it easier to test predictor from a dataset and adds prediction to the tabnet example.