### PR TITLE
[M1 Macs] add warning for model criteria inexplicably not working when api is loaded as a jar in a new project.

### DIFF
--- a/api/src/main/java/ai/djl/repository/zoo/Criteria.java
+++ b/api/src/main/java/ai/djl/repository/zoo/Criteria.java
@@ -181,6 +181,9 @@ public class Criteria<I, O> {
                 }
             }
         }
+        logger.debug(
+                "If you're on an MacOS arch64 (Apple Silicon) you may be getting here "+
+                        "because you do not have the pytorch-model-zoo dependency installed.");
         throw new ModelNotFoundException(
                 "No model with the specified URI or the matching Input/Output type is found.",
                 lastException);


### PR DESCRIPTION

## Description ##
When you load models on an M1 Mac you can get the error 
 fails with input/output not matching exception. 
This can arise when you're using dlj `api.jar` in a new project as a dependency - but you didn't include `pytorch-model-zoo`

Brief description of what this PR is about
The purpose of this PR is to give a flag to the user to say "hey - just in case you didn't know this" - you're probably looking in the wrong place to solve this problem. Look at project dependencies, not input parameters to `Criteria`. 

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
