### PR TITLE
Expose numpy encode and decode

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/NDArray.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArray.java
@@ -147,6 +147,15 @@ public interface NDArray extends NDResource, BytesSupplier {
     }
 
     /**
+     * Encodes {@code NDArray} to a numpy .npy byte array.
+     *
+     * @return a numpy .npy byte array
+     */
+    default byte[] encodeAsNumpy() {
+        return NDSerializer.encodeAsNumpy(this);
+    }
+
+    /**
      * Moves this {@code NDArray} to a different {@link Device}.
      *
      * @param device the {@link Device} to be set

--- a/api/src/main/java/ai/djl/ndarray/NDList.java
+++ b/api/src/main/java/ai/djl/ndarray/NDList.java
@@ -222,7 +222,7 @@ public class NDList extends ArrayList<NDArray> implements NDResource, BytesSuppl
         ZipEntry entry;
         while ((entry = zis.getNextEntry()) != null) {
             String name = entry.getName();
-            NDArray array = NDSerializer.decodeNumpy(manager, zis);
+            NDArray array = manager.decodeNumpy(zis);
             if (!name.startsWith("arr_") && name.endsWith(".npy")) {
                 array.setName(name.substring(0, name.length() - 4));
             }

--- a/api/src/main/java/ai/djl/ndarray/NDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/NDManager.java
@@ -720,6 +720,27 @@ public interface NDManager extends AutoCloseable {
     }
 
     /**
+     * Decodes a numpy .npy {@link NDArray} through byte array.
+     *
+     * @param bytes byte array to load from
+     * @return {@link NDArray}
+     */
+    default NDArray decodeNumpy(byte[] bytes) {
+        return NDSerializer.decodeNumpy(this, ByteBuffer.wrap(bytes));
+    }
+
+    /**
+     * Decodes a numpy .npy {@link NDArray} through {@link DataInputStream}.
+     *
+     * @param is input stream data to load from
+     * @return {@link NDArray}
+     * @throws IOException data is not readable
+     */
+    default NDArray decodeNumpy(InputStream is) throws IOException {
+        return NDSerializer.decodeNumpy(this, is);
+    }
+
+    /**
      * Loads the NDArrays saved to a file.
      *
      * @param path the path to the file

--- a/api/src/main/java/ai/djl/util/ByteBufferBackedInputStream.java
+++ b/api/src/main/java/ai/djl/util/ByteBufferBackedInputStream.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * A utility for reading a {@link ByteBuffer} with an {@link InputStream}.
+ *
+ * @see <a href="https://stackoverflow.com/a/6603018">source</a>
+ */
+public class ByteBufferBackedInputStream extends InputStream {
+    ByteBuffer buf;
+
+    /**
+     * Constructs a new {@link ByteBufferBackedInputStream}.
+     *
+     * @param buf the backing buffer
+     */
+    public ByteBufferBackedInputStream(ByteBuffer buf) {
+        this.buf = buf;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int read() {
+        if (!buf.hasRemaining()) {
+            return -1;
+        }
+        return buf.get() & 0xFF;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int read(byte[] bytes, int off, int len) {
+        if (!buf.hasRemaining()) {
+            return -1;
+        }
+
+        len = Math.min(len, buf.remaining());
+        buf.get(bytes, off, len);
+        return len;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public synchronized void mark(int readlimit) {
+        buf.mark();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public synchronized void reset() throws IOException {
+        buf.reset();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean markSupported() {
+        return true;
+    }
+}

--- a/api/src/test/java/ai/djl/ndarray/NDSerializerTest.java
+++ b/api/src/test/java/ai/djl/ndarray/NDSerializerTest.java
@@ -107,7 +107,7 @@ public class NDSerializerTest {
 
     private static NDArray decode(NDManager manager, byte[] data) throws IOException {
         try (ByteArrayInputStream bis = new ByteArrayInputStream(data)) {
-            return NDSerializer.decodeNumpy(manager, bis);
+            return manager.decodeNumpy(bis);
         }
     }
 

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayOtherOpTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayOtherOpTest.java
@@ -842,6 +842,16 @@ public class NDArrayOtherOpTest {
     }
 
     @Test
+    public void testEncodeDecodeNumpy() {
+        try (NDManager manager = NDManager.newBaseManager(TestUtils.getEngine())) {
+            NDArray array = manager.create(new byte[] {0, 3}, new Shape(2));
+            byte[] bytes = array.encodeAsNumpy();
+            NDArray recovered = manager.decodeNumpy(bytes);
+            Assertions.assertAlmostEquals(recovered, array);
+        }
+    }
+
+    @Test
     public void testErfinv() {
         try (NDManager manager = NDManager.newBaseManager(TestUtils.getEngine())) {
             // test 1-D


### PR DESCRIPTION
This exposes the numpy encoding on the NDArray class and the decoding on the NDManager class. It also refactors the NDSerializer to use a ByteBufferBackedInputStream (added as a utility) to combine the encoding of input streams and byte buffers
