### PR TITLE
Setup custom ft build for Llama support

### DIFF
--- a/.github/workflows/build_triton_and_ft.yml
+++ b/.github/workflows/build_triton_and_ft.yml
@@ -11,6 +11,11 @@ on:
         description: 'fastertransformer branch/tag version'
         required: true
         default: 'main'
+      is_llama_build:
+        description: 'whether to build custom llama source'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build-triton:
@@ -68,7 +73,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build FasterTransformers
         run: |
-          tools/scripts/build_ft_deps.sh ${{ github.event.inputs.fastertransformer }} ${{ github.event.inputs.triton }}
+          tools/scripts/build_ft_deps.sh ${{ github.event.inputs.fastertransformer }} ${{ github.event.inputs.triton }} ${{ github.event.inputs.is_llama_build }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -76,9 +81,15 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Copy files to S3 with the AWS CLI
+        if !${{ github.event.inputs.is_llama_build }}
         run: |
           aws s3 sync /tmp/binaries/ s3://djl-ai/publish/fastertransformer/${{ github.event.inputs.fastertransformer }}/
           aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/fastertransformer/${{ github.event.inputs.fastertransformer }}/*"
+        if ${{ github.event.inputs.is_llama_build }}
+        run: |
+          echo "pushing binaries to ft llama path"
+          aws s3 sync /tmp/binaries/ s3://djl-ai/publish/fastertransformer-llama/${{ github.event.inputs.fastertransformer }}/
+          aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/fastertransformer-llama/${{ github.event.inputs.fastertransformer }}/*"
 
   stop-runner:
     if: ${{ github.repository == 'deepjavalibrary/djl' && always() }}

--- a/.github/workflows/build_triton_and_ft.yml
+++ b/.github/workflows/build_triton_and_ft.yml
@@ -81,11 +81,11 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Copy files to S3 with the AWS CLI
-        if ${{ github.event.inputs.is_llama_build }} == 'false'
+        if: ${{ github.event.inputs.is_llama_build }} == 'false'
         run: |
           aws s3 sync /tmp/binaries/ s3://djl-ai/publish/fastertransformer/${{ github.event.inputs.fastertransformer }}/
           aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/fastertransformer/${{ github.event.inputs.fastertransformer }}/*"
-        if ${{ github.event.inputs.is_llama_build }} == 'true'
+        if: ${{ github.event.inputs.is_llama_build }} == 'true'
         run: |
           echo "pushing binaries to ft/llama"
           aws s3 sync /tmp/binaries/ s3://djl-ai/publish/fastertransformer/llama/

--- a/.github/workflows/build_triton_and_ft.yml
+++ b/.github/workflows/build_triton_and_ft.yml
@@ -33,8 +33,7 @@ jobs:
       - name: Build Triton Binary
         shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
         run: |
-          # python3 build.py --enable-logging --enable-metrics --enable-stats --enable-cpu-metrics --endpoint http
-          echo "dummy"
+          python3 build.py --enable-logging --enable-metrics --enable-stats --enable-cpu-metrics --endpoint http
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -43,10 +42,9 @@ jobs:
           aws-region: us-east-2
       - name: Copy files to S3 with the AWS CLI
         run: |
-          echo "dummy"
-          # aws s3 cp build/install/lib/libtritonserver.so s3://djl-ai/publish/tritonserver/${{ github.event.inputs.triton }}/
-          # aws s3 cp build/install/bin/tritonserver s3://djl-ai/publish/tritonserver/${{ github.event.inputs.triton }}/
-          # aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/tritonserver/${{ github.event.inputs.triton }}/*"
+          aws s3 cp build/install/lib/libtritonserver.so s3://djl-ai/publish/tritonserver/${{ github.event.inputs.triton }}/
+          aws s3 cp build/install/bin/tritonserver s3://djl-ai/publish/tritonserver/${{ github.event.inputs.triton }}/
+          aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/tritonserver/${{ github.event.inputs.triton }}/*"
 
   create-runner:
     if: github.repository == 'deepjavalibrary/djl'
@@ -75,8 +73,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build FasterTransformers
         run: |
-          # tools/scripts/build_ft_deps.sh ${{ github.event.inputs.fastertransformer }} ${{ github.event.inputs.triton }} ${{ github.event.inputs.is_llama_build }}
-          echo "dummy ft build commnad"
+          tools/scripts/build_ft_deps.sh ${{ github.event.inputs.fastertransformer }} ${{ github.event.inputs.triton }} ${{ github.event.inputs.is_llama_build }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -86,21 +83,14 @@ jobs:
       - name: Copy files to S3 with the AWS CLI
         if: github.event.inputs.is_llama_build == 'false'
         run: |
-          echo "pushing binaries to ft/main"
-          echo github.event.inputs.is_llama_build == 'false'
-          echo github.event.inputs.is_llama_build
-          echo !${{ github.event.inputs.is_llama_build }}
-          # aws s3 sync /tmp/binaries/ s3://djl-ai/publish/fastertransformer/${{ github.event.inputs.fastertransformer }}/
-          # aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/fastertransformer/${{ github.event.inputs.fastertransformer }}/*"
+          aws s3 sync /tmp/binaries/ s3://djl-ai/publish/fastertransformer/${{ github.event.inputs.fastertransformer }}/
+          aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/fastertransformer/${{ github.event.inputs.fastertransformer }}/*"
       - name: Copy files for llama build to S3 with AWS CLI
         if: github.event.inputs.is_llama_build == 'true'
         run: |
           echo "pushing binaries to ft/llama"
-          echo github.event.inputs.is_llama_build == 'true'
-          echo github.event.inputs.is_llama_build
-          echo !github.event.inputs.is_llama_build
-          # aws s3 sync /tmp/binaries/ s3://djl-ai/publish/fastertransformer/llama/
-          # aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/fastertransformer-llama/${{ github.event.inputs.fastertransformer }}/*"
+          aws s3 sync /tmp/binaries/ s3://djl-ai/publish/fastertransformer/llama/
+          aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/fastertransformer-llama/${{ github.event.inputs.fastertransformer }}/*"
 
   stop-runner:
     if: ${{ github.repository == 'deepjavalibrary/djl' && always() }}

--- a/.github/workflows/build_triton_and_ft.yml
+++ b/.github/workflows/build_triton_and_ft.yml
@@ -84,21 +84,21 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Copy files to S3 with the AWS CLI
-        if: ${{ github.event.inputs.is_llama_build }} == 'false'
+        if: github.event.inputs.is_llama_build == 'false'
         run: |
           echo "pushing binaries to ft/main"
-          echo ${{ github.event.inputs.is_llama_build }} == 'false'
-          echo ${{ github.event.inputs.is_llama_build }}
+          echo github.event.inputs.is_llama_build == 'false'
+          echo github.event.inputs.is_llama_build
           echo !${{ github.event.inputs.is_llama_build }}
           # aws s3 sync /tmp/binaries/ s3://djl-ai/publish/fastertransformer/${{ github.event.inputs.fastertransformer }}/
           # aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/fastertransformer/${{ github.event.inputs.fastertransformer }}/*"
       - name: Copy files for llama build to S3 with AWS CLI
-        if: ${{ github.event.inputs.is_llama_build }} == 'true'
+        if: github.event.inputs.is_llama_build == 'true'
         run: |
           echo "pushing binaries to ft/llama"
-          echo ${{ github.event.inputs.is_llama_build }} == 'false'
-          echo ${{ github.event.inputs.is_llama_build }}
-          echo !${{ github.event.inputs.is_llama_build }}
+          echo github.event.inputs.is_llama_build == 'true'
+          echo github.event.inputs.is_llama_build
+          echo !github.event.inputs.is_llama_build
           # aws s3 sync /tmp/binaries/ s3://djl-ai/publish/fastertransformer/llama/
           # aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/fastertransformer-llama/${{ github.event.inputs.fastertransformer }}/*"
 

--- a/.github/workflows/build_triton_and_ft.yml
+++ b/.github/workflows/build_triton_and_ft.yml
@@ -33,7 +33,8 @@ jobs:
       - name: Build Triton Binary
         shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
         run: |
-          python3 build.py --enable-logging --enable-metrics --enable-stats --enable-cpu-metrics --endpoint http
+          # python3 build.py --enable-logging --enable-metrics --enable-stats --enable-cpu-metrics --endpoint http
+          echo "dummy"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -42,9 +43,10 @@ jobs:
           aws-region: us-east-2
       - name: Copy files to S3 with the AWS CLI
         run: |
-          aws s3 cp build/install/lib/libtritonserver.so s3://djl-ai/publish/tritonserver/${{ github.event.inputs.triton }}/
-          aws s3 cp build/install/bin/tritonserver s3://djl-ai/publish/tritonserver/${{ github.event.inputs.triton }}/
-          aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/tritonserver/${{ github.event.inputs.triton }}/*"
+          echo "dummy"
+          # aws s3 cp build/install/lib/libtritonserver.so s3://djl-ai/publish/tritonserver/${{ github.event.inputs.triton }}/
+          # aws s3 cp build/install/bin/tritonserver s3://djl-ai/publish/tritonserver/${{ github.event.inputs.triton }}/
+          # aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/tritonserver/${{ github.event.inputs.triton }}/*"
 
   create-runner:
     if: github.repository == 'deepjavalibrary/djl'
@@ -85,14 +87,18 @@ jobs:
         if: ${{ github.event.inputs.is_llama_build }} == 'false'
         run: |
           echo "pushing binaries to ft/main"
+          echo ${{ github.event.inputs.is_llama_build }} == 'false'
           echo ${{ github.event.inputs.is_llama_build }}
+          echo !${{ github.event.inputs.is_llama_build }}
           # aws s3 sync /tmp/binaries/ s3://djl-ai/publish/fastertransformer/${{ github.event.inputs.fastertransformer }}/
           # aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/fastertransformer/${{ github.event.inputs.fastertransformer }}/*"
       - name: Copy files for llama build to S3 with AWS CLI
         if: ${{ github.event.inputs.is_llama_build }} == 'true'
         run: |
           echo "pushing binaries to ft/llama"
+          echo ${{ github.event.inputs.is_llama_build }} == 'false'
           echo ${{ github.event.inputs.is_llama_build }}
+          echo !${{ github.event.inputs.is_llama_build }}
           # aws s3 sync /tmp/binaries/ s3://djl-ai/publish/fastertransformer/llama/
           # aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/fastertransformer-llama/${{ github.event.inputs.fastertransformer }}/*"
 

--- a/.github/workflows/build_triton_and_ft.yml
+++ b/.github/workflows/build_triton_and_ft.yml
@@ -73,7 +73,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build FasterTransformers
         run: |
-          tools/scripts/build_ft_deps.sh ${{ github.event.inputs.fastertransformer }} ${{ github.event.inputs.triton }} ${{ github.event.inputs.is_llama_build }}
+          # tools/scripts/build_ft_deps.sh ${{ github.event.inputs.fastertransformer }} ${{ github.event.inputs.triton }} ${{ github.event.inputs.is_llama_build }}
+          echo "dummy ft build commnad"
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -83,14 +84,17 @@ jobs:
       - name: Copy files to S3 with the AWS CLI
         if: ${{ github.event.inputs.is_llama_build }} == 'false'
         run: |
-          aws s3 sync /tmp/binaries/ s3://djl-ai/publish/fastertransformer/${{ github.event.inputs.fastertransformer }}/
-          aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/fastertransformer/${{ github.event.inputs.fastertransformer }}/*"
+          echo "pushing binaries to ft/main"
+          echo ${{ github.event.inputs.is_llama_build }}
+          # aws s3 sync /tmp/binaries/ s3://djl-ai/publish/fastertransformer/${{ github.event.inputs.fastertransformer }}/
+          # aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/fastertransformer/${{ github.event.inputs.fastertransformer }}/*"
       - name: Copy files for llama build to S3 with AWS CLI
         if: ${{ github.event.inputs.is_llama_build }} == 'true'
         run: |
           echo "pushing binaries to ft/llama"
-          aws s3 sync /tmp/binaries/ s3://djl-ai/publish/fastertransformer/llama/
-          aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/fastertransformer-llama/${{ github.event.inputs.fastertransformer }}/*"
+          echo ${{ github.event.inputs.is_llama_build }}
+          # aws s3 sync /tmp/binaries/ s3://djl-ai/publish/fastertransformer/llama/
+          # aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/fastertransformer-llama/${{ github.event.inputs.fastertransformer }}/*"
 
   stop-runner:
     if: ${{ github.repository == 'deepjavalibrary/djl' && always() }}

--- a/.github/workflows/build_triton_and_ft.yml
+++ b/.github/workflows/build_triton_and_ft.yml
@@ -81,14 +81,14 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - name: Copy files to S3 with the AWS CLI
-        if !${{ github.event.inputs.is_llama_build }}
+        if ${{ github.event.inputs.is_llama_build }} == 'false'
         run: |
           aws s3 sync /tmp/binaries/ s3://djl-ai/publish/fastertransformer/${{ github.event.inputs.fastertransformer }}/
           aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/fastertransformer/${{ github.event.inputs.fastertransformer }}/*"
-        if ${{ github.event.inputs.is_llama_build }}
+        if ${{ github.event.inputs.is_llama_build }} == 'true'
         run: |
-          echo "pushing binaries to ft llama path"
-          aws s3 sync /tmp/binaries/ s3://djl-ai/publish/fastertransformer-llama/${{ github.event.inputs.fastertransformer }}/
+          echo "pushing binaries to ft/llama"
+          aws s3 sync /tmp/binaries/ s3://djl-ai/publish/fastertransformer/llama/
           aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/fastertransformer-llama/${{ github.event.inputs.fastertransformer }}/*"
 
   stop-runner:

--- a/.github/workflows/build_triton_and_ft.yml
+++ b/.github/workflows/build_triton_and_ft.yml
@@ -85,6 +85,7 @@ jobs:
         run: |
           aws s3 sync /tmp/binaries/ s3://djl-ai/publish/fastertransformer/${{ github.event.inputs.fastertransformer }}/
           aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/fastertransformer/${{ github.event.inputs.fastertransformer }}/*"
+      - name: Copy files for llama build to S3 with AWS CLI
         if: ${{ github.event.inputs.is_llama_build }} == 'true'
         run: |
           echo "pushing binaries to ft/llama"

--- a/tools/scripts/build_ft_deps.sh
+++ b/tools/scripts/build_ft_deps.sh
@@ -4,6 +4,7 @@ set -ex
 
 FT_VERSION=$1
 NVIDIA_TRITON_SERVER_VERSION=$2
+IS_LLAMA_BUILD=$3
 
 apt-get update && apt-get install -y rapidjson-dev
 
@@ -15,7 +16,12 @@ export FT_DIR=/tmp/FasterTransformer
 mkdir -p /tmp/binaries
 
 # Build FasterTransformer Triton library
-git clone https://github.com/triton-inference-server/fastertransformer_backend.git
+if [ "$IS_LLAMA_BUILD" = false ] ; then
+      git clone https://github.com/triton-inference-server/fastertransformer_backend.git
+else
+      echo "cloning forked FT backend repo with llama support"
+      git clone https://github.com/rohithkrn/fastertransformer_backend.git -b llama_void_main
+fi
 mkdir -p fastertransformer_backend/build
 cd fastertransformer_backend/build
 cmake \

--- a/tools/scripts/build_ft_deps.sh
+++ b/tools/scripts/build_ft_deps.sh
@@ -16,7 +16,7 @@ export FT_DIR=/tmp/FasterTransformer
 mkdir -p /tmp/binaries
 
 # Build FasterTransformer Triton library
-if [ "$IS_LLAMA_BUILD" = false ] ; then
+if [ "$IS_LLAMA_BUILD" = "false" ] ; then
       git clone https://github.com/triton-inference-server/fastertransformer_backend.git
 else
       echo "cloning forked FT backend repo with llama support"


### PR DESCRIPTION
## Description ##

- Clones FT backend from forked repo - https://github.com/rohithkrn/fastertransformer_backend.git which adds llama support. Backend repo [points](https://github.com/rohithkrn/fastertransformer_backend/blob/llama_support/CMakeLists.txt#L113) to FT repo with model implementation which taken from void-main's PR to FT repo.
- Added `is_llama_build` flag to isolate from existing setup so that it will be easy to switch. This also pushes binaries to a new s3 path (`fastertransformer/llama`) which probably needs creation.