### PR TITLE
[CI] Fixes flaky early stopping test

### DIFF
--- a/integration/src/main/java/ai/djl/integration/tests/training/listener/EarlyStoppingListenerTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/training/listener/EarlyStoppingListenerTest.java
@@ -174,11 +174,12 @@ public class EarlyStoppingListenerTest {
                 trainer.setMetrics(metrics);
 
                 try {
-                    // Set epoch to 5 as we expect the early stopping to stop after the second epoch
-                    EasyTrain.fit(trainer, 5, trainMnistDataset, testMnistDataset);
+                    // Set epoch to 10 as we expect the early stopping to stop after the second
+                    // epoch
+                    EasyTrain.fit(trainer, 10, trainMnistDataset, testMnistDataset);
                 } catch (EarlyStoppingListener.EarlyStoppedException e) {
                     Assert.assertTrue(e.getMessage().contains("ms elapsed >= 1 maxMillis"));
-                    Assert.assertEquals(e.getStopEpoch(), 1);
+                    Assert.assertTrue(e.getStopEpoch() < 10); // Stop epoch is before 10
                 }
 
                 TrainingResult trainingResult = trainer.getTrainingResult();


### PR DESCRIPTION
This changes the test from requiring the early stopping at a particular epoch to ensuring that it stops early due to time constraints. This should help reduce the chances of being flaky due to race conditions.