### PR TITLE
Add Evaluator support to update multiple accumulators

### DIFF
--- a/api/src/main/java/ai/djl/training/evaluator/AbstractAccuracy.java
+++ b/api/src/main/java/ai/djl/training/evaluator/AbstractAccuracy.java
@@ -77,9 +77,22 @@ public abstract class AbstractAccuracy extends Evaluator {
     /** {@inheritDoc} */
     @Override
     public void updateAccumulator(String key, NDList labels, NDList predictions) {
+        updateAccumulators(new String[] {key}, labels, predictions);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateAccumulators(String[] keys, NDList labels, NDList predictions) {
         Pair<Long, NDArray> update = accuracyHelper(labels, predictions);
-        totalInstances.compute(key, (k, v) -> v + update.getKey());
-        correctInstances.compute(key, (k, v) -> v + update.getValue().sum().getLong());
+        NDArray value = update.getValue();
+        NDArray sum = value.sum();
+        long correct = sum.getLong();
+        for (String key : keys) {
+            totalInstances.compute(key, (k, v) -> v + update.getKey());
+            correctInstances.compute(key, (k, v) -> v + correct);
+        }
+        value.close();
+        sum.close();
     }
 
     /** {@inheritDoc} */

--- a/api/src/main/java/ai/djl/training/evaluator/BoundingBoxError.java
+++ b/api/src/main/java/ai/djl/training/evaluator/BoundingBoxError.java
@@ -63,10 +63,18 @@ public class BoundingBoxError extends Evaluator {
     /** {@inheritDoc} */
     @Override
     public void updateAccumulator(String key, NDList labels, NDList predictions) {
+        updateAccumulators(new String[] {key}, labels, predictions);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateAccumulators(String[] keys, NDList labels, NDList predictions) {
         NDArray boundingBoxError = evaluate(labels, predictions);
         float update = boundingBoxError.sum().getFloat();
-        totalInstances.compute(key, (k, v) -> v + boundingBoxError.size());
-        ssdBoxPredictionError.compute(key, (k, v) -> v + update);
+        for (String key : keys) {
+            totalInstances.compute(key, (k, v) -> v + boundingBoxError.size());
+            ssdBoxPredictionError.compute(key, (k, v) -> v + update);
+        }
     }
 
     /** {@inheritDoc} */

--- a/api/src/main/java/ai/djl/training/evaluator/Evaluator.java
+++ b/api/src/main/java/ai/djl/training/evaluator/Evaluator.java
@@ -75,12 +75,13 @@ public abstract class Evaluator {
     public abstract void addAccumulator(String key);
 
     /**
-     * Updates the evaluator with the given keys based on a {@link NDList} of labels and predictions.
+     * Updates the evaluator with the given keys based on a {@link NDList} of labels and
+     * predictions.
      *
      * <p>This is a synchronized operation. You should only call it at the end of a batch or epoch.
      *
-     * <p>This is an alternative to @{link {@link #updateAccumulator(String, NDList, NDList)}} that may
-     * be more efficient when updating multiple accumulators at once.
+     * <p>This is an alternative to @{link {@link #updateAccumulator(String, NDList, NDList)}} that
+     * may be more efficient when updating multiple accumulators at once.
      *
      * @param keys the keys of all the accumulators to update
      * @param labels a {@code NDList} of labels

--- a/api/src/main/java/ai/djl/training/evaluator/Evaluator.java
+++ b/api/src/main/java/ai/djl/training/evaluator/Evaluator.java
@@ -75,6 +75,24 @@ public abstract class Evaluator {
     public abstract void addAccumulator(String key);
 
     /**
+     * Updates the evaluator with the given keys based on a {@link NDList} of labels and predictions.
+     *
+     * <p>This is a synchronized operation. You should only call it at the end of a batch or epoch.
+     *
+     * <p>This is an alternative to @{link {@link #updateAccumulator(String, NDList, NDList)}} that may
+     * be more efficient when updating multiple accumulators at once.
+     *
+     * @param keys the keys of all the accumulators to update
+     * @param labels a {@code NDList} of labels
+     * @param predictions a {@code NDList} of predictions
+     */
+    public void updateAccumulators(String[] keys, NDList labels, NDList predictions) {
+        for (String key : keys) {
+            updateAccumulator(key, labels, predictions);
+        }
+    }
+
+    /**
      * Updates the evaluator with the given key based on a {@link NDList} of labels and predictions.
      *
      * <p>This is a synchronized operation. You should only call it at the end of a batch or epoch.

--- a/api/src/main/java/ai/djl/training/evaluator/IndexEvaluator.java
+++ b/api/src/main/java/ai/djl/training/evaluator/IndexEvaluator.java
@@ -69,6 +69,12 @@ public class IndexEvaluator extends Evaluator {
 
     /** {@inheritDoc} */
     @Override
+    public void updateAccumulators(String[] keys, NDList labels, NDList predictions) {
+        evaluator.updateAccumulators(keys, getLabels(labels), getPredictions(predictions));
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void resetAccumulator(String key) {
         evaluator.resetAccumulator(key);
     }

--- a/api/src/main/java/ai/djl/training/listener/EvaluatorTrainingListener.java
+++ b/api/src/main/java/ai/djl/training/listener/EvaluatorTrainingListener.java
@@ -144,9 +144,7 @@ public class EvaluatorTrainingListener extends TrainingListenerAdapter {
             for (Device device : batchData.getLabels().keySet()) {
                 NDList labels = batchData.getLabels().get(device);
                 NDList predictions = batchData.getPredictions().get(device);
-                for (String accumulator : accumulators) {
-                    evaluator.updateAccumulator(accumulator, labels, predictions);
-                }
+                evaluator.updateAccumulators(accumulators, labels, predictions);
             }
         }
     }

--- a/api/src/main/java/ai/djl/training/loss/AbstractCompositeLoss.java
+++ b/api/src/main/java/ai/djl/training/loss/AbstractCompositeLoss.java
@@ -80,10 +80,10 @@ public abstract class AbstractCompositeLoss extends Loss {
 
     /** {@inheritDoc} */
     @Override
-    public void updateAccumulator(String key, NDList labels, NDList predictions) {
+    public void updateAccumulators(String[] keys, NDList labels, NDList predictions) {
         for (int i = 0; i < components.size(); i++) {
             Pair<NDList, NDList> inputs = inputForComponent(i, labels, predictions);
-            components.get(i).updateAccumulator(key, inputs.getKey(), inputs.getValue());
+            components.get(i).updateAccumulators(keys, inputs.getKey(), inputs.getValue());
         }
     }
 

--- a/api/src/main/java/ai/djl/training/loss/Loss.java
+++ b/api/src/main/java/ai/djl/training/loss/Loss.java
@@ -385,10 +385,18 @@ public abstract class Loss extends Evaluator {
     /** {@inheritDoc} */
     @Override
     public void updateAccumulator(String key, NDList labels, NDList predictions) {
+        updateAccumulators(new String[] {key}, labels, predictions);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateAccumulators(String[] keys, NDList labels, NDList predictions) {
         // this is a synchronized operation, only call it at end of batch or epoch
         float update = evaluate(labels, predictions).sum().getFloat();
-        totalInstances.compute(key, (k, v) -> v + 1);
-        totalLoss.compute(key, (k, v) -> v + update);
+        for (String key : keys) {
+            totalInstances.compute(key, (k, v) -> v + 1);
+            totalLoss.compute(key, (k, v) -> v + update);
+        }
     }
 
     /** {@inheritDoc} */

--- a/extensions/timeseries/src/main/java/ai/djl/timeseries/evaluator/Rmsse.java
+++ b/extensions/timeseries/src/main/java/ai/djl/timeseries/evaluator/Rmsse.java
@@ -94,15 +94,23 @@ public class Rmsse extends Evaluator {
     /** {@inheritDoc} */
     @Override
     public void updateAccumulator(String key, NDList labels, NDList predictions) {
+        updateAccumulators(new String[] {key}, labels, predictions);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateAccumulators(String[] keys, NDList labels, NDList predictions) {
         Pair<Long, NDArray> update = evaluateHelper(labels, predictions);
-        totalInstances.compute(key, (k, v) -> v + update.getKey());
-        totalLoss.compute(
-                key,
-                (k, v) -> {
-                    try (NDArray array = update.getValue().sum()) {
-                        return v + array.getFloat();
-                    }
-                });
+        for (String key : keys) {
+            totalInstances.compute(key, (k, v) -> v + update.getKey());
+            totalLoss.compute(
+                    key,
+                    (k, v) -> {
+                        try (NDArray array = update.getValue().sum()) {
+                            return v + array.getFloat();
+                        }
+                    });
+        }
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
## Description ##

This PR proposes adding a method to the `Evaluator` abstract class
```java
   public void updateAccumulators(String[] keys, NDList labels, NDList predictions) {
        for (String key : keys) {
            updateAccumulator(key, labels, predictions);
        }
    }
```
and then overriding this in subclasses to more efficiently update accumulators.

The reason is that the use of `EvaluatorTrainingListener` can dominate training time - at least when using Apple Silicon + MPS with the recent PR https://github.com/deepjavalibrary/djl/pull/2873

Part of the issue seems to be that `updateAccumulator` needs to be called multiple times for different evaluators after each batch, e.g. accuracy and loss. This results in the same values being recalculated multiple times and transferred to the CPU. The recalculation itself is quite fast, but transfer to the CPU is slow.

## Example with MNIST

I see the following improvements when training with MNIST using MPS.

### With the PR
```
08:21:32.873 [main] [INFO ] a.d.t.l.LoggingTrainingListener - Epoch 50 finished.
08:21:32.873 [main] [INFO ] a.d.t.l.LoggingTrainingListener - Train: Accuracy: 1.00, SoftmaxCrossEntropyLoss: 3.24E-03
08:21:32.873 [main] [INFO ] a.d.t.l.LoggingTrainingListener - Validate: Accuracy: 0.97, SoftmaxCrossEntropyLoss: 0.12
Time: 13.673
```

### Without the PR
```
08:22:41.559 [main] [INFO ] a.d.t.l.LoggingTrainingListener - Epoch 50 finished.
08:22:41.559 [main] [INFO ] a.d.t.l.LoggingTrainingListener - Train: Accuracy: 1.00, SoftmaxCrossEntropyLoss: 3.24E-03
08:22:41.559 [main] [INFO ] a.d.t.l.LoggingTrainingListener - Validate: Accuracy: 0.97, SoftmaxCrossEntropyLoss: 0.12
Time: 17.899
```

### Without logging

Removing `TrainingListener.Defaults.logging()`, I see 
```
Time: 10.006
```
indicating that there is still a considerable overhead in the use of training listeners, but it is roughly halved with the changes here.

### On the CPU

The MNIST example admittedly isn't the best, because it's much faster to use the CPU than MPS anyway. There are still modest improvements though

* **Previous behavior, with logging:** Time: 6.059
* **With the PR, with logging:** Time: 5.601

I see more substantial improvements with custom training for semantic segmentation, e.g. with U-Net, when MPS is much faster than using the CPU.

Without logging, the PR should have little or no effect:

* **Previous behavior, no logging:** Time: 4.893
* **With the PR, no logging:** Time: 4.974



### Code

Adapted from the [MNIST tutorial](https://github.com/deepjavalibrary/djl/blob/5ab2685b01b13ccceb99a0ca1667112b2b68e4f3/jupyter/tutorial/02_train_your_first_model.ipynb)

```java
import ai.djl.Device;
import ai.djl.Model;
import ai.djl.basicdataset.cv.classification.Mnist;
import ai.djl.basicmodelzoo.basic.Mlp;
import ai.djl.engine.Engine;
import ai.djl.metric.Metrics;
import ai.djl.ndarray.NDManager;
import ai.djl.ndarray.types.Shape;
import ai.djl.training.DefaultTrainingConfig;
import ai.djl.training.EasyTrain;
import ai.djl.training.Trainer;
import ai.djl.training.dataset.RandomAccessDataset;
import ai.djl.training.evaluator.Accuracy;
import ai.djl.training.listener.TrainingListener;
import ai.djl.training.loss.Loss;

import java.util.Arrays;

public class MNISTMinimal {

    public static void main(String[] args) {

        int batchSize = 1000;

        Device device = Device.of("mps", 0);
        try (NDManager manager = NDManager.newBaseManager(device, "PyTorch")) {

            Engine.getEngine("PyTorch").setRandomSeed(1243);

            Mnist mnist = Mnist.builder()
                    .optDevice(device)
                    .optManager(manager)
                    .setSampling(batchSize, true)
                    .build();

            mnist.prepare();

            Model model = Model.newInstance("mlp", device);
            model.setBlock(new Mlp(28 * 28, 10, new int[] {128, 64}));

            DefaultTrainingConfig config = new DefaultTrainingConfig(Loss.softmaxCrossEntropyLoss())
                    .optDevices(new Device[]{device})
                    .addEvaluator(new Accuracy()) // Use accuracy so we humans can understand how accurate the model is
                    .addTrainingListeners(TrainingListener.Defaults.logging());

            // Now that we have our training configuration, we should create a new trainer for our model
            Trainer trainer = model.newTrainer(config);

            trainer.setMetrics(new Metrics());
            trainer.initialize(new Shape(1, 28*28));

            // Deep learning is typically trained in epochs where each epoch trains the model on each item in the dataset once.
            int epoch = 50;

            long start = System.currentTimeMillis();
            RandomAccessDataset split[] = mnist.randomSplit(6, 4);
            EasyTrain.fit(trainer, epoch, split[0], split[1]);
            long end = System.currentTimeMillis();

            System.out.println("Time: " + (end - start) / 1000.0);
        } catch (Exception e) {
            e.printStackTrace();
        }
    }
}
```