### PR TITLE
Prevent model server crash if data is missing in metadata file during callHome

### DIFF
--- a/api/src/main/java/ai/djl/util/Ec2Utils.java
+++ b/api/src/main/java/ai/djl/util/Ec2Utils.java
@@ -178,7 +178,7 @@ public final class Ec2Utils {
         Path path = Paths.get(ENDPOINT_METADATA_FILE);
         try (Reader reader = Files.newBufferedReader(path)) {
             JsonObject json = JsonUtils.GSON.fromJson(reader, JsonObject.class);
-            return json.get(key).getAsString();
+            return (json.get(key) != null) ? json.get(key).getAsString() : null;
         } catch (IOException e) {
             // ignore
         }


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
