### PR TITLE
[fix] Set past_kv name for corner case.

### DIFF
--- a/engines/pytorch/pytorch-model-zoo/src/test/java/ai/djl/pytorch/zoo/nlp/textgeneration/GptTranslatorTest.java
+++ b/engines/pytorch/pytorch-model-zoo/src/test/java/ai/djl/pytorch/zoo/nlp/textgeneration/GptTranslatorTest.java
@@ -34,10 +34,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-public class TextGenerationTest {
+public class GptTranslatorTest {
 
     @Test
     public void testGpt2() throws TranslateException, ModelException, IOException {
+        // This is a fake model that simulates language models like GPT2: NDList(inputIds, posIds,
+        // attnMask) -> NDList(logits(1), pastKv(12*2)[, hiddenStates(13)])
         Block block =
                 new LambdaBlock(
                         a -> {


### PR DESCRIPTION
## Description ##

1. Add documentation and clarify some naming
2. Set tuple name for pastKeyValues, when the init inference call to gpt2 has not-null kvCache input. Previously this case was missed and would cause error.
