### PR TITLE
Suppress serial warning for JDK21

### DIFF
--- a/api/src/main/java/ai/djl/modality/cv/output/CategoryMask.java
+++ b/api/src/main/java/ai/djl/modality/cv/output/CategoryMask.java
@@ -43,7 +43,9 @@ public class CategoryMask implements JsonSerializable {
                     .registerTypeAdapter(CategoryMask.class, new SegmentationSerializer())
                     .create();
 
-    private transient List<String> classes;
+    @SuppressWarnings("serial")
+    private List<String> classes;
+
     private int[][] mask;
 
     /**

--- a/api/src/main/java/ai/djl/translate/PaddingStackBatchifier.java
+++ b/api/src/main/java/ai/djl/translate/PaddingStackBatchifier.java
@@ -29,10 +29,17 @@ public final class PaddingStackBatchifier implements Batchifier {
 
     private static final long serialVersionUID = 1L;
 
-    private transient List<Integer> arraysToPad;
-    private transient List<Integer> dimsToPad;
+    @SuppressWarnings("serial")
+    private List<Integer> arraysToPad;
+
+    @SuppressWarnings("serial")
+    private List<Integer> dimsToPad;
+
     private transient List<NDArraySupplier> paddingSuppliers;
-    private transient List<Integer> paddingSizes;
+
+    @SuppressWarnings("serial")
+    private List<Integer> paddingSizes;
+
     private boolean includeValidLengths;
 
     private PaddingStackBatchifier(Builder builder) {


### PR DESCRIPTION
In JDK21, it now throws the serial warning for including potentially unserializable instance variables. This includes the standard Java data structures like List, Set, and Map. This changes the JDK21 support from https://github.com/deepjavalibrary/djl/pull/2903 to suppress the warning rather than no longer serializing the variables.