### PR TITLE
pytorch support inference on separate cuda stream

### DIFF
--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/IValueUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/IValueUtils.java
@@ -35,6 +35,8 @@ public final class IValueUtils {
     private static final Pattern PATTERN_LIST = Pattern.compile("\\w+\\[]");
     private static final Pattern PATTERN_TUPLE = Pattern.compile("\\w+\\(\\)");
     private static final Pattern PATTERN_TUPLE_OF_TUPLE = Pattern.compile("\\w+(\\([\\d,]+\\))");
+    private static final boolean CUDA_STREAM =
+            Boolean.getBoolean("ai.djl.pytorch.enable_cuda_stream");
 
     private IValueUtils() {}
 
@@ -51,15 +53,9 @@ public final class IValueUtils {
         IValue[] ivalues = inputPair.getKey();
         String method = inputPair.getValue();
         long[] iValueHandles = Arrays.stream(ivalues).mapToLong(IValue::getHandle).toArray();
-        boolean inferenceSeparateCudaStream =
-                Boolean.getBoolean("ai.djl.pytorch.inference_separate_cuda_stream");
         long result =
                 PyTorchLibrary.LIB.moduleRunMethod(
-                        block.getHandle(),
-                        method,
-                        iValueHandles,
-                        isTrain,
-                        inferenceSeparateCudaStream);
+                        block.getHandle(), method, iValueHandles, isTrain, CUDA_STREAM);
         PtNDManager manager = (PtNDManager) inputs.get(0).getManager();
         Arrays.stream(ivalues).forEach(IValue::close);
         try (IValue iValue = new IValue(result)) {
@@ -88,15 +84,9 @@ public final class IValueUtils {
      */
     public static IValue runMethod(PtSymbolBlock block, String methodName, IValue... inputs) {
         long[] iValueHandles = Arrays.stream(inputs).mapToLong(IValue::getHandle).toArray();
-        boolean inferenceSeparateCudaStream =
-                Boolean.getBoolean("ai.djl.pytorch.inference_separate_cuda_stream");
         return new IValue(
                 PyTorchLibrary.LIB.moduleRunMethod(
-                        block.getHandle(),
-                        methodName,
-                        iValueHandles,
-                        false,
-                        inferenceSeparateCudaStream));
+                        block.getHandle(), methodName, iValueHandles, false, CUDA_STREAM));
     }
 
     private static int addToMap(

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/IValueUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/IValueUtils.java
@@ -51,10 +51,15 @@ public final class IValueUtils {
         IValue[] ivalues = inputPair.getKey();
         String method = inputPair.getValue();
         long[] iValueHandles = Arrays.stream(ivalues).mapToLong(IValue::getHandle).toArray();
-        boolean inferenceSeparateCudaStream = Boolean.getBoolean("ai.djl.pytorch.inference_separate_cuda_stream");
+        boolean inferenceSeparateCudaStream =
+                Boolean.getBoolean("ai.djl.pytorch.inference_separate_cuda_stream");
         long result =
                 PyTorchLibrary.LIB.moduleRunMethod(
-                        block.getHandle(), method, iValueHandles, isTrain, inferenceSeparateCudaStream);
+                        block.getHandle(),
+                        method,
+                        iValueHandles,
+                        isTrain,
+                        inferenceSeparateCudaStream);
         PtNDManager manager = (PtNDManager) inputs.get(0).getManager();
         Arrays.stream(ivalues).forEach(IValue::close);
         try (IValue iValue = new IValue(result)) {
@@ -83,10 +88,15 @@ public final class IValueUtils {
      */
     public static IValue runMethod(PtSymbolBlock block, String methodName, IValue... inputs) {
         long[] iValueHandles = Arrays.stream(inputs).mapToLong(IValue::getHandle).toArray();
-        boolean inferenceSeparateCudaStream = Boolean.getBoolean("ai.djl.pytorch.inference_separate_cuda_stream");
+        boolean inferenceSeparateCudaStream =
+                Boolean.getBoolean("ai.djl.pytorch.inference_separate_cuda_stream");
         return new IValue(
                 PyTorchLibrary.LIB.moduleRunMethod(
-                        block.getHandle(), methodName, iValueHandles, false, inferenceSeparateCudaStream));
+                        block.getHandle(),
+                        methodName,
+                        iValueHandles,
+                        false,
+                        inferenceSeparateCudaStream));
     }
 
     private static int addToMap(

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/IValueUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/IValueUtils.java
@@ -51,9 +51,10 @@ public final class IValueUtils {
         IValue[] ivalues = inputPair.getKey();
         String method = inputPair.getValue();
         long[] iValueHandles = Arrays.stream(ivalues).mapToLong(IValue::getHandle).toArray();
+        boolean inferenceSeparateCudaStream = Boolean.getBoolean("ai.djl.pytorch.inference_separate_cuda_stream");
         long result =
                 PyTorchLibrary.LIB.moduleRunMethod(
-                        block.getHandle(), method, iValueHandles, isTrain);
+                        block.getHandle(), method, iValueHandles, isTrain, inferenceSeparateCudaStream);
         PtNDManager manager = (PtNDManager) inputs.get(0).getManager();
         Arrays.stream(ivalues).forEach(IValue::close);
         try (IValue iValue = new IValue(result)) {
@@ -82,9 +83,10 @@ public final class IValueUtils {
      */
     public static IValue runMethod(PtSymbolBlock block, String methodName, IValue... inputs) {
         long[] iValueHandles = Arrays.stream(inputs).mapToLong(IValue::getHandle).toArray();
+        boolean inferenceSeparateCudaStream = Boolean.getBoolean("ai.djl.pytorch.inference_separate_cuda_stream");
         return new IValue(
                 PyTorchLibrary.LIB.moduleRunMethod(
-                        block.getHandle(), methodName, iValueHandles, false));
+                        block.getHandle(), methodName, iValueHandles, false, inferenceSeparateCudaStream));
     }
 
     private static int addToMap(

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
@@ -544,7 +544,7 @@ final class PyTorchLibrary {
             String methodName,
             long[] iValueHandles,
             boolean isTrain,
-            boolean inferenceSeparateCudaStream);
+            boolean separateCudaStream);
 
     native void setGraphExecutorOptimize(boolean enabled);
 

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
@@ -540,7 +540,11 @@ final class PyTorchLibrary {
     native void moduleTrain(long handle);
 
     native long moduleRunMethod(
-            long moduleHandle, String methodName, long[] iValueHandles, boolean isTrain, boolean inferenceSeparateCudaStream);
+            long moduleHandle,
+            String methodName,
+            long[] iValueHandles,
+            boolean isTrain,
+            boolean inferenceSeparateCudaStream);
 
     native void setGraphExecutorOptimize(boolean enabled);
 

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
@@ -540,7 +540,7 @@ final class PyTorchLibrary {
     native void moduleTrain(long handle);
 
     native long moduleRunMethod(
-            long moduleHandle, String methodName, long[] iValueHandles, boolean isTrain);
+            long moduleHandle, String methodName, long[] iValueHandles, boolean isTrain, boolean inferenceSeparateCudaStream);
 
     native void setGraphExecutorOptimize(boolean enabled);
 

--- a/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_inference.cc
+++ b/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_inference.cc
@@ -16,6 +16,7 @@
 #ifdef USE_CUDA
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
+#include <ATen/cuda/CUDAContext.h>
 #endif
 
 #include "ai_djl_pytorch_jni_PyTorchLibrary.h"


### PR DESCRIPTION
## Description ##

This PR is an attempt to support running inference on separate cuda streams for pytorch engine. By doing this, we can maximize GPU utilization when running concurrent inference requests on GPU.

Also added a boolean flag `inferenceSeparateCudaStream` controlled through system properties `"ai.djl.pytorch.inference_separate_cuda_stream"` to determine whether this new feature is enabled.

I considered exposing the full cuda stream related pytorch api through JNI but in the end decided to only expose a high level boolean flag, mainly because:

- it's much easier to expose only this boolean flag
- there's no other use case that requires the full cuda stream api