### PR TITLE
Adds Device.getDevices() for all Device

### DIFF
--- a/api/src/main/java/ai/djl/Device.java
+++ b/api/src/main/java/ai/djl/Device.java
@@ -15,6 +15,7 @@ package ai.djl;
 import ai.djl.engine.Engine;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -162,6 +163,15 @@ public class Device {
         return Type.GPU.equals(deviceType);
     }
 
+    /**
+     * Returns the sub devices if present (such as a {@link MultiDevice}), otherwise this.
+     *
+     * @return the sub devices if present (such as a {@link MultiDevice}), otherwise this.
+     */
+    public List<Device> getDevices() {
+        return Collections.singletonList(this);
+    }
+
     /** {@inheritDoc} */
     @Override
     public String toString() {
@@ -276,11 +286,8 @@ public class Device {
             this.devices = devices;
         }
 
-        /**
-         * Returns the sub devices.
-         *
-         * @return the sub devices
-         */
+        /** {@inheritDoc} */
+        @Override
         public List<Device> getDevices() {
             return devices;
         }

--- a/api/src/test/java/ai/djl/DeviceTest.java
+++ b/api/src/test/java/ai/djl/DeviceTest.java
@@ -39,6 +39,7 @@ public class DeviceTest {
         System.setProperty("test_key", "test");
         Engine.debugEnvironment();
 
+        Assert.assertEquals(1, Device.cpu().getDevices().size());
         Assert.assertEquals(2, new MultiDevice(Device.gpu(1), Device.gpu(2)).getDevices().size());
     }
 


### PR DESCRIPTION
This improves upon the creation of MultiDevice in #2819 by moving the getDevices function to the main Device class. This can simplify the usage of something which is potentially a MultiDevice and make it easier to check for the presence of a MultiDevice.