### PR TITLE
Fixes archiveBaseName in native builds

### DIFF
--- a/engines/mxnet/native/build.gradle
+++ b/engines/mxnet/native/build.gradle
@@ -89,6 +89,7 @@ flavorNames.each { flavor ->
             }
             from file("${BINARY_ROOT}/${flavor}/${osName}")
             archiveClassifier = "${osName}-x86_64"
+            archiveBaseName = "mxnet-native-${flavor}"
 
             manifest {
                 attributes("Automatic-Module-Name": "ai.djl.mxnet_native_${flavor}_${osName}")

--- a/engines/paddlepaddle/paddlepaddle-native/build.gradle
+++ b/engines/paddlepaddle/paddlepaddle-native/build.gradle
@@ -213,6 +213,7 @@ flavorNames.each { flavor ->
             }
             from file("${BINARY_ROOT}/${flavor}/${osName}")
             archiveClassifier = "${osName}-x86_64"
+            archiveBaseName = "paddlepaddle-native-${flavor}"
 
             manifest {
                 attributes("Automatic-Module-Name": "ai.djl.paddlepaddle_native_${flavor}_${osName}")

--- a/engines/tensorflow/tensorflow-native/build.gradle
+++ b/engines/tensorflow/tensorflow-native/build.gradle
@@ -153,6 +153,7 @@ flavorNames.each { flavor ->
             }
             from file("${BINARY_ROOT}/${flavor}/${osName}")
             archiveClassifier = "${osName}-x86_64"
+            archiveBaseName = "tensorflow-native-${flavor}"
 
             manifest {
                 attributes("Automatic-Module-Name": "ai.djl.tensorflow_native_${flavor}_${osName}")

--- a/engines/tflite/tflite-native/build.gradle
+++ b/engines/tflite/tflite-native/build.gradle
@@ -155,6 +155,7 @@ flavorNames.each { flavor ->
             from file("src/main/resources")
             from file("${project.buildDir}/classes/java/main")
             archiveClassifier = "${osName}"
+            archiveBaseName = "tflite-native-${flavor}"
 
             manifest {
                 attributes("Automatic-Module-Name": "ai.djl.tflite_native_${flavor}_${osName}")


### PR DESCRIPTION
This property is necessary to avoid conflicts in building multiple flavors which can be observed in the native properties file not matching the jar for some engine builds.