### PR TITLE
add algebraic logging

### DIFF
--- a/api/src/main/java/ai/djl/nn/Blocks.java
+++ b/api/src/main/java/ai/djl/nn/Blocks.java
@@ -33,12 +33,7 @@ public final class Blocks {
      * @return a {@link NDList} that contains the inflated {@link ai.djl.ndarray.NDArray}
      */
     public static NDArray batchFlatten(NDArray array) {
-        long batch = array.size(0);
-        if (batch == 0) {
-            // calculate the size of second dimension manually as using -1 would not work here
-            return array.reshape(batch, array.getShape().slice(1).size());
-        }
-        return array.reshape(batch, -1);
+        return array.reshape(-1, array.getShape().slice(1).size());
     }
 
     /**

--- a/api/src/main/java/ai/djl/training/EasyTrain.java
+++ b/api/src/main/java/ai/djl/training/EasyTrain.java
@@ -127,6 +127,8 @@ public final class EasyTrain {
         time = System.nanoTime();
         batchData.getLabels().put(labels.get(0).getDevice(), labels);
         batchData.getPredictions().put(preds.get(0).getDevice(), preds);
+        batchData.getData().put(preds.get(0).getDevice(), data);
+        batchData.getLoss().put(preds.get(0).getDevice(), lossValue);
         trainer.addMetric("training-metrics", time);
         return true;
     }

--- a/api/src/main/java/ai/djl/training/listener/AlgebraicListener.java
+++ b/api/src/main/java/ai/djl/training/listener/AlgebraicListener.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.training.listener;
+
+import ai.djl.Device;
+import ai.djl.Model;
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDList;
+import ai.djl.nn.Parameter;
+import ai.djl.training.Trainer;
+import ai.djl.util.NativeResource;
+import ai.djl.util.Pair;
+import ai.djl.util.PairList;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** {@link TrainingListener} that records algebraic operations as Python code. */
+public class AlgebraicListener extends TrainingListenerAdapter {
+
+    private static AlgebraicListener currentListener;
+
+    private static final Logger logger = LoggerFactory.getLogger(AlgebraicListener.class);
+
+    private final Map<Object, Node> nodeMap = new ConcurrentHashMap<>();
+
+    @SuppressWarnings("PMD.UseConcurrentHashMap")
+    private final Map<String, Integer> losses = new LinkedHashMap<>();
+
+    @SuppressWarnings("PMD.UseConcurrentHashMap")
+    private final Map<String, Integer> predictions = new LinkedHashMap<>();
+
+    private Map<String, String> parameters;
+    private String outputFile;
+    private AtomicInteger parametersOpCount = new AtomicInteger(0);
+
+    private long batchSize = -2;
+    private int numEpoch;
+
+    /**
+     * New listener to record algebraic operations into the given file.
+     *
+     * @param outputFile file to store output - will be overridden if exist
+     */
+    public AlgebraicListener(String outputFile) {
+        this.outputFile = outputFile;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void onEpoch(Trainer trainer) {
+        numEpoch++;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void onTrainingBatch(Trainer trainer, BatchData batchData) {
+        writeParameters(trainer.getModel());
+        AtomicInteger opCount = new AtomicInteger(parametersOpCount.get());
+        for (Device device : batchData.getLabels().keySet()) {
+            NDList data = batchData.getData().get(device);
+            NDList preds = batchData.getPredictions().get(device);
+            NDList labels = batchData.getLabels().get(device);
+            NDArray loss = batchData.getLoss().get(device);
+            if (data != null) {
+                setLeaf(data, "x");
+            }
+            if (preds != null) {
+                writePredictions(preds, opCount);
+            }
+            if (preds != null) {
+                setLeaf(preds, "prediction");
+            }
+            if (labels != null) {
+                setLeaf(labels, "label");
+            }
+            if (loss != null) {
+                writeLoss(loss, opCount);
+            }
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void onTrainingBegin(Trainer trainer) {
+        currentListener = this;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void onTrainingEnd(Trainer trainer) {
+        try (OutputStream out = Files.newOutputStream(Paths.get(outputFile))) {
+            describe(out);
+        } catch (IOException e) {
+            logger.error("Failed logging algebraic operations", e);
+        }
+        parameters.clear();
+        predictions.clear();
+        losses.clear();
+        nodeMap.clear();
+        currentListener = null;
+    }
+
+    private void setLeaf(NDArray x, String name) {
+        Node node = get(x);
+        if (node == null) {
+            return;
+        }
+        node.name = name;
+        node.isLeaf = true;
+    }
+
+    private void setLeaf(NDList data, String name) {
+        for (NDArray x : data) {
+            setLeaf(x, name);
+        }
+    }
+
+    private void writePredictions(NDList preds, AtomicInteger opCount) {
+        for (NDArray pred : preds) {
+            String python = get(pred).toPythonFunctionBody(opCount);
+            predictions.compute(python, (key, count) -> count == null ? 1 : count + 1);
+            batchSize = pred.getShape().head();
+        }
+    }
+
+    private void writeLoss(NDArray lss, AtomicInteger opCount) {
+        String python = get(lss).toPythonFunctionBody(opCount);
+        losses.compute(python, (key, count) -> count == null ? 1 : count + 1);
+    }
+
+    private void describe(OutputStream out) throws IOException {
+        PrintStream writer = new PrintStream(out, true, StandardCharsets.US_ASCII.name());
+        writer.println("class MyModel(tf.keras.Model):");
+        writer.println("  def __init__(self, **kwargs):");
+        writer.println("    super().__init__(**kwargs)");
+        for (Entry<String, String> param : parameters.entrySet()) {
+            writer.println(
+                    Node.indent(param.getKey() + " = tf.Variable(" + param.getValue() + ")"));
+        }
+        writer.println("");
+        for (Entry<String, Integer> pred : predictions.entrySet()) {
+            writer.println("## " + pred.getValue());
+            writer.println("  def call(self, x):");
+            writer.println(pred.getKey());
+            writer.println("    return result");
+        }
+        writer.println("");
+        for (Entry<String, Integer> loss : losses.entrySet()) {
+            writer.println("## " + loss.getValue());
+            writer.println("def loss(label, prediction):");
+            writer.println(loss.getKey());
+            writer.println("    return result");
+        }
+        writer.println("");
+        writer.println(String.format("# number of epochs was %s", numEpoch));
+        writer.println(String.format("# number of batches was %s", batchSize));
+        writer.println("");
+    }
+
+    private void writeParameters(Model model) {
+        if (parameters == null) {
+            parameters = new LinkedHashMap<>();
+            for (Pair<String, Parameter> pair : model.getBlock().getParameters()) {
+                NDArray array = pair.getValue().getArray();
+                String initialization =
+                        get(pair.getValue().getArray())
+                                        .toPythonExpression(null, parametersOpCount, false)
+                                + (pair.getValue().requiresGradient() ? "" : ", trainable = False");
+                String pythonClassVariable = "self._" + pair.getKey();
+                parameters.put(pythonClassVariable, initialization);
+                setLeaf(array, pythonClassVariable);
+            }
+        }
+    }
+
+    /**
+     * Records an algebraic operation that is executed with the given parameters.
+     *
+     * @param name the name of the operation
+     * @param src the input to the operation
+     * @param dest the output of the operation
+     * @param param parameters for the operation
+     */
+    public static void record(
+            String name, NDArray[] src, NDArray[] dest, PairList<String, ?> param) {
+        if (currentListener != null) {
+            currentListener.recordInternal(name, src, dest, param);
+        }
+    }
+
+    private void recordInternal(
+            String name, NDArray[] src, NDArray[] dest, PairList<String, ?> param) {
+        Node n = new Node(name, param);
+        for (NDArray array : src) {
+            Node node = get(array);
+            if (node == null) {
+                node =
+                        new Node(
+                                array.getName() != null
+                                        ? array.getName()
+                                        : "UNKNOWN_ARRAY" + array.getShape(),
+                                null);
+                nodeMap.put(key(array), n);
+                node.outputShape = array.getShape();
+            }
+            n.src.add(node);
+        }
+        for (NDArray array : dest) {
+            nodeMap.put(key(array), n);
+            n.outputShape = array.getShape();
+        }
+    }
+
+    private Node get(NDArray array) {
+        return nodeMap.get(key(array));
+    }
+
+    private Object key(NDArray array) {
+        return ((NativeResource<?>) array).getHandle();
+    }
+}

--- a/api/src/main/java/ai/djl/training/listener/Node.java
+++ b/api/src/main/java/ai/djl/training/listener/Node.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.training.listener;
+
+import ai.djl.ndarray.types.Shape;
+import ai.djl.util.PairList;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/** One node of the computational graph. */
+class Node {
+
+    String name;
+    List<Node> src = new ArrayList<>();
+    PairList<String, ?> param;
+    boolean isLeaf;
+    Shape outputShape;
+
+    public Node(String name, PairList<String, ?> param) {
+        this.name = name;
+        this.param = param;
+    }
+
+    String toPythonExpression(Map<Node, String> locals, AtomicInteger opCount, boolean useLocals) {
+        if (isLeaf) {
+            return name;
+        }
+        if (useLocals && locals.containsKey(this)) {
+            return locals.get(this);
+        }
+        switch (name) {
+            case "pick":
+                {
+                    Object[][] args = {{0}, {1, "indices"}, {"axis", "batch_dims"}};
+                    return format("tf.gather", args, locals, opCount);
+                }
+            case "_npx_log_softmax":
+                {
+                    Object[][] args = {{0}, {"axis", "axis"}};
+                    return format("tf.nn.log_softmax", args, locals, opCount);
+                }
+            case "_npi_zeros":
+                {
+                    Object[][] args = {{"shape", "shape"}, {"dtype", "dtype", "tf.dtypes.%s"}};
+                    return format("tf.zeros", args, locals, opCount);
+                }
+            case "_npi_ones":
+                {
+                    Object[][] args = {{"shape", "shape"}, {"dtype", "dtype", "tf.dtypes.%s"}};
+                    return format("tf.ones", args, locals, opCount);
+                }
+            case "_npi_normal":
+                {
+                    Object[][] args = {
+                        {"size", "shape"},
+                        {"loc", "mean"},
+                        {"scale", "stddev"},
+                        {"dtype", "dtype", "tf.dtypes.%s"}
+                    };
+                    return format("tf.random.normal", args, locals, opCount);
+                }
+            case "_np_reshape":
+                {
+                    Object[][] args = {{0}, {"newshape", "shape"}};
+                    return format("tf.reshape", args, locals, opCount);
+                }
+            case "_np_transpose":
+                {
+                    Object[][] args = {{0}, {"axes", "perm"}};
+                    return format("tf.transpose", args, locals, opCount);
+                }
+            case "_npx_activation":
+                {
+                    Object[][] args = {{0}};
+                    return format("tf.nn." + this.param.get("act_type"), args, locals, opCount);
+                }
+            case "_npx_convolution":
+                {
+                    int[] perm = {2, 3, 1, 0};
+                    Object[][] filtersParams = {{1}, {null, "perm", Arrays.toString(perm)}};
+                    String filters = format("tf.transpose", filtersParams, locals, opCount);
+                    Shape filtersShape =
+                            new Shape(
+                                    IntStream.of(perm)
+                                            .mapToLong(src.get(1).outputShape::get)
+                                            .toArray());
+                    String padding = "(0, 0)".equals(this.param.get("pad")) ? "'VALID'" : "'SAME'";
+                    Object[][] args = {
+                        {0},
+                        {null, "filters", filters, filtersShape},
+                        {"stride", "strides"},
+                        {"pad", "padding", padding},
+                        {"dilate", "dilations"},
+                        {null, "data_format", "'NCHW'"}
+                    };
+                    return addBias(
+                            format("tf.nn.convolution", args, locals, opCount),
+                            true,
+                            locals,
+                            opCount);
+                }
+            case "_npx_pooling":
+                {
+                    if ("True".equals(this.param.get("global_pool"))) {
+                        String op =
+                                "avg".equals(this.param.get("pool_type"))
+                                        ? "reduce_mean"
+                                        : "reduce_max";
+                        Object[][] args = {{0}, {null, "axis", "[2, 3]"}};
+                        return format("tf." + op, args, locals, opCount);
+                    }
+                    String padding = "(0, 0)".equals(this.param.get("pad")) ? "'VALID'" : "'SAME'";
+                    String poolingType =
+                            "avg".equals(this.param.get("pool_type")) ? "'AVG'" : "'MAX'";
+                    Object[][] args = {
+                        {0},
+                        {"kernel", "window_shape"},
+                        {"pool_type", "pooling_type", poolingType},
+                        {"stride", "strides"},
+                        {"pad", "padding", padding},
+                        {"dilate", "dilations"},
+                        {null, "data_format", "'NCHW'"}
+                    };
+                    return format("tf.nn.pool", args, locals, opCount);
+                }
+            case "_npx_batch_norm":
+                {
+                    Object[][] args = {
+                        {0},
+                        {1, "scale"},
+                        {2, "offset"},
+                        {3, "mean"},
+                        {4, "variance"},
+                        {"eps", "epsilon"},
+                        {null, "is_training", "True"},
+                        {"momentum", "exponential_avg_factor"},
+                        {null, "data_format", "'NCHW'"}
+                    };
+                    return format("tf.compat.v1.nn.fused_batch_norm", args, locals, opCount);
+                }
+            case "_npx_fully_connected":
+                {
+                    Object[][] args = {{0}, {1, "b"}, {null, "transpose_b", "True"}};
+                    return addBias(
+                            format("tf.matmul", args, locals, opCount), false, locals, opCount);
+                }
+            case "_npi_matmul":
+                {
+                    Object[][] args = {{0}, {1}};
+                    return addBias(
+                            format("tf.matmul", args, locals, opCount), false, locals, opCount);
+                }
+            case "_npi_add":
+                {
+                    Object[][] args = {{0}, {1}};
+                    return format("tf.add", args, locals, opCount);
+                }
+            case "_npi_subtract":
+                {
+                    Object[][] args = {{0}, {1}};
+                    return format("tf.subtract", args, locals, opCount);
+                }
+            case "_npi_mean":
+                {
+                    Object[][] args = {{0}};
+                    return format("tf.reduce_mean", args, locals, opCount);
+                }
+            case "_npi_negative":
+                {
+                    Object[][] args = {{0}};
+                    return format("tf.negative", args, locals, opCount);
+                }
+            case "_npi_absolute":
+                {
+                    Object[][] args = {{0}};
+                    return format("tf.abs", args, locals, opCount);
+                }
+            default:
+                {
+                    return String.format(
+                            "%s(%s)",
+                            name,
+                            src.stream()
+                                    .map(node -> node.toPythonExpression(locals, opCount, true))
+                                    .collect(Collectors.joining(", ")));
+                }
+        }
+    }
+
+    /**
+     * Constructs a Python expression for the given operation and formatting arguments.
+     *
+     * @param op tensorflow operation name
+     * @param args array of array of:<br>
+     *     [0]: index for {@link #src} or {@link #param} to retrieve argument value, or <code>null
+     *     </code><br>
+     *     [1]: tensorflow parameter name<br>
+     *     [2]: format of argument<br>
+     *     [3]: output shape of argument<br>
+     * @param locals nodes stored in local Python variables
+     * @param opCount operation counter
+     * @return the Python expression
+     */
+    private String format(
+            String op, Object[][] args, Map<Node, String> locals, AtomicInteger opCount) {
+        StringBuilder sb = new StringBuilder(op + "(\n");
+        for (Object[] arg : args) {
+            String s = arg.length >= 3 ? String.valueOf(arg[2]) : "%s";
+            Shape shape = arg.length >= 4 ? (Shape) arg[3] : null;
+            if (arg[0] instanceof Integer && src.size() > (int) arg[0]) {
+                Node node = src.get((int) arg[0]);
+                s = String.format(s, node.toPythonExpression(locals, opCount, true));
+                shape = node.outputShape;
+            } else if (this.param != null && this.param.get(String.valueOf(arg[0])) != null) {
+                s = String.format(s, this.param.get(String.valueOf(arg[0])));
+            } else if (arg[0] != null) {
+                continue; // cannot resolve index, so skip
+            }
+            if (s.startsWith("(") && s.endsWith(")")) {
+                s = String.format("[%s]", s.substring(1, s.length() - 1));
+            }
+            if (arg.length >= 2 && arg[1] != null) {
+                s = String.format("%s=%s", arg[1], s);
+            }
+            sb.append(indent(s) + "," + (shape != null ? " # " + shape : "") + "\n");
+        }
+        sb.append(
+                indent(
+                        String.format(
+                                "name='%s_%s_',\n",
+                                op.substring(op.lastIndexOf('.') + 1), opCount.incrementAndGet())));
+        sb.append(')');
+        return sb.toString();
+    }
+
+    private String addBias(
+            String result,
+            boolean setChannelFirst,
+            Map<Node, String> locals,
+            AtomicInteger opCount) {
+        if (src.size() == 3) {
+            Object[][] args = {
+                {null, null, result, this.outputShape},
+                {2, "bias"},
+                {null, "data_format", setChannelFirst ? "'NCHW'" : "None"}
+            };
+            return format("tf.nn.bias_add", args, locals, opCount);
+        }
+        return result;
+    }
+
+    private void identifyMultipleUsages(Map<Node, Integer> usages) {
+        if (isLeaf) {
+            return;
+        }
+        if (usages.compute(this, (key, count) -> count == null ? 1 : count + 1) >= 2) {
+            return;
+        }
+        for (Node node : src) {
+            node.identifyMultipleUsages(usages);
+        }
+        // reposition behind src nodes
+        usages.put(this, usages.remove(this));
+    }
+
+    String toPythonFunctionBody(AtomicInteger opCount) {
+        @SuppressWarnings("PMD.UseConcurrentHashMap")
+        Map<Node, Integer> usages = new LinkedHashMap<>();
+        identifyMultipleUsages(usages);
+        Map<Node, String> locals = new ConcurrentHashMap<>();
+        List<String> statements = new ArrayList<>();
+        int val = 1;
+        int batchnorm = 1;
+        for (Map.Entry<Node, Integer> usage : usages.entrySet()) {
+            Node node = usage.getKey();
+            if (usage.getValue() >= 2) {
+                // save the result of an expression that is used multiple times in local variable
+                locals.put(node, "val".concat(Integer.toString(val++)));
+            } else if ("_npx_batch_norm".equals(node.name)) {
+                // local required to assign locals 'running_mean' and 'running_var' at the same time
+                locals.put(node, "batchnorm".concat(Integer.toString(batchnorm++)));
+            }
+        }
+        for (Map.Entry<Node, Integer> usage : usages.entrySet()) {
+            Node node = usage.getKey();
+            if (usage.getValue() >= 2) {
+                statements.add(
+                        String.format(
+                                "%s = %s",
+                                locals.get(node), node.toPythonExpression(locals, opCount, false)));
+            } else if ("_npx_batch_norm".equals(node.name)) {
+                statements.add(
+                        String.format(
+                                "(%s, running_mean, running_var) = %s",
+                                locals.get(node), node.toPythonExpression(locals, opCount, false)));
+                statements.add(
+                        String.format(
+                                "%s.assign(running_mean)",
+                                node.src.get(3).toPythonExpression(locals, opCount, false)));
+                statements.add(
+                        String.format(
+                                "%s.assign(running_var)",
+                                node.src.get(4).toPythonExpression(locals, opCount, false)));
+            }
+        }
+        statements.add("result = ".concat(toPythonExpression(locals, opCount, false)));
+        return statements.stream().map(Node::indent).collect(Collectors.joining("  \n"));
+    }
+
+    static String indent(String val) {
+        return val.replaceAll("(?m)^", "    ");
+    }
+}

--- a/api/src/main/java/ai/djl/training/listener/TrainingListener.java
+++ b/api/src/main/java/ai/djl/training/listener/TrainingListener.java
@@ -13,11 +13,13 @@
 package ai.djl.training.listener;
 
 import ai.djl.Device;
+import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDList;
 import ai.djl.training.Trainer;
 import ai.djl.training.dataset.Batch;
 
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * {@code TrainingListener} offers an interface that performs some actions when certain events have
@@ -163,6 +165,20 @@ public interface TrainingListener {
                 new TimeMeasureTrainingListener(outputDir)
             };
         }
+
+        /**
+         * Returns listener for logging algebraic operation.
+         *
+         * @param outputFile the output file to store the algebraic log. Can be null which skips
+         *     algebraic logging.
+         * @return the new set of listeners
+         */
+        static TrainingListener[] algebraicLogging(String outputFile) {
+            if (outputFile == null) {
+                return new TrainingListener[] {}; // algebraic logging disabled
+            }
+            return new TrainingListener[] {new AlgebraicListener(outputFile)};
+        }
     }
 
     /** A class to pass data from the batch into the training listeners. */
@@ -171,6 +187,8 @@ public interface TrainingListener {
         private Batch batch;
         private Map<Device, NDList> labels;
         private Map<Device, NDList> predictions;
+        private Map<Device, NDList> data;
+        private Map<Device, NDArray> loss;
 
         /**
          * Constructs a new {@link BatchData}.
@@ -183,6 +201,8 @@ public interface TrainingListener {
             this.batch = batch;
             this.labels = labels;
             this.predictions = predictions;
+            this.data = new ConcurrentHashMap<>();
+            this.loss = new ConcurrentHashMap<>();
         }
 
         /**
@@ -210,6 +230,24 @@ public interface TrainingListener {
          */
         public Map<Device, NDList> getPredictions() {
             return predictions;
+        }
+
+        /**
+         * Returns the data for each device.
+         *
+         * @return the data for each device
+         */
+        public Map<Device, NDList> getData() {
+            return data;
+        }
+
+        /**
+         * Returns the loss for each device.
+         *
+         * @return the loss for each device
+         */
+        public Map<Device, NDArray> getLoss() {
+            return loss;
         }
     }
 }

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayEx.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArrayEx.java
@@ -287,7 +287,7 @@ class MxNDArrayEx implements NDArrayEx {
         params.add("pool_type", "max");
         params.addParam("global_pool", true);
         try (NDArray temp = getManager().invoke("_npx_pooling", getArray(), params)) {
-            return temp.reshape(temp.getShape().size(0), temp.getShape().size(1));
+            return temp.reshape(-1, temp.getShape().size(1));
         }
     }
 
@@ -318,7 +318,7 @@ class MxNDArrayEx implements NDArrayEx {
         params.add("pool_type", "avg");
         params.addParam("global_pool", true);
         try (NDArray temp = getManager().invoke("_npx_pooling", getArray(), params)) {
-            return temp.reshape(temp.getShape().size(0), temp.getShape().size(1));
+            return temp.reshape(-1, temp.getShape().size(1));
         }
     }
 
@@ -355,7 +355,7 @@ class MxNDArrayEx implements NDArrayEx {
         params.addParam("p_value", (int) normType);
         params.addParam("global_pool", true);
         try (NDArray temp = getManager().invoke("_npx_pooling", getArray(), params)) {
-            return temp.reshape(temp.getShape().size(0), temp.getShape().size(1));
+            return temp.reshape(-1, temp.getShape().size(1));
         }
     }
 

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDManager.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDManager.java
@@ -23,6 +23,7 @@ import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.ndarray.types.SparseFormat;
+import ai.djl.training.listener.AlgebraicListener;
 import ai.djl.util.PairList;
 
 import com.sun.jna.Pointer;
@@ -338,12 +339,15 @@ public class MxNDManager extends BaseNDManager {
     public void invoke(
             String operation, NDArray[] src, NDArray[] dest, PairList<String, ?> params) {
         JnaUtils.op(operation).invoke(this, src, dest, params);
+        AlgebraicListener.record(operation, src, dest, params);
     }
 
     /** {@inheritDoc} */
     @Override
     public NDList invoke(String operation, NDList src, PairList<String, ?> params) {
-        return new NDList(JnaUtils.op(operation).invoke(this, src.toArray(EMPTY), params));
+        NDArray[] dest = JnaUtils.op(operation).invoke(this, src.toArray(EMPTY), params);
+        AlgebraicListener.record(operation, src.toArray(EMPTY), dest, params);
+        return new NDList(dest);
     }
 
     /**
@@ -379,7 +383,9 @@ public class MxNDManager extends BaseNDManager {
      * @throws EngineException if operation failed in native engine
      */
     public NDArray invoke(String operation, NDArray[] src, PairList<String, ?> params) {
-        return JnaUtils.op(operation).invoke(this, src, params)[0];
+        NDArray[] dest = JnaUtils.op(operation).invoke(this, src, params);
+        AlgebraicListener.record(operation, src, dest, params);
+        return dest[0];
     }
 
     /**

--- a/examples/src/main/java/ai/djl/examples/training/TrainMnist.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainMnist.java
@@ -107,6 +107,8 @@ public final class TrainMnist {
                 .addEvaluator(new Accuracy())
                 .optDevices(Engine.getInstance().getDevices(arguments.getMaxGpus()))
                 .addTrainingListeners(TrainingListener.Defaults.logging(outputDir))
+                .addTrainingListeners(
+                        TrainingListener.Defaults.algebraicLogging(arguments.getAlgebraicLogFile()))
                 .addTrainingListeners(listener);
     }
 

--- a/examples/src/main/java/ai/djl/examples/training/transferlearning/TrainResnetWithCifar10.java
+++ b/examples/src/main/java/ai/djl/examples/training/transferlearning/TrainResnetWithCifar10.java
@@ -215,6 +215,8 @@ public final class TrainResnetWithCifar10 {
         return new DefaultTrainingConfig(Loss.softmaxCrossEntropyLoss())
                 .addEvaluator(new Accuracy())
                 .optDevices(Engine.getInstance().getDevices(arguments.getMaxGpus()))
+                .addTrainingListeners(
+                        TrainingListener.Defaults.algebraicLogging(arguments.getAlgebraicLogFile()))
                 .addTrainingListeners(TrainingListener.Defaults.logging(arguments.getOutputDir()));
     }
 

--- a/examples/src/main/java/ai/djl/examples/training/util/Arguments.java
+++ b/examples/src/main/java/ai/djl/examples/training/util/Arguments.java
@@ -38,6 +38,7 @@ public class Arguments {
     protected long limit;
     protected String modelDir;
     protected Map<String, String> criteria;
+    protected String algebraicLogFile;
 
     protected void initialize() {
         epoch = 2;
@@ -45,6 +46,7 @@ public class Arguments {
         outputDir = "build/model";
         limit = Long.MAX_VALUE;
         modelDir = null;
+        algebraicLogFile = null;
     }
 
     protected void setCmd(CommandLine cmd) {
@@ -74,6 +76,9 @@ public class Arguments {
         if (cmd.hasOption("criteria")) {
             Type type = new TypeToken<Map<String, Object>>() {}.getType();
             criteria = JsonUtils.GSON.fromJson(cmd.getOptionValue("criteria"), type);
+        }
+        if (cmd.hasOption("algebraic-log")) {
+            algebraicLogFile = cmd.getOptionValue("algebraic-log");
         }
     }
 
@@ -162,6 +167,15 @@ public class Arguments {
                         .argName("CRITERIA")
                         .desc("The criteria used for the model.")
                         .build());
+        options.addOption(
+                Option.builder("a")
+                        .longOpt("algebraic-log")
+                        .hasArg()
+                        .argName("ALGEBRAIC-LOG")
+                        .desc(
+                                "File to log algebraic operations executed during training as"
+                                        + " Python program.")
+                        .build());
         return options;
     }
 
@@ -191,6 +205,10 @@ public class Arguments {
 
     public String getOutputDir() {
         return outputDir;
+    }
+
+    public String getAlgebraicLogFile() {
+        return algebraicLogFile;
     }
 
     public long getLimit() {

--- a/examples/src/test/java/ai/djl/examples/training/TrainWithAlgebraicLogging.java
+++ b/examples/src/test/java/ai/djl/examples/training/TrainWithAlgebraicLogging.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.examples.training;
+
+import ai.djl.ModelException;
+import ai.djl.engine.Engine;
+import ai.djl.examples.training.transferlearning.TrainResnetWithCifar10;
+import ai.djl.testing.TestRequirements;
+import ai.djl.training.TrainingResult;
+import ai.djl.translate.TranslateException;
+import ai.djl.util.Utils;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class TrainWithAlgebraicLogging {
+
+    private static final int SEED = 1234;
+
+    @Test
+    public void testTrainMnist() throws ModelException, TranslateException, IOException {
+        TestRequirements.engine("MXNet");
+
+        Path pathActual = Paths.get("build/tmp/algebraiclog/TrainMnist.py");
+        Files.createDirectories(pathActual.getParent());
+        pathActual.toFile().delete();
+
+        String[] args = new String[] {"-g", "1", "-m", "2", "-a", pathActual.toFile().toString()};
+
+        TrainMnist.runExample(args);
+        Path path = Paths.get("src/test/resources/algebraiclog/TrainMnist.py");
+
+        try (InputStream is = Files.newInputStream(path);
+                InputStream isActual = Files.newInputStream(pathActual)) {
+            List<String> expected = Utils.readLines(is);
+            List<String> actual = Utils.readLines(isActual);
+            Assert.assertEquals(expected, actual);
+        }
+    }
+
+    @Test
+    public void testTrainResNetImperative() throws ModelException, IOException, TranslateException {
+        TestRequirements.engine("MXNet");
+
+        Path pathActual = Paths.get("build/tmp/algebraiclog/TrainResnetWithCifar10.py");
+        Files.createDirectories(pathActual.getParent());
+        pathActual.toFile().delete();
+
+        // Limit max 4 gpu for cifar10 training to make it converge faster.
+        // and only train 10 batch for unit test.
+        String[] args = {
+            "-e", "1", "-g", "4", "-m", "1", "-b", "111", "-a", pathActual.toFile().toString()
+        };
+
+        Engine.getInstance().setRandomSeed(SEED);
+        TrainingResult result = TrainResnetWithCifar10.runExample(args);
+        Assert.assertNotNull(result);
+
+        Path path = Paths.get("src/test/resources/algebraiclog/TrainResnetWithCifar10.py");
+
+        try (InputStream is = Files.newInputStream(path);
+                InputStream isActual = Files.newInputStream(pathActual)) {
+            List<String> expected = Utils.readLines(is);
+            List<String> actual = Utils.readLines(isActual);
+            Assert.assertEquals(expected, actual);
+        }
+    }
+}

--- a/examples/src/test/resources/algebraiclog/TrainMnist.py
+++ b/examples/src/test/resources/algebraiclog/TrainMnist.py
@@ -1,0 +1,108 @@
+class MyModel(tf.keras.Model):
+  def __init__(self, **kwargs):
+    super().__init__(**kwargs)
+    self._02Linear_weight = tf.Variable(tf.random.normal(
+        shape=[128, 784],
+        mean=0.0,
+        stddev=0.050507627,
+        dtype=tf.dtypes.float32,
+        name='normal_1_',
+    ))
+    self._02Linear_bias = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_2_',
+    ))
+    self._04Linear_weight = tf.Variable(tf.random.normal(
+        shape=[64, 128],
+        mean=0.0,
+        stddev=0.125,
+        dtype=tf.dtypes.float32,
+        name='normal_3_',
+    ))
+    self._04Linear_bias = tf.Variable(tf.zeros(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='zeros_4_',
+    ))
+    self._06Linear_weight = tf.Variable(tf.random.normal(
+        shape=[10, 64],
+        mean=0.0,
+        stddev=0.17677669,
+        dtype=tf.dtypes.float32,
+        name='normal_5_',
+    ))
+    self._06Linear_bias = tf.Variable(tf.zeros(
+        shape=[10],
+        dtype=tf.dtypes.float32,
+        name='zeros_6_',
+    ))
+
+## 4
+  def call(self, x):
+    result = tf.nn.bias_add(
+        tf.matmul(
+            tf.nn.relu(
+                tf.nn.bias_add(
+                    tf.matmul(
+                        tf.nn.relu(
+                            tf.nn.bias_add(
+                                tf.matmul(
+                                    tf.reshape(
+                                        x, # (32, 1, 28, 28)
+                                        shape=[-1, 784],
+                                        name='reshape_7_',
+                                    ), # (32, 784)
+                                    b=self._02Linear_weight, # (128, 784)
+                                    transpose_b=True,
+                                    name='matmul_8_',
+                                ), # (32, 128)
+                                bias=self._02Linear_bias, # (128)
+                                data_format=None,
+                                name='bias_add_9_',
+                            ), # (32, 128)
+                            name='relu_10_',
+                        ), # (32, 128)
+                        b=self._04Linear_weight, # (64, 128)
+                        transpose_b=True,
+                        name='matmul_11_',
+                    ), # (32, 64)
+                    bias=self._04Linear_bias, # (64)
+                    data_format=None,
+                    name='bias_add_12_',
+                ), # (32, 64)
+                name='relu_13_',
+            ), # (32, 64)
+            b=self._06Linear_weight, # (10, 64)
+            transpose_b=True,
+            name='matmul_14_',
+        ), # (32, 10)
+        bias=self._06Linear_bias, # (10)
+        data_format=None,
+        name='bias_add_15_',
+    )
+    return result
+
+## 4
+def loss(label, prediction):
+    result = tf.reduce_mean(
+        tf.negative(
+            tf.gather(
+                tf.nn.log_softmax(
+                    prediction, # (32, 10)
+                    axis=-1,
+                    name='log_softmax_16_',
+                ), # (32, 10)
+                indices=label, # (32)
+                batch_dims=1,
+                name='gather_17_',
+            ), # (32, 1)
+            name='negative_18_',
+        ), # (32, 1)
+        name='reduce_mean_19_',
+    )
+    return result
+
+# number of epochs was 2
+# number of batches was 32
+

--- a/examples/src/test/resources/algebraiclog/TrainResnetWithCifar10.py
+++ b/examples/src/test/resources/algebraiclog/TrainResnetWithCifar10.py
@@ -1,0 +1,3389 @@
+class MyModel(tf.keras.Model):
+  def __init__(self, **kwargs):
+    super().__init__(**kwargs)
+    self._01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[64, 3, 3, 3],
+        mean=0.0,
+        stddev=0.27216554,
+        dtype=tf.dtypes.float32,
+        name='normal_1_',
+    ))
+    self._02ParallelBlock_01SequentialBlock_01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[64, 64, 1, 1],
+        mean=0.0,
+        stddev=0.17677669,
+        dtype=tf.dtypes.float32,
+        name='normal_2_',
+    ))
+    self._02ParallelBlock_01SequentialBlock_01Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='zeros_3_',
+    ))
+    self._02ParallelBlock_01SequentialBlock_02BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='ones_4_',
+    ))
+    self._02ParallelBlock_01SequentialBlock_02BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='zeros_5_',
+    ))
+    self._02ParallelBlock_01SequentialBlock_02BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='zeros_6_',
+    ), trainable = False)
+    self._02ParallelBlock_01SequentialBlock_02BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='ones_7_',
+    ), trainable = False)
+    self._02ParallelBlock_01SequentialBlock_04Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[64, 64, 3, 3],
+        mean=0.0,
+        stddev=0.058925565,
+        dtype=tf.dtypes.float32,
+        name='normal_8_',
+    ))
+    self._02ParallelBlock_01SequentialBlock_05BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='ones_9_',
+    ))
+    self._02ParallelBlock_01SequentialBlock_05BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='zeros_10_',
+    ))
+    self._02ParallelBlock_01SequentialBlock_05BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='zeros_11_',
+    ), trainable = False)
+    self._02ParallelBlock_01SequentialBlock_05BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='ones_12_',
+    ), trainable = False)
+    self._02ParallelBlock_01SequentialBlock_07Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[256, 64, 1, 1],
+        mean=0.0,
+        stddev=0.17677669,
+        dtype=tf.dtypes.float32,
+        name='normal_13_',
+    ))
+    self._02ParallelBlock_01SequentialBlock_07Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_14_',
+    ))
+    self._02ParallelBlock_01SequentialBlock_08BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_15_',
+    ))
+    self._02ParallelBlock_01SequentialBlock_08BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_16_',
+    ))
+    self._02ParallelBlock_01SequentialBlock_08BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_17_',
+    ), trainable = False)
+    self._02ParallelBlock_01SequentialBlock_08BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_18_',
+    ), trainable = False)
+    self._02ParallelBlock_02SequentialBlock_01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[256, 64, 1, 1],
+        mean=0.0,
+        stddev=0.17677669,
+        dtype=tf.dtypes.float32,
+        name='normal_19_',
+    ))
+    self._02ParallelBlock_02SequentialBlock_02BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_20_',
+    ))
+    self._02ParallelBlock_02SequentialBlock_02BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_21_',
+    ))
+    self._02ParallelBlock_02SequentialBlock_02BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_22_',
+    ), trainable = False)
+    self._02ParallelBlock_02SequentialBlock_02BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_23_',
+    ), trainable = False)
+    self._03ParallelBlock_01SequentialBlock_01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[64, 256, 1, 1],
+        mean=0.0,
+        stddev=0.088388346,
+        dtype=tf.dtypes.float32,
+        name='normal_24_',
+    ))
+    self._03ParallelBlock_01SequentialBlock_01Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='zeros_25_',
+    ))
+    self._03ParallelBlock_01SequentialBlock_02BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='ones_26_',
+    ))
+    self._03ParallelBlock_01SequentialBlock_02BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='zeros_27_',
+    ))
+    self._03ParallelBlock_01SequentialBlock_02BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='zeros_28_',
+    ), trainable = False)
+    self._03ParallelBlock_01SequentialBlock_02BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='ones_29_',
+    ), trainable = False)
+    self._03ParallelBlock_01SequentialBlock_04Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[64, 64, 3, 3],
+        mean=0.0,
+        stddev=0.058925565,
+        dtype=tf.dtypes.float32,
+        name='normal_30_',
+    ))
+    self._03ParallelBlock_01SequentialBlock_05BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='ones_31_',
+    ))
+    self._03ParallelBlock_01SequentialBlock_05BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='zeros_32_',
+    ))
+    self._03ParallelBlock_01SequentialBlock_05BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='zeros_33_',
+    ), trainable = False)
+    self._03ParallelBlock_01SequentialBlock_05BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='ones_34_',
+    ), trainable = False)
+    self._03ParallelBlock_01SequentialBlock_07Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[256, 64, 1, 1],
+        mean=0.0,
+        stddev=0.17677669,
+        dtype=tf.dtypes.float32,
+        name='normal_35_',
+    ))
+    self._03ParallelBlock_01SequentialBlock_07Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_36_',
+    ))
+    self._03ParallelBlock_01SequentialBlock_08BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_37_',
+    ))
+    self._03ParallelBlock_01SequentialBlock_08BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_38_',
+    ))
+    self._03ParallelBlock_01SequentialBlock_08BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_39_',
+    ), trainable = False)
+    self._03ParallelBlock_01SequentialBlock_08BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_40_',
+    ), trainable = False)
+    self._04ParallelBlock_01SequentialBlock_01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[64, 256, 1, 1],
+        mean=0.0,
+        stddev=0.088388346,
+        dtype=tf.dtypes.float32,
+        name='normal_41_',
+    ))
+    self._04ParallelBlock_01SequentialBlock_01Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='zeros_42_',
+    ))
+    self._04ParallelBlock_01SequentialBlock_02BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='ones_43_',
+    ))
+    self._04ParallelBlock_01SequentialBlock_02BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='zeros_44_',
+    ))
+    self._04ParallelBlock_01SequentialBlock_02BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='zeros_45_',
+    ), trainable = False)
+    self._04ParallelBlock_01SequentialBlock_02BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='ones_46_',
+    ), trainable = False)
+    self._04ParallelBlock_01SequentialBlock_04Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[64, 64, 3, 3],
+        mean=0.0,
+        stddev=0.058925565,
+        dtype=tf.dtypes.float32,
+        name='normal_47_',
+    ))
+    self._04ParallelBlock_01SequentialBlock_05BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='ones_48_',
+    ))
+    self._04ParallelBlock_01SequentialBlock_05BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='zeros_49_',
+    ))
+    self._04ParallelBlock_01SequentialBlock_05BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='zeros_50_',
+    ), trainable = False)
+    self._04ParallelBlock_01SequentialBlock_05BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[64],
+        dtype=tf.dtypes.float32,
+        name='ones_51_',
+    ), trainable = False)
+    self._04ParallelBlock_01SequentialBlock_07Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[256, 64, 1, 1],
+        mean=0.0,
+        stddev=0.17677669,
+        dtype=tf.dtypes.float32,
+        name='normal_52_',
+    ))
+    self._04ParallelBlock_01SequentialBlock_07Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_53_',
+    ))
+    self._04ParallelBlock_01SequentialBlock_08BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_54_',
+    ))
+    self._04ParallelBlock_01SequentialBlock_08BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_55_',
+    ))
+    self._04ParallelBlock_01SequentialBlock_08BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_56_',
+    ), trainable = False)
+    self._04ParallelBlock_01SequentialBlock_08BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_57_',
+    ), trainable = False)
+    self._05ParallelBlock_01SequentialBlock_01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[128, 256, 1, 1],
+        mean=0.0,
+        stddev=0.088388346,
+        dtype=tf.dtypes.float32,
+        name='normal_58_',
+    ))
+    self._05ParallelBlock_01SequentialBlock_01Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_59_',
+    ))
+    self._05ParallelBlock_01SequentialBlock_02BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='ones_60_',
+    ))
+    self._05ParallelBlock_01SequentialBlock_02BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_61_',
+    ))
+    self._05ParallelBlock_01SequentialBlock_02BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_62_',
+    ), trainable = False)
+    self._05ParallelBlock_01SequentialBlock_02BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='ones_63_',
+    ), trainable = False)
+    self._05ParallelBlock_01SequentialBlock_04Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[128, 128, 3, 3],
+        mean=0.0,
+        stddev=0.041666668,
+        dtype=tf.dtypes.float32,
+        name='normal_64_',
+    ))
+    self._05ParallelBlock_01SequentialBlock_05BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='ones_65_',
+    ))
+    self._05ParallelBlock_01SequentialBlock_05BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_66_',
+    ))
+    self._05ParallelBlock_01SequentialBlock_05BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_67_',
+    ), trainable = False)
+    self._05ParallelBlock_01SequentialBlock_05BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='ones_68_',
+    ), trainable = False)
+    self._05ParallelBlock_01SequentialBlock_07Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[512, 128, 1, 1],
+        mean=0.0,
+        stddev=0.125,
+        dtype=tf.dtypes.float32,
+        name='normal_69_',
+    ))
+    self._05ParallelBlock_01SequentialBlock_07Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_70_',
+    ))
+    self._05ParallelBlock_01SequentialBlock_08BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_71_',
+    ))
+    self._05ParallelBlock_01SequentialBlock_08BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_72_',
+    ))
+    self._05ParallelBlock_01SequentialBlock_08BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_73_',
+    ), trainable = False)
+    self._05ParallelBlock_01SequentialBlock_08BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_74_',
+    ), trainable = False)
+    self._05ParallelBlock_02SequentialBlock_01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[512, 256, 1, 1],
+        mean=0.0,
+        stddev=0.088388346,
+        dtype=tf.dtypes.float32,
+        name='normal_75_',
+    ))
+    self._05ParallelBlock_02SequentialBlock_02BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_76_',
+    ))
+    self._05ParallelBlock_02SequentialBlock_02BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_77_',
+    ))
+    self._05ParallelBlock_02SequentialBlock_02BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_78_',
+    ), trainable = False)
+    self._05ParallelBlock_02SequentialBlock_02BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_79_',
+    ), trainable = False)
+    self._06ParallelBlock_01SequentialBlock_01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[128, 512, 1, 1],
+        mean=0.0,
+        stddev=0.0625,
+        dtype=tf.dtypes.float32,
+        name='normal_80_',
+    ))
+    self._06ParallelBlock_01SequentialBlock_01Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_81_',
+    ))
+    self._06ParallelBlock_01SequentialBlock_02BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='ones_82_',
+    ))
+    self._06ParallelBlock_01SequentialBlock_02BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_83_',
+    ))
+    self._06ParallelBlock_01SequentialBlock_02BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_84_',
+    ), trainable = False)
+    self._06ParallelBlock_01SequentialBlock_02BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='ones_85_',
+    ), trainable = False)
+    self._06ParallelBlock_01SequentialBlock_04Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[128, 128, 3, 3],
+        mean=0.0,
+        stddev=0.041666668,
+        dtype=tf.dtypes.float32,
+        name='normal_86_',
+    ))
+    self._06ParallelBlock_01SequentialBlock_05BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='ones_87_',
+    ))
+    self._06ParallelBlock_01SequentialBlock_05BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_88_',
+    ))
+    self._06ParallelBlock_01SequentialBlock_05BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_89_',
+    ), trainable = False)
+    self._06ParallelBlock_01SequentialBlock_05BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='ones_90_',
+    ), trainable = False)
+    self._06ParallelBlock_01SequentialBlock_07Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[512, 128, 1, 1],
+        mean=0.0,
+        stddev=0.125,
+        dtype=tf.dtypes.float32,
+        name='normal_91_',
+    ))
+    self._06ParallelBlock_01SequentialBlock_07Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_92_',
+    ))
+    self._06ParallelBlock_01SequentialBlock_08BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_93_',
+    ))
+    self._06ParallelBlock_01SequentialBlock_08BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_94_',
+    ))
+    self._06ParallelBlock_01SequentialBlock_08BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_95_',
+    ), trainable = False)
+    self._06ParallelBlock_01SequentialBlock_08BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_96_',
+    ), trainable = False)
+    self._07ParallelBlock_01SequentialBlock_01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[128, 512, 1, 1],
+        mean=0.0,
+        stddev=0.0625,
+        dtype=tf.dtypes.float32,
+        name='normal_97_',
+    ))
+    self._07ParallelBlock_01SequentialBlock_01Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_98_',
+    ))
+    self._07ParallelBlock_01SequentialBlock_02BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='ones_99_',
+    ))
+    self._07ParallelBlock_01SequentialBlock_02BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_100_',
+    ))
+    self._07ParallelBlock_01SequentialBlock_02BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_101_',
+    ), trainable = False)
+    self._07ParallelBlock_01SequentialBlock_02BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='ones_102_',
+    ), trainable = False)
+    self._07ParallelBlock_01SequentialBlock_04Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[128, 128, 3, 3],
+        mean=0.0,
+        stddev=0.041666668,
+        dtype=tf.dtypes.float32,
+        name='normal_103_',
+    ))
+    self._07ParallelBlock_01SequentialBlock_05BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='ones_104_',
+    ))
+    self._07ParallelBlock_01SequentialBlock_05BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_105_',
+    ))
+    self._07ParallelBlock_01SequentialBlock_05BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_106_',
+    ), trainable = False)
+    self._07ParallelBlock_01SequentialBlock_05BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='ones_107_',
+    ), trainable = False)
+    self._07ParallelBlock_01SequentialBlock_07Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[512, 128, 1, 1],
+        mean=0.0,
+        stddev=0.125,
+        dtype=tf.dtypes.float32,
+        name='normal_108_',
+    ))
+    self._07ParallelBlock_01SequentialBlock_07Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_109_',
+    ))
+    self._07ParallelBlock_01SequentialBlock_08BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_110_',
+    ))
+    self._07ParallelBlock_01SequentialBlock_08BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_111_',
+    ))
+    self._07ParallelBlock_01SequentialBlock_08BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_112_',
+    ), trainable = False)
+    self._07ParallelBlock_01SequentialBlock_08BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_113_',
+    ), trainable = False)
+    self._08ParallelBlock_01SequentialBlock_01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[128, 512, 1, 1],
+        mean=0.0,
+        stddev=0.0625,
+        dtype=tf.dtypes.float32,
+        name='normal_114_',
+    ))
+    self._08ParallelBlock_01SequentialBlock_01Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_115_',
+    ))
+    self._08ParallelBlock_01SequentialBlock_02BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='ones_116_',
+    ))
+    self._08ParallelBlock_01SequentialBlock_02BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_117_',
+    ))
+    self._08ParallelBlock_01SequentialBlock_02BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_118_',
+    ), trainable = False)
+    self._08ParallelBlock_01SequentialBlock_02BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='ones_119_',
+    ), trainable = False)
+    self._08ParallelBlock_01SequentialBlock_04Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[128, 128, 3, 3],
+        mean=0.0,
+        stddev=0.041666668,
+        dtype=tf.dtypes.float32,
+        name='normal_120_',
+    ))
+    self._08ParallelBlock_01SequentialBlock_05BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='ones_121_',
+    ))
+    self._08ParallelBlock_01SequentialBlock_05BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_122_',
+    ))
+    self._08ParallelBlock_01SequentialBlock_05BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='zeros_123_',
+    ), trainable = False)
+    self._08ParallelBlock_01SequentialBlock_05BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[128],
+        dtype=tf.dtypes.float32,
+        name='ones_124_',
+    ), trainable = False)
+    self._08ParallelBlock_01SequentialBlock_07Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[512, 128, 1, 1],
+        mean=0.0,
+        stddev=0.125,
+        dtype=tf.dtypes.float32,
+        name='normal_125_',
+    ))
+    self._08ParallelBlock_01SequentialBlock_07Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_126_',
+    ))
+    self._08ParallelBlock_01SequentialBlock_08BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_127_',
+    ))
+    self._08ParallelBlock_01SequentialBlock_08BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_128_',
+    ))
+    self._08ParallelBlock_01SequentialBlock_08BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_129_',
+    ), trainable = False)
+    self._08ParallelBlock_01SequentialBlock_08BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_130_',
+    ), trainable = False)
+    self._09ParallelBlock_01SequentialBlock_01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[256, 512, 1, 1],
+        mean=0.0,
+        stddev=0.0625,
+        dtype=tf.dtypes.float32,
+        name='normal_131_',
+    ))
+    self._09ParallelBlock_01SequentialBlock_01Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_132_',
+    ))
+    self._09ParallelBlock_01SequentialBlock_02BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_133_',
+    ))
+    self._09ParallelBlock_01SequentialBlock_02BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_134_',
+    ))
+    self._09ParallelBlock_01SequentialBlock_02BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_135_',
+    ), trainable = False)
+    self._09ParallelBlock_01SequentialBlock_02BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_136_',
+    ), trainable = False)
+    self._09ParallelBlock_01SequentialBlock_04Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[256, 256, 3, 3],
+        mean=0.0,
+        stddev=0.029462783,
+        dtype=tf.dtypes.float32,
+        name='normal_137_',
+    ))
+    self._09ParallelBlock_01SequentialBlock_05BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_138_',
+    ))
+    self._09ParallelBlock_01SequentialBlock_05BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_139_',
+    ))
+    self._09ParallelBlock_01SequentialBlock_05BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_140_',
+    ), trainable = False)
+    self._09ParallelBlock_01SequentialBlock_05BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_141_',
+    ), trainable = False)
+    self._09ParallelBlock_01SequentialBlock_07Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[1024, 256, 1, 1],
+        mean=0.0,
+        stddev=0.088388346,
+        dtype=tf.dtypes.float32,
+        name='normal_142_',
+    ))
+    self._09ParallelBlock_01SequentialBlock_07Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='zeros_143_',
+    ))
+    self._09ParallelBlock_01SequentialBlock_08BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='ones_144_',
+    ))
+    self._09ParallelBlock_01SequentialBlock_08BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='zeros_145_',
+    ))
+    self._09ParallelBlock_01SequentialBlock_08BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='zeros_146_',
+    ), trainable = False)
+    self._09ParallelBlock_01SequentialBlock_08BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='ones_147_',
+    ), trainable = False)
+    self._09ParallelBlock_02SequentialBlock_01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[1024, 512, 1, 1],
+        mean=0.0,
+        stddev=0.0625,
+        dtype=tf.dtypes.float32,
+        name='normal_148_',
+    ))
+    self._09ParallelBlock_02SequentialBlock_02BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='ones_149_',
+    ))
+    self._09ParallelBlock_02SequentialBlock_02BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='zeros_150_',
+    ))
+    self._09ParallelBlock_02SequentialBlock_02BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='zeros_151_',
+    ), trainable = False)
+    self._09ParallelBlock_02SequentialBlock_02BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='ones_152_',
+    ), trainable = False)
+    self._10ParallelBlock_01SequentialBlock_01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[256, 1024, 1, 1],
+        mean=0.0,
+        stddev=0.044194173,
+        dtype=tf.dtypes.float32,
+        name='normal_153_',
+    ))
+    self._10ParallelBlock_01SequentialBlock_01Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_154_',
+    ))
+    self._10ParallelBlock_01SequentialBlock_02BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_155_',
+    ))
+    self._10ParallelBlock_01SequentialBlock_02BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_156_',
+    ))
+    self._10ParallelBlock_01SequentialBlock_02BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_157_',
+    ), trainable = False)
+    self._10ParallelBlock_01SequentialBlock_02BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_158_',
+    ), trainable = False)
+    self._10ParallelBlock_01SequentialBlock_04Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[256, 256, 3, 3],
+        mean=0.0,
+        stddev=0.029462783,
+        dtype=tf.dtypes.float32,
+        name='normal_159_',
+    ))
+    self._10ParallelBlock_01SequentialBlock_05BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_160_',
+    ))
+    self._10ParallelBlock_01SequentialBlock_05BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_161_',
+    ))
+    self._10ParallelBlock_01SequentialBlock_05BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_162_',
+    ), trainable = False)
+    self._10ParallelBlock_01SequentialBlock_05BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_163_',
+    ), trainable = False)
+    self._10ParallelBlock_01SequentialBlock_07Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[1024, 256, 1, 1],
+        mean=0.0,
+        stddev=0.088388346,
+        dtype=tf.dtypes.float32,
+        name='normal_164_',
+    ))
+    self._10ParallelBlock_01SequentialBlock_07Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='zeros_165_',
+    ))
+    self._10ParallelBlock_01SequentialBlock_08BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='ones_166_',
+    ))
+    self._10ParallelBlock_01SequentialBlock_08BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='zeros_167_',
+    ))
+    self._10ParallelBlock_01SequentialBlock_08BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='zeros_168_',
+    ), trainable = False)
+    self._10ParallelBlock_01SequentialBlock_08BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='ones_169_',
+    ), trainable = False)
+    self._11ParallelBlock_01SequentialBlock_01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[256, 1024, 1, 1],
+        mean=0.0,
+        stddev=0.044194173,
+        dtype=tf.dtypes.float32,
+        name='normal_170_',
+    ))
+    self._11ParallelBlock_01SequentialBlock_01Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_171_',
+    ))
+    self._11ParallelBlock_01SequentialBlock_02BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_172_',
+    ))
+    self._11ParallelBlock_01SequentialBlock_02BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_173_',
+    ))
+    self._11ParallelBlock_01SequentialBlock_02BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_174_',
+    ), trainable = False)
+    self._11ParallelBlock_01SequentialBlock_02BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_175_',
+    ), trainable = False)
+    self._11ParallelBlock_01SequentialBlock_04Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[256, 256, 3, 3],
+        mean=0.0,
+        stddev=0.029462783,
+        dtype=tf.dtypes.float32,
+        name='normal_176_',
+    ))
+    self._11ParallelBlock_01SequentialBlock_05BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_177_',
+    ))
+    self._11ParallelBlock_01SequentialBlock_05BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_178_',
+    ))
+    self._11ParallelBlock_01SequentialBlock_05BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_179_',
+    ), trainable = False)
+    self._11ParallelBlock_01SequentialBlock_05BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_180_',
+    ), trainable = False)
+    self._11ParallelBlock_01SequentialBlock_07Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[1024, 256, 1, 1],
+        mean=0.0,
+        stddev=0.088388346,
+        dtype=tf.dtypes.float32,
+        name='normal_181_',
+    ))
+    self._11ParallelBlock_01SequentialBlock_07Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='zeros_182_',
+    ))
+    self._11ParallelBlock_01SequentialBlock_08BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='ones_183_',
+    ))
+    self._11ParallelBlock_01SequentialBlock_08BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='zeros_184_',
+    ))
+    self._11ParallelBlock_01SequentialBlock_08BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='zeros_185_',
+    ), trainable = False)
+    self._11ParallelBlock_01SequentialBlock_08BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='ones_186_',
+    ), trainable = False)
+    self._12ParallelBlock_01SequentialBlock_01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[256, 1024, 1, 1],
+        mean=0.0,
+        stddev=0.044194173,
+        dtype=tf.dtypes.float32,
+        name='normal_187_',
+    ))
+    self._12ParallelBlock_01SequentialBlock_01Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_188_',
+    ))
+    self._12ParallelBlock_01SequentialBlock_02BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_189_',
+    ))
+    self._12ParallelBlock_01SequentialBlock_02BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_190_',
+    ))
+    self._12ParallelBlock_01SequentialBlock_02BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_191_',
+    ), trainable = False)
+    self._12ParallelBlock_01SequentialBlock_02BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_192_',
+    ), trainable = False)
+    self._12ParallelBlock_01SequentialBlock_04Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[256, 256, 3, 3],
+        mean=0.0,
+        stddev=0.029462783,
+        dtype=tf.dtypes.float32,
+        name='normal_193_',
+    ))
+    self._12ParallelBlock_01SequentialBlock_05BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_194_',
+    ))
+    self._12ParallelBlock_01SequentialBlock_05BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_195_',
+    ))
+    self._12ParallelBlock_01SequentialBlock_05BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_196_',
+    ), trainable = False)
+    self._12ParallelBlock_01SequentialBlock_05BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_197_',
+    ), trainable = False)
+    self._12ParallelBlock_01SequentialBlock_07Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[1024, 256, 1, 1],
+        mean=0.0,
+        stddev=0.088388346,
+        dtype=tf.dtypes.float32,
+        name='normal_198_',
+    ))
+    self._12ParallelBlock_01SequentialBlock_07Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='zeros_199_',
+    ))
+    self._12ParallelBlock_01SequentialBlock_08BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='ones_200_',
+    ))
+    self._12ParallelBlock_01SequentialBlock_08BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='zeros_201_',
+    ))
+    self._12ParallelBlock_01SequentialBlock_08BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='zeros_202_',
+    ), trainable = False)
+    self._12ParallelBlock_01SequentialBlock_08BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='ones_203_',
+    ), trainable = False)
+    self._13ParallelBlock_01SequentialBlock_01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[256, 1024, 1, 1],
+        mean=0.0,
+        stddev=0.044194173,
+        dtype=tf.dtypes.float32,
+        name='normal_204_',
+    ))
+    self._13ParallelBlock_01SequentialBlock_01Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_205_',
+    ))
+    self._13ParallelBlock_01SequentialBlock_02BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_206_',
+    ))
+    self._13ParallelBlock_01SequentialBlock_02BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_207_',
+    ))
+    self._13ParallelBlock_01SequentialBlock_02BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_208_',
+    ), trainable = False)
+    self._13ParallelBlock_01SequentialBlock_02BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_209_',
+    ), trainable = False)
+    self._13ParallelBlock_01SequentialBlock_04Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[256, 256, 3, 3],
+        mean=0.0,
+        stddev=0.029462783,
+        dtype=tf.dtypes.float32,
+        name='normal_210_',
+    ))
+    self._13ParallelBlock_01SequentialBlock_05BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_211_',
+    ))
+    self._13ParallelBlock_01SequentialBlock_05BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_212_',
+    ))
+    self._13ParallelBlock_01SequentialBlock_05BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_213_',
+    ), trainable = False)
+    self._13ParallelBlock_01SequentialBlock_05BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_214_',
+    ), trainable = False)
+    self._13ParallelBlock_01SequentialBlock_07Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[1024, 256, 1, 1],
+        mean=0.0,
+        stddev=0.088388346,
+        dtype=tf.dtypes.float32,
+        name='normal_215_',
+    ))
+    self._13ParallelBlock_01SequentialBlock_07Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='zeros_216_',
+    ))
+    self._13ParallelBlock_01SequentialBlock_08BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='ones_217_',
+    ))
+    self._13ParallelBlock_01SequentialBlock_08BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='zeros_218_',
+    ))
+    self._13ParallelBlock_01SequentialBlock_08BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='zeros_219_',
+    ), trainable = False)
+    self._13ParallelBlock_01SequentialBlock_08BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='ones_220_',
+    ), trainable = False)
+    self._14ParallelBlock_01SequentialBlock_01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[256, 1024, 1, 1],
+        mean=0.0,
+        stddev=0.044194173,
+        dtype=tf.dtypes.float32,
+        name='normal_221_',
+    ))
+    self._14ParallelBlock_01SequentialBlock_01Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_222_',
+    ))
+    self._14ParallelBlock_01SequentialBlock_02BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_223_',
+    ))
+    self._14ParallelBlock_01SequentialBlock_02BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_224_',
+    ))
+    self._14ParallelBlock_01SequentialBlock_02BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_225_',
+    ), trainable = False)
+    self._14ParallelBlock_01SequentialBlock_02BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_226_',
+    ), trainable = False)
+    self._14ParallelBlock_01SequentialBlock_04Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[256, 256, 3, 3],
+        mean=0.0,
+        stddev=0.029462783,
+        dtype=tf.dtypes.float32,
+        name='normal_227_',
+    ))
+    self._14ParallelBlock_01SequentialBlock_05BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_228_',
+    ))
+    self._14ParallelBlock_01SequentialBlock_05BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_229_',
+    ))
+    self._14ParallelBlock_01SequentialBlock_05BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='zeros_230_',
+    ), trainable = False)
+    self._14ParallelBlock_01SequentialBlock_05BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[256],
+        dtype=tf.dtypes.float32,
+        name='ones_231_',
+    ), trainable = False)
+    self._14ParallelBlock_01SequentialBlock_07Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[1024, 256, 1, 1],
+        mean=0.0,
+        stddev=0.088388346,
+        dtype=tf.dtypes.float32,
+        name='normal_232_',
+    ))
+    self._14ParallelBlock_01SequentialBlock_07Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='zeros_233_',
+    ))
+    self._14ParallelBlock_01SequentialBlock_08BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='ones_234_',
+    ))
+    self._14ParallelBlock_01SequentialBlock_08BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='zeros_235_',
+    ))
+    self._14ParallelBlock_01SequentialBlock_08BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='zeros_236_',
+    ), trainable = False)
+    self._14ParallelBlock_01SequentialBlock_08BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[1024],
+        dtype=tf.dtypes.float32,
+        name='ones_237_',
+    ), trainable = False)
+    self._15ParallelBlock_01SequentialBlock_01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[512, 1024, 1, 1],
+        mean=0.0,
+        stddev=0.044194173,
+        dtype=tf.dtypes.float32,
+        name='normal_238_',
+    ))
+    self._15ParallelBlock_01SequentialBlock_01Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_239_',
+    ))
+    self._15ParallelBlock_01SequentialBlock_02BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_240_',
+    ))
+    self._15ParallelBlock_01SequentialBlock_02BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_241_',
+    ))
+    self._15ParallelBlock_01SequentialBlock_02BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_242_',
+    ), trainable = False)
+    self._15ParallelBlock_01SequentialBlock_02BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_243_',
+    ), trainable = False)
+    self._15ParallelBlock_01SequentialBlock_04Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[512, 512, 3, 3],
+        mean=0.0,
+        stddev=0.020833334,
+        dtype=tf.dtypes.float32,
+        name='normal_244_',
+    ))
+    self._15ParallelBlock_01SequentialBlock_05BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_245_',
+    ))
+    self._15ParallelBlock_01SequentialBlock_05BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_246_',
+    ))
+    self._15ParallelBlock_01SequentialBlock_05BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_247_',
+    ), trainable = False)
+    self._15ParallelBlock_01SequentialBlock_05BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_248_',
+    ), trainable = False)
+    self._15ParallelBlock_01SequentialBlock_07Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[2048, 512, 1, 1],
+        mean=0.0,
+        stddev=0.0625,
+        dtype=tf.dtypes.float32,
+        name='normal_249_',
+    ))
+    self._15ParallelBlock_01SequentialBlock_07Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[2048],
+        dtype=tf.dtypes.float32,
+        name='zeros_250_',
+    ))
+    self._15ParallelBlock_01SequentialBlock_08BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[2048],
+        dtype=tf.dtypes.float32,
+        name='ones_251_',
+    ))
+    self._15ParallelBlock_01SequentialBlock_08BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[2048],
+        dtype=tf.dtypes.float32,
+        name='zeros_252_',
+    ))
+    self._15ParallelBlock_01SequentialBlock_08BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[2048],
+        dtype=tf.dtypes.float32,
+        name='zeros_253_',
+    ), trainable = False)
+    self._15ParallelBlock_01SequentialBlock_08BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[2048],
+        dtype=tf.dtypes.float32,
+        name='ones_254_',
+    ), trainable = False)
+    self._15ParallelBlock_02SequentialBlock_01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[2048, 1024, 1, 1],
+        mean=0.0,
+        stddev=0.044194173,
+        dtype=tf.dtypes.float32,
+        name='normal_255_',
+    ))
+    self._15ParallelBlock_02SequentialBlock_02BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[2048],
+        dtype=tf.dtypes.float32,
+        name='ones_256_',
+    ))
+    self._15ParallelBlock_02SequentialBlock_02BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[2048],
+        dtype=tf.dtypes.float32,
+        name='zeros_257_',
+    ))
+    self._15ParallelBlock_02SequentialBlock_02BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[2048],
+        dtype=tf.dtypes.float32,
+        name='zeros_258_',
+    ), trainable = False)
+    self._15ParallelBlock_02SequentialBlock_02BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[2048],
+        dtype=tf.dtypes.float32,
+        name='ones_259_',
+    ), trainable = False)
+    self._16ParallelBlock_01SequentialBlock_01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[512, 2048, 1, 1],
+        mean=0.0,
+        stddev=0.03125,
+        dtype=tf.dtypes.float32,
+        name='normal_260_',
+    ))
+    self._16ParallelBlock_01SequentialBlock_01Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_261_',
+    ))
+    self._16ParallelBlock_01SequentialBlock_02BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_262_',
+    ))
+    self._16ParallelBlock_01SequentialBlock_02BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_263_',
+    ))
+    self._16ParallelBlock_01SequentialBlock_02BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_264_',
+    ), trainable = False)
+    self._16ParallelBlock_01SequentialBlock_02BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_265_',
+    ), trainable = False)
+    self._16ParallelBlock_01SequentialBlock_04Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[512, 512, 3, 3],
+        mean=0.0,
+        stddev=0.020833334,
+        dtype=tf.dtypes.float32,
+        name='normal_266_',
+    ))
+    self._16ParallelBlock_01SequentialBlock_05BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_267_',
+    ))
+    self._16ParallelBlock_01SequentialBlock_05BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_268_',
+    ))
+    self._16ParallelBlock_01SequentialBlock_05BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_269_',
+    ), trainable = False)
+    self._16ParallelBlock_01SequentialBlock_05BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_270_',
+    ), trainable = False)
+    self._16ParallelBlock_01SequentialBlock_07Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[2048, 512, 1, 1],
+        mean=0.0,
+        stddev=0.0625,
+        dtype=tf.dtypes.float32,
+        name='normal_271_',
+    ))
+    self._16ParallelBlock_01SequentialBlock_07Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[2048],
+        dtype=tf.dtypes.float32,
+        name='zeros_272_',
+    ))
+    self._16ParallelBlock_01SequentialBlock_08BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[2048],
+        dtype=tf.dtypes.float32,
+        name='ones_273_',
+    ))
+    self._16ParallelBlock_01SequentialBlock_08BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[2048],
+        dtype=tf.dtypes.float32,
+        name='zeros_274_',
+    ))
+    self._16ParallelBlock_01SequentialBlock_08BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[2048],
+        dtype=tf.dtypes.float32,
+        name='zeros_275_',
+    ), trainable = False)
+    self._16ParallelBlock_01SequentialBlock_08BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[2048],
+        dtype=tf.dtypes.float32,
+        name='ones_276_',
+    ), trainable = False)
+    self._17ParallelBlock_01SequentialBlock_01Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[512, 2048, 1, 1],
+        mean=0.0,
+        stddev=0.03125,
+        dtype=tf.dtypes.float32,
+        name='normal_277_',
+    ))
+    self._17ParallelBlock_01SequentialBlock_01Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_278_',
+    ))
+    self._17ParallelBlock_01SequentialBlock_02BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_279_',
+    ))
+    self._17ParallelBlock_01SequentialBlock_02BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_280_',
+    ))
+    self._17ParallelBlock_01SequentialBlock_02BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_281_',
+    ), trainable = False)
+    self._17ParallelBlock_01SequentialBlock_02BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_282_',
+    ), trainable = False)
+    self._17ParallelBlock_01SequentialBlock_04Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[512, 512, 3, 3],
+        mean=0.0,
+        stddev=0.020833334,
+        dtype=tf.dtypes.float32,
+        name='normal_283_',
+    ))
+    self._17ParallelBlock_01SequentialBlock_05BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_284_',
+    ))
+    self._17ParallelBlock_01SequentialBlock_05BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_285_',
+    ))
+    self._17ParallelBlock_01SequentialBlock_05BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='zeros_286_',
+    ), trainable = False)
+    self._17ParallelBlock_01SequentialBlock_05BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[512],
+        dtype=tf.dtypes.float32,
+        name='ones_287_',
+    ), trainable = False)
+    self._17ParallelBlock_01SequentialBlock_07Conv2d_weight = tf.Variable(tf.random.normal(
+        shape=[2048, 512, 1, 1],
+        mean=0.0,
+        stddev=0.0625,
+        dtype=tf.dtypes.float32,
+        name='normal_288_',
+    ))
+    self._17ParallelBlock_01SequentialBlock_07Conv2d_bias = tf.Variable(tf.zeros(
+        shape=[2048],
+        dtype=tf.dtypes.float32,
+        name='zeros_289_',
+    ))
+    self._17ParallelBlock_01SequentialBlock_08BatchNorm_gamma = tf.Variable(tf.ones(
+        shape=[2048],
+        dtype=tf.dtypes.float32,
+        name='ones_290_',
+    ))
+    self._17ParallelBlock_01SequentialBlock_08BatchNorm_beta = tf.Variable(tf.zeros(
+        shape=[2048],
+        dtype=tf.dtypes.float32,
+        name='zeros_291_',
+    ))
+    self._17ParallelBlock_01SequentialBlock_08BatchNorm_runningMean = tf.Variable(tf.zeros(
+        shape=[2048],
+        dtype=tf.dtypes.float32,
+        name='zeros_292_',
+    ), trainable = False)
+    self._17ParallelBlock_01SequentialBlock_08BatchNorm_runningVar = tf.Variable(tf.ones(
+        shape=[2048],
+        dtype=tf.dtypes.float32,
+        name='ones_293_',
+    ), trainable = False)
+    self._20Linear_weight = tf.Variable(tf.random.normal(
+        shape=[10, 2048],
+        mean=0.0,
+        stddev=0.03125,
+        dtype=tf.dtypes.float32,
+        name='normal_294_',
+    ))
+    self._20Linear_bias = tf.Variable(tf.zeros(
+        shape=[10],
+        dtype=tf.dtypes.float32,
+        name='zeros_295_',
+    ))
+
+## 1
+  def call(self, x):
+    val1 = tf.nn.convolution(
+        x, # (111, 3, 32, 32)
+        filters=tf.transpose(
+            self._01Conv2d_weight, # (64, 3, 3, 3)
+            perm=[2, 3, 1, 0],
+            name='transpose_296_',
+        ), # (3, 3, 3, 64)
+        strides=[1, 1],
+        padding='SAME',
+        dilations=[1, 1],
+        data_format='NCHW',
+        name='convolution_297_',
+    )  
+    (batchnorm1, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                val1, # (111, 64, 32, 32)
+                filters=tf.transpose(
+                    self._02ParallelBlock_01SequentialBlock_01Conv2d_weight, # (64, 64, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_298_',
+                ), # (1, 1, 64, 64)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_299_',
+            ), # (111, 64, 32, 32)
+            bias=self._02ParallelBlock_01SequentialBlock_01Conv2d_bias, # (64)
+            data_format='NCHW',
+            name='bias_add_300_',
+        ), # (111, 64, 32, 32)
+        scale=self._02ParallelBlock_01SequentialBlock_02BatchNorm_gamma, # (64)
+        offset=self._02ParallelBlock_01SequentialBlock_02BatchNorm_beta, # (64)
+        mean=self._02ParallelBlock_01SequentialBlock_02BatchNorm_runningMean, # (64)
+        variance=self._02ParallelBlock_01SequentialBlock_02BatchNorm_runningVar, # (64)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_301_',
+    )  
+    self._02ParallelBlock_01SequentialBlock_02BatchNorm_runningMean.assign(running_mean)  
+    self._02ParallelBlock_01SequentialBlock_02BatchNorm_runningVar.assign(running_var)  
+    (batchnorm2, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.convolution(
+            tf.nn.relu(
+                batchnorm1, # (111, 64, 32, 32)
+                name='relu_303_',
+            ), # (111, 64, 32, 32)
+            filters=tf.transpose(
+                self._02ParallelBlock_01SequentialBlock_04Conv2d_weight, # (64, 64, 3, 3)
+                perm=[2, 3, 1, 0],
+                name='transpose_302_',
+            ), # (3, 3, 64, 64)
+            strides=[1, 1],
+            padding='SAME',
+            dilations=[1, 1],
+            data_format='NCHW',
+            name='convolution_304_',
+        ), # (111, 64, 32, 32)
+        scale=self._02ParallelBlock_01SequentialBlock_05BatchNorm_gamma, # (64)
+        offset=self._02ParallelBlock_01SequentialBlock_05BatchNorm_beta, # (64)
+        mean=self._02ParallelBlock_01SequentialBlock_05BatchNorm_runningMean, # (64)
+        variance=self._02ParallelBlock_01SequentialBlock_05BatchNorm_runningVar, # (64)
+        epsilon=2.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_305_',
+    )  
+    self._02ParallelBlock_01SequentialBlock_05BatchNorm_runningMean.assign(running_mean)  
+    self._02ParallelBlock_01SequentialBlock_05BatchNorm_runningVar.assign(running_var)  
+    (batchnorm3, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                tf.nn.relu(
+                    batchnorm2, # (111, 64, 32, 32)
+                    name='relu_307_',
+                ), # (111, 64, 32, 32)
+                filters=tf.transpose(
+                    self._02ParallelBlock_01SequentialBlock_07Conv2d_weight, # (256, 64, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_306_',
+                ), # (1, 1, 64, 256)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_308_',
+            ), # (111, 256, 32, 32)
+            bias=self._02ParallelBlock_01SequentialBlock_07Conv2d_bias, # (256)
+            data_format='NCHW',
+            name='bias_add_309_',
+        ), # (111, 256, 32, 32)
+        scale=self._02ParallelBlock_01SequentialBlock_08BatchNorm_gamma, # (256)
+        offset=self._02ParallelBlock_01SequentialBlock_08BatchNorm_beta, # (256)
+        mean=self._02ParallelBlock_01SequentialBlock_08BatchNorm_runningMean, # (256)
+        variance=self._02ParallelBlock_01SequentialBlock_08BatchNorm_runningVar, # (256)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_310_',
+    )  
+    self._02ParallelBlock_01SequentialBlock_08BatchNorm_runningMean.assign(running_mean)  
+    self._02ParallelBlock_01SequentialBlock_08BatchNorm_runningVar.assign(running_var)  
+    (batchnorm4, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.convolution(
+            val1, # (111, 64, 32, 32)
+            filters=tf.transpose(
+                self._02ParallelBlock_02SequentialBlock_01Conv2d_weight, # (256, 64, 1, 1)
+                perm=[2, 3, 1, 0],
+                name='transpose_311_',
+            ), # (1, 1, 64, 256)
+            strides=[1, 1],
+            padding='VALID',
+            dilations=[1, 1],
+            data_format='NCHW',
+            name='convolution_312_',
+        ), # (111, 256, 32, 32)
+        scale=self._02ParallelBlock_02SequentialBlock_02BatchNorm_gamma, # (256)
+        offset=self._02ParallelBlock_02SequentialBlock_02BatchNorm_beta, # (256)
+        mean=self._02ParallelBlock_02SequentialBlock_02BatchNorm_runningMean, # (256)
+        variance=self._02ParallelBlock_02SequentialBlock_02BatchNorm_runningVar, # (256)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_313_',
+    )  
+    self._02ParallelBlock_02SequentialBlock_02BatchNorm_runningMean.assign(running_mean)  
+    self._02ParallelBlock_02SequentialBlock_02BatchNorm_runningVar.assign(running_var)  
+    val2 = tf.nn.relu(
+        tf.add(
+            batchnorm3, # (111, 256, 32, 32)
+            batchnorm4, # (111, 256, 32, 32)
+            name='add_314_',
+        ), # (111, 256, 32, 32)
+        name='relu_315_',
+    )  
+    (batchnorm5, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                val2, # (111, 256, 32, 32)
+                filters=tf.transpose(
+                    self._03ParallelBlock_01SequentialBlock_01Conv2d_weight, # (64, 256, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_316_',
+                ), # (1, 1, 256, 64)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_317_',
+            ), # (111, 64, 32, 32)
+            bias=self._03ParallelBlock_01SequentialBlock_01Conv2d_bias, # (64)
+            data_format='NCHW',
+            name='bias_add_318_',
+        ), # (111, 64, 32, 32)
+        scale=self._03ParallelBlock_01SequentialBlock_02BatchNorm_gamma, # (64)
+        offset=self._03ParallelBlock_01SequentialBlock_02BatchNorm_beta, # (64)
+        mean=self._03ParallelBlock_01SequentialBlock_02BatchNorm_runningMean, # (64)
+        variance=self._03ParallelBlock_01SequentialBlock_02BatchNorm_runningVar, # (64)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_319_',
+    )  
+    self._03ParallelBlock_01SequentialBlock_02BatchNorm_runningMean.assign(running_mean)  
+    self._03ParallelBlock_01SequentialBlock_02BatchNorm_runningVar.assign(running_var)  
+    (batchnorm6, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.convolution(
+            tf.nn.relu(
+                batchnorm5, # (111, 64, 32, 32)
+                name='relu_321_',
+            ), # (111, 64, 32, 32)
+            filters=tf.transpose(
+                self._03ParallelBlock_01SequentialBlock_04Conv2d_weight, # (64, 64, 3, 3)
+                perm=[2, 3, 1, 0],
+                name='transpose_320_',
+            ), # (3, 3, 64, 64)
+            strides=[1, 1],
+            padding='SAME',
+            dilations=[1, 1],
+            data_format='NCHW',
+            name='convolution_322_',
+        ), # (111, 64, 32, 32)
+        scale=self._03ParallelBlock_01SequentialBlock_05BatchNorm_gamma, # (64)
+        offset=self._03ParallelBlock_01SequentialBlock_05BatchNorm_beta, # (64)
+        mean=self._03ParallelBlock_01SequentialBlock_05BatchNorm_runningMean, # (64)
+        variance=self._03ParallelBlock_01SequentialBlock_05BatchNorm_runningVar, # (64)
+        epsilon=2.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_323_',
+    )  
+    self._03ParallelBlock_01SequentialBlock_05BatchNorm_runningMean.assign(running_mean)  
+    self._03ParallelBlock_01SequentialBlock_05BatchNorm_runningVar.assign(running_var)  
+    (batchnorm7, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                tf.nn.relu(
+                    batchnorm6, # (111, 64, 32, 32)
+                    name='relu_325_',
+                ), # (111, 64, 32, 32)
+                filters=tf.transpose(
+                    self._03ParallelBlock_01SequentialBlock_07Conv2d_weight, # (256, 64, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_324_',
+                ), # (1, 1, 64, 256)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_326_',
+            ), # (111, 256, 32, 32)
+            bias=self._03ParallelBlock_01SequentialBlock_07Conv2d_bias, # (256)
+            data_format='NCHW',
+            name='bias_add_327_',
+        ), # (111, 256, 32, 32)
+        scale=self._03ParallelBlock_01SequentialBlock_08BatchNorm_gamma, # (256)
+        offset=self._03ParallelBlock_01SequentialBlock_08BatchNorm_beta, # (256)
+        mean=self._03ParallelBlock_01SequentialBlock_08BatchNorm_runningMean, # (256)
+        variance=self._03ParallelBlock_01SequentialBlock_08BatchNorm_runningVar, # (256)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_328_',
+    )  
+    self._03ParallelBlock_01SequentialBlock_08BatchNorm_runningMean.assign(running_mean)  
+    self._03ParallelBlock_01SequentialBlock_08BatchNorm_runningVar.assign(running_var)  
+    val3 = tf.nn.relu(
+        tf.add(
+            batchnorm7, # (111, 256, 32, 32)
+            val2, # (111, 256, 32, 32)
+            name='add_329_',
+        ), # (111, 256, 32, 32)
+        name='relu_330_',
+    )  
+    (batchnorm8, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                val3, # (111, 256, 32, 32)
+                filters=tf.transpose(
+                    self._04ParallelBlock_01SequentialBlock_01Conv2d_weight, # (64, 256, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_331_',
+                ), # (1, 1, 256, 64)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_332_',
+            ), # (111, 64, 32, 32)
+            bias=self._04ParallelBlock_01SequentialBlock_01Conv2d_bias, # (64)
+            data_format='NCHW',
+            name='bias_add_333_',
+        ), # (111, 64, 32, 32)
+        scale=self._04ParallelBlock_01SequentialBlock_02BatchNorm_gamma, # (64)
+        offset=self._04ParallelBlock_01SequentialBlock_02BatchNorm_beta, # (64)
+        mean=self._04ParallelBlock_01SequentialBlock_02BatchNorm_runningMean, # (64)
+        variance=self._04ParallelBlock_01SequentialBlock_02BatchNorm_runningVar, # (64)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_334_',
+    )  
+    self._04ParallelBlock_01SequentialBlock_02BatchNorm_runningMean.assign(running_mean)  
+    self._04ParallelBlock_01SequentialBlock_02BatchNorm_runningVar.assign(running_var)  
+    (batchnorm9, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.convolution(
+            tf.nn.relu(
+                batchnorm8, # (111, 64, 32, 32)
+                name='relu_336_',
+            ), # (111, 64, 32, 32)
+            filters=tf.transpose(
+                self._04ParallelBlock_01SequentialBlock_04Conv2d_weight, # (64, 64, 3, 3)
+                perm=[2, 3, 1, 0],
+                name='transpose_335_',
+            ), # (3, 3, 64, 64)
+            strides=[1, 1],
+            padding='SAME',
+            dilations=[1, 1],
+            data_format='NCHW',
+            name='convolution_337_',
+        ), # (111, 64, 32, 32)
+        scale=self._04ParallelBlock_01SequentialBlock_05BatchNorm_gamma, # (64)
+        offset=self._04ParallelBlock_01SequentialBlock_05BatchNorm_beta, # (64)
+        mean=self._04ParallelBlock_01SequentialBlock_05BatchNorm_runningMean, # (64)
+        variance=self._04ParallelBlock_01SequentialBlock_05BatchNorm_runningVar, # (64)
+        epsilon=2.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_338_',
+    )  
+    self._04ParallelBlock_01SequentialBlock_05BatchNorm_runningMean.assign(running_mean)  
+    self._04ParallelBlock_01SequentialBlock_05BatchNorm_runningVar.assign(running_var)  
+    (batchnorm10, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                tf.nn.relu(
+                    batchnorm9, # (111, 64, 32, 32)
+                    name='relu_340_',
+                ), # (111, 64, 32, 32)
+                filters=tf.transpose(
+                    self._04ParallelBlock_01SequentialBlock_07Conv2d_weight, # (256, 64, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_339_',
+                ), # (1, 1, 64, 256)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_341_',
+            ), # (111, 256, 32, 32)
+            bias=self._04ParallelBlock_01SequentialBlock_07Conv2d_bias, # (256)
+            data_format='NCHW',
+            name='bias_add_342_',
+        ), # (111, 256, 32, 32)
+        scale=self._04ParallelBlock_01SequentialBlock_08BatchNorm_gamma, # (256)
+        offset=self._04ParallelBlock_01SequentialBlock_08BatchNorm_beta, # (256)
+        mean=self._04ParallelBlock_01SequentialBlock_08BatchNorm_runningMean, # (256)
+        variance=self._04ParallelBlock_01SequentialBlock_08BatchNorm_runningVar, # (256)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_343_',
+    )  
+    self._04ParallelBlock_01SequentialBlock_08BatchNorm_runningMean.assign(running_mean)  
+    self._04ParallelBlock_01SequentialBlock_08BatchNorm_runningVar.assign(running_var)  
+    val4 = tf.nn.relu(
+        tf.add(
+            batchnorm10, # (111, 256, 32, 32)
+            val3, # (111, 256, 32, 32)
+            name='add_344_',
+        ), # (111, 256, 32, 32)
+        name='relu_345_',
+    )  
+    (batchnorm11, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                val4, # (111, 256, 32, 32)
+                filters=tf.transpose(
+                    self._05ParallelBlock_01SequentialBlock_01Conv2d_weight, # (128, 256, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_346_',
+                ), # (1, 1, 256, 128)
+                strides=[2, 2],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_347_',
+            ), # (111, 128, 16, 16)
+            bias=self._05ParallelBlock_01SequentialBlock_01Conv2d_bias, # (128)
+            data_format='NCHW',
+            name='bias_add_348_',
+        ), # (111, 128, 16, 16)
+        scale=self._05ParallelBlock_01SequentialBlock_02BatchNorm_gamma, # (128)
+        offset=self._05ParallelBlock_01SequentialBlock_02BatchNorm_beta, # (128)
+        mean=self._05ParallelBlock_01SequentialBlock_02BatchNorm_runningMean, # (128)
+        variance=self._05ParallelBlock_01SequentialBlock_02BatchNorm_runningVar, # (128)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_349_',
+    )  
+    self._05ParallelBlock_01SequentialBlock_02BatchNorm_runningMean.assign(running_mean)  
+    self._05ParallelBlock_01SequentialBlock_02BatchNorm_runningVar.assign(running_var)  
+    (batchnorm12, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.convolution(
+            tf.nn.relu(
+                batchnorm11, # (111, 128, 16, 16)
+                name='relu_351_',
+            ), # (111, 128, 16, 16)
+            filters=tf.transpose(
+                self._05ParallelBlock_01SequentialBlock_04Conv2d_weight, # (128, 128, 3, 3)
+                perm=[2, 3, 1, 0],
+                name='transpose_350_',
+            ), # (3, 3, 128, 128)
+            strides=[1, 1],
+            padding='SAME',
+            dilations=[1, 1],
+            data_format='NCHW',
+            name='convolution_352_',
+        ), # (111, 128, 16, 16)
+        scale=self._05ParallelBlock_01SequentialBlock_05BatchNorm_gamma, # (128)
+        offset=self._05ParallelBlock_01SequentialBlock_05BatchNorm_beta, # (128)
+        mean=self._05ParallelBlock_01SequentialBlock_05BatchNorm_runningMean, # (128)
+        variance=self._05ParallelBlock_01SequentialBlock_05BatchNorm_runningVar, # (128)
+        epsilon=2.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_353_',
+    )  
+    self._05ParallelBlock_01SequentialBlock_05BatchNorm_runningMean.assign(running_mean)  
+    self._05ParallelBlock_01SequentialBlock_05BatchNorm_runningVar.assign(running_var)  
+    (batchnorm13, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                tf.nn.relu(
+                    batchnorm12, # (111, 128, 16, 16)
+                    name='relu_355_',
+                ), # (111, 128, 16, 16)
+                filters=tf.transpose(
+                    self._05ParallelBlock_01SequentialBlock_07Conv2d_weight, # (512, 128, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_354_',
+                ), # (1, 1, 128, 512)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_356_',
+            ), # (111, 512, 16, 16)
+            bias=self._05ParallelBlock_01SequentialBlock_07Conv2d_bias, # (512)
+            data_format='NCHW',
+            name='bias_add_357_',
+        ), # (111, 512, 16, 16)
+        scale=self._05ParallelBlock_01SequentialBlock_08BatchNorm_gamma, # (512)
+        offset=self._05ParallelBlock_01SequentialBlock_08BatchNorm_beta, # (512)
+        mean=self._05ParallelBlock_01SequentialBlock_08BatchNorm_runningMean, # (512)
+        variance=self._05ParallelBlock_01SequentialBlock_08BatchNorm_runningVar, # (512)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_358_',
+    )  
+    self._05ParallelBlock_01SequentialBlock_08BatchNorm_runningMean.assign(running_mean)  
+    self._05ParallelBlock_01SequentialBlock_08BatchNorm_runningVar.assign(running_var)  
+    (batchnorm14, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.convolution(
+            val4, # (111, 256, 32, 32)
+            filters=tf.transpose(
+                self._05ParallelBlock_02SequentialBlock_01Conv2d_weight, # (512, 256, 1, 1)
+                perm=[2, 3, 1, 0],
+                name='transpose_359_',
+            ), # (1, 1, 256, 512)
+            strides=[2, 2],
+            padding='VALID',
+            dilations=[1, 1],
+            data_format='NCHW',
+            name='convolution_360_',
+        ), # (111, 512, 16, 16)
+        scale=self._05ParallelBlock_02SequentialBlock_02BatchNorm_gamma, # (512)
+        offset=self._05ParallelBlock_02SequentialBlock_02BatchNorm_beta, # (512)
+        mean=self._05ParallelBlock_02SequentialBlock_02BatchNorm_runningMean, # (512)
+        variance=self._05ParallelBlock_02SequentialBlock_02BatchNorm_runningVar, # (512)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_361_',
+    )  
+    self._05ParallelBlock_02SequentialBlock_02BatchNorm_runningMean.assign(running_mean)  
+    self._05ParallelBlock_02SequentialBlock_02BatchNorm_runningVar.assign(running_var)  
+    val5 = tf.nn.relu(
+        tf.add(
+            batchnorm13, # (111, 512, 16, 16)
+            batchnorm14, # (111, 512, 16, 16)
+            name='add_362_',
+        ), # (111, 512, 16, 16)
+        name='relu_363_',
+    )  
+    (batchnorm15, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                val5, # (111, 512, 16, 16)
+                filters=tf.transpose(
+                    self._06ParallelBlock_01SequentialBlock_01Conv2d_weight, # (128, 512, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_364_',
+                ), # (1, 1, 512, 128)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_365_',
+            ), # (111, 128, 16, 16)
+            bias=self._06ParallelBlock_01SequentialBlock_01Conv2d_bias, # (128)
+            data_format='NCHW',
+            name='bias_add_366_',
+        ), # (111, 128, 16, 16)
+        scale=self._06ParallelBlock_01SequentialBlock_02BatchNorm_gamma, # (128)
+        offset=self._06ParallelBlock_01SequentialBlock_02BatchNorm_beta, # (128)
+        mean=self._06ParallelBlock_01SequentialBlock_02BatchNorm_runningMean, # (128)
+        variance=self._06ParallelBlock_01SequentialBlock_02BatchNorm_runningVar, # (128)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_367_',
+    )  
+    self._06ParallelBlock_01SequentialBlock_02BatchNorm_runningMean.assign(running_mean)  
+    self._06ParallelBlock_01SequentialBlock_02BatchNorm_runningVar.assign(running_var)  
+    (batchnorm16, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.convolution(
+            tf.nn.relu(
+                batchnorm15, # (111, 128, 16, 16)
+                name='relu_369_',
+            ), # (111, 128, 16, 16)
+            filters=tf.transpose(
+                self._06ParallelBlock_01SequentialBlock_04Conv2d_weight, # (128, 128, 3, 3)
+                perm=[2, 3, 1, 0],
+                name='transpose_368_',
+            ), # (3, 3, 128, 128)
+            strides=[1, 1],
+            padding='SAME',
+            dilations=[1, 1],
+            data_format='NCHW',
+            name='convolution_370_',
+        ), # (111, 128, 16, 16)
+        scale=self._06ParallelBlock_01SequentialBlock_05BatchNorm_gamma, # (128)
+        offset=self._06ParallelBlock_01SequentialBlock_05BatchNorm_beta, # (128)
+        mean=self._06ParallelBlock_01SequentialBlock_05BatchNorm_runningMean, # (128)
+        variance=self._06ParallelBlock_01SequentialBlock_05BatchNorm_runningVar, # (128)
+        epsilon=2.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_371_',
+    )  
+    self._06ParallelBlock_01SequentialBlock_05BatchNorm_runningMean.assign(running_mean)  
+    self._06ParallelBlock_01SequentialBlock_05BatchNorm_runningVar.assign(running_var)  
+    (batchnorm17, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                tf.nn.relu(
+                    batchnorm16, # (111, 128, 16, 16)
+                    name='relu_373_',
+                ), # (111, 128, 16, 16)
+                filters=tf.transpose(
+                    self._06ParallelBlock_01SequentialBlock_07Conv2d_weight, # (512, 128, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_372_',
+                ), # (1, 1, 128, 512)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_374_',
+            ), # (111, 512, 16, 16)
+            bias=self._06ParallelBlock_01SequentialBlock_07Conv2d_bias, # (512)
+            data_format='NCHW',
+            name='bias_add_375_',
+        ), # (111, 512, 16, 16)
+        scale=self._06ParallelBlock_01SequentialBlock_08BatchNorm_gamma, # (512)
+        offset=self._06ParallelBlock_01SequentialBlock_08BatchNorm_beta, # (512)
+        mean=self._06ParallelBlock_01SequentialBlock_08BatchNorm_runningMean, # (512)
+        variance=self._06ParallelBlock_01SequentialBlock_08BatchNorm_runningVar, # (512)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_376_',
+    )  
+    self._06ParallelBlock_01SequentialBlock_08BatchNorm_runningMean.assign(running_mean)  
+    self._06ParallelBlock_01SequentialBlock_08BatchNorm_runningVar.assign(running_var)  
+    val6 = tf.nn.relu(
+        tf.add(
+            batchnorm17, # (111, 512, 16, 16)
+            val5, # (111, 512, 16, 16)
+            name='add_377_',
+        ), # (111, 512, 16, 16)
+        name='relu_378_',
+    )  
+    (batchnorm18, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                val6, # (111, 512, 16, 16)
+                filters=tf.transpose(
+                    self._07ParallelBlock_01SequentialBlock_01Conv2d_weight, # (128, 512, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_379_',
+                ), # (1, 1, 512, 128)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_380_',
+            ), # (111, 128, 16, 16)
+            bias=self._07ParallelBlock_01SequentialBlock_01Conv2d_bias, # (128)
+            data_format='NCHW',
+            name='bias_add_381_',
+        ), # (111, 128, 16, 16)
+        scale=self._07ParallelBlock_01SequentialBlock_02BatchNorm_gamma, # (128)
+        offset=self._07ParallelBlock_01SequentialBlock_02BatchNorm_beta, # (128)
+        mean=self._07ParallelBlock_01SequentialBlock_02BatchNorm_runningMean, # (128)
+        variance=self._07ParallelBlock_01SequentialBlock_02BatchNorm_runningVar, # (128)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_382_',
+    )  
+    self._07ParallelBlock_01SequentialBlock_02BatchNorm_runningMean.assign(running_mean)  
+    self._07ParallelBlock_01SequentialBlock_02BatchNorm_runningVar.assign(running_var)  
+    (batchnorm19, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.convolution(
+            tf.nn.relu(
+                batchnorm18, # (111, 128, 16, 16)
+                name='relu_384_',
+            ), # (111, 128, 16, 16)
+            filters=tf.transpose(
+                self._07ParallelBlock_01SequentialBlock_04Conv2d_weight, # (128, 128, 3, 3)
+                perm=[2, 3, 1, 0],
+                name='transpose_383_',
+            ), # (3, 3, 128, 128)
+            strides=[1, 1],
+            padding='SAME',
+            dilations=[1, 1],
+            data_format='NCHW',
+            name='convolution_385_',
+        ), # (111, 128, 16, 16)
+        scale=self._07ParallelBlock_01SequentialBlock_05BatchNorm_gamma, # (128)
+        offset=self._07ParallelBlock_01SequentialBlock_05BatchNorm_beta, # (128)
+        mean=self._07ParallelBlock_01SequentialBlock_05BatchNorm_runningMean, # (128)
+        variance=self._07ParallelBlock_01SequentialBlock_05BatchNorm_runningVar, # (128)
+        epsilon=2.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_386_',
+    )  
+    self._07ParallelBlock_01SequentialBlock_05BatchNorm_runningMean.assign(running_mean)  
+    self._07ParallelBlock_01SequentialBlock_05BatchNorm_runningVar.assign(running_var)  
+    (batchnorm20, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                tf.nn.relu(
+                    batchnorm19, # (111, 128, 16, 16)
+                    name='relu_388_',
+                ), # (111, 128, 16, 16)
+                filters=tf.transpose(
+                    self._07ParallelBlock_01SequentialBlock_07Conv2d_weight, # (512, 128, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_387_',
+                ), # (1, 1, 128, 512)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_389_',
+            ), # (111, 512, 16, 16)
+            bias=self._07ParallelBlock_01SequentialBlock_07Conv2d_bias, # (512)
+            data_format='NCHW',
+            name='bias_add_390_',
+        ), # (111, 512, 16, 16)
+        scale=self._07ParallelBlock_01SequentialBlock_08BatchNorm_gamma, # (512)
+        offset=self._07ParallelBlock_01SequentialBlock_08BatchNorm_beta, # (512)
+        mean=self._07ParallelBlock_01SequentialBlock_08BatchNorm_runningMean, # (512)
+        variance=self._07ParallelBlock_01SequentialBlock_08BatchNorm_runningVar, # (512)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_391_',
+    )  
+    self._07ParallelBlock_01SequentialBlock_08BatchNorm_runningMean.assign(running_mean)  
+    self._07ParallelBlock_01SequentialBlock_08BatchNorm_runningVar.assign(running_var)  
+    val7 = tf.nn.relu(
+        tf.add(
+            batchnorm20, # (111, 512, 16, 16)
+            val6, # (111, 512, 16, 16)
+            name='add_392_',
+        ), # (111, 512, 16, 16)
+        name='relu_393_',
+    )  
+    (batchnorm21, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                val7, # (111, 512, 16, 16)
+                filters=tf.transpose(
+                    self._08ParallelBlock_01SequentialBlock_01Conv2d_weight, # (128, 512, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_394_',
+                ), # (1, 1, 512, 128)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_395_',
+            ), # (111, 128, 16, 16)
+            bias=self._08ParallelBlock_01SequentialBlock_01Conv2d_bias, # (128)
+            data_format='NCHW',
+            name='bias_add_396_',
+        ), # (111, 128, 16, 16)
+        scale=self._08ParallelBlock_01SequentialBlock_02BatchNorm_gamma, # (128)
+        offset=self._08ParallelBlock_01SequentialBlock_02BatchNorm_beta, # (128)
+        mean=self._08ParallelBlock_01SequentialBlock_02BatchNorm_runningMean, # (128)
+        variance=self._08ParallelBlock_01SequentialBlock_02BatchNorm_runningVar, # (128)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_397_',
+    )  
+    self._08ParallelBlock_01SequentialBlock_02BatchNorm_runningMean.assign(running_mean)  
+    self._08ParallelBlock_01SequentialBlock_02BatchNorm_runningVar.assign(running_var)  
+    (batchnorm22, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.convolution(
+            tf.nn.relu(
+                batchnorm21, # (111, 128, 16, 16)
+                name='relu_399_',
+            ), # (111, 128, 16, 16)
+            filters=tf.transpose(
+                self._08ParallelBlock_01SequentialBlock_04Conv2d_weight, # (128, 128, 3, 3)
+                perm=[2, 3, 1, 0],
+                name='transpose_398_',
+            ), # (3, 3, 128, 128)
+            strides=[1, 1],
+            padding='SAME',
+            dilations=[1, 1],
+            data_format='NCHW',
+            name='convolution_400_',
+        ), # (111, 128, 16, 16)
+        scale=self._08ParallelBlock_01SequentialBlock_05BatchNorm_gamma, # (128)
+        offset=self._08ParallelBlock_01SequentialBlock_05BatchNorm_beta, # (128)
+        mean=self._08ParallelBlock_01SequentialBlock_05BatchNorm_runningMean, # (128)
+        variance=self._08ParallelBlock_01SequentialBlock_05BatchNorm_runningVar, # (128)
+        epsilon=2.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_401_',
+    )  
+    self._08ParallelBlock_01SequentialBlock_05BatchNorm_runningMean.assign(running_mean)  
+    self._08ParallelBlock_01SequentialBlock_05BatchNorm_runningVar.assign(running_var)  
+    (batchnorm23, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                tf.nn.relu(
+                    batchnorm22, # (111, 128, 16, 16)
+                    name='relu_403_',
+                ), # (111, 128, 16, 16)
+                filters=tf.transpose(
+                    self._08ParallelBlock_01SequentialBlock_07Conv2d_weight, # (512, 128, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_402_',
+                ), # (1, 1, 128, 512)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_404_',
+            ), # (111, 512, 16, 16)
+            bias=self._08ParallelBlock_01SequentialBlock_07Conv2d_bias, # (512)
+            data_format='NCHW',
+            name='bias_add_405_',
+        ), # (111, 512, 16, 16)
+        scale=self._08ParallelBlock_01SequentialBlock_08BatchNorm_gamma, # (512)
+        offset=self._08ParallelBlock_01SequentialBlock_08BatchNorm_beta, # (512)
+        mean=self._08ParallelBlock_01SequentialBlock_08BatchNorm_runningMean, # (512)
+        variance=self._08ParallelBlock_01SequentialBlock_08BatchNorm_runningVar, # (512)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_406_',
+    )  
+    self._08ParallelBlock_01SequentialBlock_08BatchNorm_runningMean.assign(running_mean)  
+    self._08ParallelBlock_01SequentialBlock_08BatchNorm_runningVar.assign(running_var)  
+    val8 = tf.nn.relu(
+        tf.add(
+            batchnorm23, # (111, 512, 16, 16)
+            val7, # (111, 512, 16, 16)
+            name='add_407_',
+        ), # (111, 512, 16, 16)
+        name='relu_408_',
+    )  
+    (batchnorm24, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                val8, # (111, 512, 16, 16)
+                filters=tf.transpose(
+                    self._09ParallelBlock_01SequentialBlock_01Conv2d_weight, # (256, 512, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_409_',
+                ), # (1, 1, 512, 256)
+                strides=[2, 2],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_410_',
+            ), # (111, 256, 8, 8)
+            bias=self._09ParallelBlock_01SequentialBlock_01Conv2d_bias, # (256)
+            data_format='NCHW',
+            name='bias_add_411_',
+        ), # (111, 256, 8, 8)
+        scale=self._09ParallelBlock_01SequentialBlock_02BatchNorm_gamma, # (256)
+        offset=self._09ParallelBlock_01SequentialBlock_02BatchNorm_beta, # (256)
+        mean=self._09ParallelBlock_01SequentialBlock_02BatchNorm_runningMean, # (256)
+        variance=self._09ParallelBlock_01SequentialBlock_02BatchNorm_runningVar, # (256)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_412_',
+    )  
+    self._09ParallelBlock_01SequentialBlock_02BatchNorm_runningMean.assign(running_mean)  
+    self._09ParallelBlock_01SequentialBlock_02BatchNorm_runningVar.assign(running_var)  
+    (batchnorm25, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.convolution(
+            tf.nn.relu(
+                batchnorm24, # (111, 256, 8, 8)
+                name='relu_414_',
+            ), # (111, 256, 8, 8)
+            filters=tf.transpose(
+                self._09ParallelBlock_01SequentialBlock_04Conv2d_weight, # (256, 256, 3, 3)
+                perm=[2, 3, 1, 0],
+                name='transpose_413_',
+            ), # (3, 3, 256, 256)
+            strides=[1, 1],
+            padding='SAME',
+            dilations=[1, 1],
+            data_format='NCHW',
+            name='convolution_415_',
+        ), # (111, 256, 8, 8)
+        scale=self._09ParallelBlock_01SequentialBlock_05BatchNorm_gamma, # (256)
+        offset=self._09ParallelBlock_01SequentialBlock_05BatchNorm_beta, # (256)
+        mean=self._09ParallelBlock_01SequentialBlock_05BatchNorm_runningMean, # (256)
+        variance=self._09ParallelBlock_01SequentialBlock_05BatchNorm_runningVar, # (256)
+        epsilon=2.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_416_',
+    )  
+    self._09ParallelBlock_01SequentialBlock_05BatchNorm_runningMean.assign(running_mean)  
+    self._09ParallelBlock_01SequentialBlock_05BatchNorm_runningVar.assign(running_var)  
+    (batchnorm26, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                tf.nn.relu(
+                    batchnorm25, # (111, 256, 8, 8)
+                    name='relu_418_',
+                ), # (111, 256, 8, 8)
+                filters=tf.transpose(
+                    self._09ParallelBlock_01SequentialBlock_07Conv2d_weight, # (1024, 256, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_417_',
+                ), # (1, 1, 256, 1024)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_419_',
+            ), # (111, 1024, 8, 8)
+            bias=self._09ParallelBlock_01SequentialBlock_07Conv2d_bias, # (1024)
+            data_format='NCHW',
+            name='bias_add_420_',
+        ), # (111, 1024, 8, 8)
+        scale=self._09ParallelBlock_01SequentialBlock_08BatchNorm_gamma, # (1024)
+        offset=self._09ParallelBlock_01SequentialBlock_08BatchNorm_beta, # (1024)
+        mean=self._09ParallelBlock_01SequentialBlock_08BatchNorm_runningMean, # (1024)
+        variance=self._09ParallelBlock_01SequentialBlock_08BatchNorm_runningVar, # (1024)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_421_',
+    )  
+    self._09ParallelBlock_01SequentialBlock_08BatchNorm_runningMean.assign(running_mean)  
+    self._09ParallelBlock_01SequentialBlock_08BatchNorm_runningVar.assign(running_var)  
+    (batchnorm27, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.convolution(
+            val8, # (111, 512, 16, 16)
+            filters=tf.transpose(
+                self._09ParallelBlock_02SequentialBlock_01Conv2d_weight, # (1024, 512, 1, 1)
+                perm=[2, 3, 1, 0],
+                name='transpose_422_',
+            ), # (1, 1, 512, 1024)
+            strides=[2, 2],
+            padding='VALID',
+            dilations=[1, 1],
+            data_format='NCHW',
+            name='convolution_423_',
+        ), # (111, 1024, 8, 8)
+        scale=self._09ParallelBlock_02SequentialBlock_02BatchNorm_gamma, # (1024)
+        offset=self._09ParallelBlock_02SequentialBlock_02BatchNorm_beta, # (1024)
+        mean=self._09ParallelBlock_02SequentialBlock_02BatchNorm_runningMean, # (1024)
+        variance=self._09ParallelBlock_02SequentialBlock_02BatchNorm_runningVar, # (1024)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_424_',
+    )  
+    self._09ParallelBlock_02SequentialBlock_02BatchNorm_runningMean.assign(running_mean)  
+    self._09ParallelBlock_02SequentialBlock_02BatchNorm_runningVar.assign(running_var)  
+    val9 = tf.nn.relu(
+        tf.add(
+            batchnorm26, # (111, 1024, 8, 8)
+            batchnorm27, # (111, 1024, 8, 8)
+            name='add_425_',
+        ), # (111, 1024, 8, 8)
+        name='relu_426_',
+    )  
+    (batchnorm28, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                val9, # (111, 1024, 8, 8)
+                filters=tf.transpose(
+                    self._10ParallelBlock_01SequentialBlock_01Conv2d_weight, # (256, 1024, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_427_',
+                ), # (1, 1, 1024, 256)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_428_',
+            ), # (111, 256, 8, 8)
+            bias=self._10ParallelBlock_01SequentialBlock_01Conv2d_bias, # (256)
+            data_format='NCHW',
+            name='bias_add_429_',
+        ), # (111, 256, 8, 8)
+        scale=self._10ParallelBlock_01SequentialBlock_02BatchNorm_gamma, # (256)
+        offset=self._10ParallelBlock_01SequentialBlock_02BatchNorm_beta, # (256)
+        mean=self._10ParallelBlock_01SequentialBlock_02BatchNorm_runningMean, # (256)
+        variance=self._10ParallelBlock_01SequentialBlock_02BatchNorm_runningVar, # (256)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_430_',
+    )  
+    self._10ParallelBlock_01SequentialBlock_02BatchNorm_runningMean.assign(running_mean)  
+    self._10ParallelBlock_01SequentialBlock_02BatchNorm_runningVar.assign(running_var)  
+    (batchnorm29, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.convolution(
+            tf.nn.relu(
+                batchnorm28, # (111, 256, 8, 8)
+                name='relu_432_',
+            ), # (111, 256, 8, 8)
+            filters=tf.transpose(
+                self._10ParallelBlock_01SequentialBlock_04Conv2d_weight, # (256, 256, 3, 3)
+                perm=[2, 3, 1, 0],
+                name='transpose_431_',
+            ), # (3, 3, 256, 256)
+            strides=[1, 1],
+            padding='SAME',
+            dilations=[1, 1],
+            data_format='NCHW',
+            name='convolution_433_',
+        ), # (111, 256, 8, 8)
+        scale=self._10ParallelBlock_01SequentialBlock_05BatchNorm_gamma, # (256)
+        offset=self._10ParallelBlock_01SequentialBlock_05BatchNorm_beta, # (256)
+        mean=self._10ParallelBlock_01SequentialBlock_05BatchNorm_runningMean, # (256)
+        variance=self._10ParallelBlock_01SequentialBlock_05BatchNorm_runningVar, # (256)
+        epsilon=2.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_434_',
+    )  
+    self._10ParallelBlock_01SequentialBlock_05BatchNorm_runningMean.assign(running_mean)  
+    self._10ParallelBlock_01SequentialBlock_05BatchNorm_runningVar.assign(running_var)  
+    (batchnorm30, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                tf.nn.relu(
+                    batchnorm29, # (111, 256, 8, 8)
+                    name='relu_436_',
+                ), # (111, 256, 8, 8)
+                filters=tf.transpose(
+                    self._10ParallelBlock_01SequentialBlock_07Conv2d_weight, # (1024, 256, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_435_',
+                ), # (1, 1, 256, 1024)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_437_',
+            ), # (111, 1024, 8, 8)
+            bias=self._10ParallelBlock_01SequentialBlock_07Conv2d_bias, # (1024)
+            data_format='NCHW',
+            name='bias_add_438_',
+        ), # (111, 1024, 8, 8)
+        scale=self._10ParallelBlock_01SequentialBlock_08BatchNorm_gamma, # (1024)
+        offset=self._10ParallelBlock_01SequentialBlock_08BatchNorm_beta, # (1024)
+        mean=self._10ParallelBlock_01SequentialBlock_08BatchNorm_runningMean, # (1024)
+        variance=self._10ParallelBlock_01SequentialBlock_08BatchNorm_runningVar, # (1024)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_439_',
+    )  
+    self._10ParallelBlock_01SequentialBlock_08BatchNorm_runningMean.assign(running_mean)  
+    self._10ParallelBlock_01SequentialBlock_08BatchNorm_runningVar.assign(running_var)  
+    val10 = tf.nn.relu(
+        tf.add(
+            batchnorm30, # (111, 1024, 8, 8)
+            val9, # (111, 1024, 8, 8)
+            name='add_440_',
+        ), # (111, 1024, 8, 8)
+        name='relu_441_',
+    )  
+    (batchnorm31, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                val10, # (111, 1024, 8, 8)
+                filters=tf.transpose(
+                    self._11ParallelBlock_01SequentialBlock_01Conv2d_weight, # (256, 1024, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_442_',
+                ), # (1, 1, 1024, 256)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_443_',
+            ), # (111, 256, 8, 8)
+            bias=self._11ParallelBlock_01SequentialBlock_01Conv2d_bias, # (256)
+            data_format='NCHW',
+            name='bias_add_444_',
+        ), # (111, 256, 8, 8)
+        scale=self._11ParallelBlock_01SequentialBlock_02BatchNorm_gamma, # (256)
+        offset=self._11ParallelBlock_01SequentialBlock_02BatchNorm_beta, # (256)
+        mean=self._11ParallelBlock_01SequentialBlock_02BatchNorm_runningMean, # (256)
+        variance=self._11ParallelBlock_01SequentialBlock_02BatchNorm_runningVar, # (256)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_445_',
+    )  
+    self._11ParallelBlock_01SequentialBlock_02BatchNorm_runningMean.assign(running_mean)  
+    self._11ParallelBlock_01SequentialBlock_02BatchNorm_runningVar.assign(running_var)  
+    (batchnorm32, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.convolution(
+            tf.nn.relu(
+                batchnorm31, # (111, 256, 8, 8)
+                name='relu_447_',
+            ), # (111, 256, 8, 8)
+            filters=tf.transpose(
+                self._11ParallelBlock_01SequentialBlock_04Conv2d_weight, # (256, 256, 3, 3)
+                perm=[2, 3, 1, 0],
+                name='transpose_446_',
+            ), # (3, 3, 256, 256)
+            strides=[1, 1],
+            padding='SAME',
+            dilations=[1, 1],
+            data_format='NCHW',
+            name='convolution_448_',
+        ), # (111, 256, 8, 8)
+        scale=self._11ParallelBlock_01SequentialBlock_05BatchNorm_gamma, # (256)
+        offset=self._11ParallelBlock_01SequentialBlock_05BatchNorm_beta, # (256)
+        mean=self._11ParallelBlock_01SequentialBlock_05BatchNorm_runningMean, # (256)
+        variance=self._11ParallelBlock_01SequentialBlock_05BatchNorm_runningVar, # (256)
+        epsilon=2.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_449_',
+    )  
+    self._11ParallelBlock_01SequentialBlock_05BatchNorm_runningMean.assign(running_mean)  
+    self._11ParallelBlock_01SequentialBlock_05BatchNorm_runningVar.assign(running_var)  
+    (batchnorm33, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                tf.nn.relu(
+                    batchnorm32, # (111, 256, 8, 8)
+                    name='relu_451_',
+                ), # (111, 256, 8, 8)
+                filters=tf.transpose(
+                    self._11ParallelBlock_01SequentialBlock_07Conv2d_weight, # (1024, 256, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_450_',
+                ), # (1, 1, 256, 1024)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_452_',
+            ), # (111, 1024, 8, 8)
+            bias=self._11ParallelBlock_01SequentialBlock_07Conv2d_bias, # (1024)
+            data_format='NCHW',
+            name='bias_add_453_',
+        ), # (111, 1024, 8, 8)
+        scale=self._11ParallelBlock_01SequentialBlock_08BatchNorm_gamma, # (1024)
+        offset=self._11ParallelBlock_01SequentialBlock_08BatchNorm_beta, # (1024)
+        mean=self._11ParallelBlock_01SequentialBlock_08BatchNorm_runningMean, # (1024)
+        variance=self._11ParallelBlock_01SequentialBlock_08BatchNorm_runningVar, # (1024)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_454_',
+    )  
+    self._11ParallelBlock_01SequentialBlock_08BatchNorm_runningMean.assign(running_mean)  
+    self._11ParallelBlock_01SequentialBlock_08BatchNorm_runningVar.assign(running_var)  
+    val11 = tf.nn.relu(
+        tf.add(
+            batchnorm33, # (111, 1024, 8, 8)
+            val10, # (111, 1024, 8, 8)
+            name='add_455_',
+        ), # (111, 1024, 8, 8)
+        name='relu_456_',
+    )  
+    (batchnorm34, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                val11, # (111, 1024, 8, 8)
+                filters=tf.transpose(
+                    self._12ParallelBlock_01SequentialBlock_01Conv2d_weight, # (256, 1024, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_457_',
+                ), # (1, 1, 1024, 256)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_458_',
+            ), # (111, 256, 8, 8)
+            bias=self._12ParallelBlock_01SequentialBlock_01Conv2d_bias, # (256)
+            data_format='NCHW',
+            name='bias_add_459_',
+        ), # (111, 256, 8, 8)
+        scale=self._12ParallelBlock_01SequentialBlock_02BatchNorm_gamma, # (256)
+        offset=self._12ParallelBlock_01SequentialBlock_02BatchNorm_beta, # (256)
+        mean=self._12ParallelBlock_01SequentialBlock_02BatchNorm_runningMean, # (256)
+        variance=self._12ParallelBlock_01SequentialBlock_02BatchNorm_runningVar, # (256)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_460_',
+    )  
+    self._12ParallelBlock_01SequentialBlock_02BatchNorm_runningMean.assign(running_mean)  
+    self._12ParallelBlock_01SequentialBlock_02BatchNorm_runningVar.assign(running_var)  
+    (batchnorm35, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.convolution(
+            tf.nn.relu(
+                batchnorm34, # (111, 256, 8, 8)
+                name='relu_462_',
+            ), # (111, 256, 8, 8)
+            filters=tf.transpose(
+                self._12ParallelBlock_01SequentialBlock_04Conv2d_weight, # (256, 256, 3, 3)
+                perm=[2, 3, 1, 0],
+                name='transpose_461_',
+            ), # (3, 3, 256, 256)
+            strides=[1, 1],
+            padding='SAME',
+            dilations=[1, 1],
+            data_format='NCHW',
+            name='convolution_463_',
+        ), # (111, 256, 8, 8)
+        scale=self._12ParallelBlock_01SequentialBlock_05BatchNorm_gamma, # (256)
+        offset=self._12ParallelBlock_01SequentialBlock_05BatchNorm_beta, # (256)
+        mean=self._12ParallelBlock_01SequentialBlock_05BatchNorm_runningMean, # (256)
+        variance=self._12ParallelBlock_01SequentialBlock_05BatchNorm_runningVar, # (256)
+        epsilon=2.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_464_',
+    )  
+    self._12ParallelBlock_01SequentialBlock_05BatchNorm_runningMean.assign(running_mean)  
+    self._12ParallelBlock_01SequentialBlock_05BatchNorm_runningVar.assign(running_var)  
+    (batchnorm36, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                tf.nn.relu(
+                    batchnorm35, # (111, 256, 8, 8)
+                    name='relu_466_',
+                ), # (111, 256, 8, 8)
+                filters=tf.transpose(
+                    self._12ParallelBlock_01SequentialBlock_07Conv2d_weight, # (1024, 256, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_465_',
+                ), # (1, 1, 256, 1024)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_467_',
+            ), # (111, 1024, 8, 8)
+            bias=self._12ParallelBlock_01SequentialBlock_07Conv2d_bias, # (1024)
+            data_format='NCHW',
+            name='bias_add_468_',
+        ), # (111, 1024, 8, 8)
+        scale=self._12ParallelBlock_01SequentialBlock_08BatchNorm_gamma, # (1024)
+        offset=self._12ParallelBlock_01SequentialBlock_08BatchNorm_beta, # (1024)
+        mean=self._12ParallelBlock_01SequentialBlock_08BatchNorm_runningMean, # (1024)
+        variance=self._12ParallelBlock_01SequentialBlock_08BatchNorm_runningVar, # (1024)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_469_',
+    )  
+    self._12ParallelBlock_01SequentialBlock_08BatchNorm_runningMean.assign(running_mean)  
+    self._12ParallelBlock_01SequentialBlock_08BatchNorm_runningVar.assign(running_var)  
+    val12 = tf.nn.relu(
+        tf.add(
+            batchnorm36, # (111, 1024, 8, 8)
+            val11, # (111, 1024, 8, 8)
+            name='add_470_',
+        ), # (111, 1024, 8, 8)
+        name='relu_471_',
+    )  
+    (batchnorm37, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                val12, # (111, 1024, 8, 8)
+                filters=tf.transpose(
+                    self._13ParallelBlock_01SequentialBlock_01Conv2d_weight, # (256, 1024, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_472_',
+                ), # (1, 1, 1024, 256)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_473_',
+            ), # (111, 256, 8, 8)
+            bias=self._13ParallelBlock_01SequentialBlock_01Conv2d_bias, # (256)
+            data_format='NCHW',
+            name='bias_add_474_',
+        ), # (111, 256, 8, 8)
+        scale=self._13ParallelBlock_01SequentialBlock_02BatchNorm_gamma, # (256)
+        offset=self._13ParallelBlock_01SequentialBlock_02BatchNorm_beta, # (256)
+        mean=self._13ParallelBlock_01SequentialBlock_02BatchNorm_runningMean, # (256)
+        variance=self._13ParallelBlock_01SequentialBlock_02BatchNorm_runningVar, # (256)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_475_',
+    )  
+    self._13ParallelBlock_01SequentialBlock_02BatchNorm_runningMean.assign(running_mean)  
+    self._13ParallelBlock_01SequentialBlock_02BatchNorm_runningVar.assign(running_var)  
+    (batchnorm38, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.convolution(
+            tf.nn.relu(
+                batchnorm37, # (111, 256, 8, 8)
+                name='relu_477_',
+            ), # (111, 256, 8, 8)
+            filters=tf.transpose(
+                self._13ParallelBlock_01SequentialBlock_04Conv2d_weight, # (256, 256, 3, 3)
+                perm=[2, 3, 1, 0],
+                name='transpose_476_',
+            ), # (3, 3, 256, 256)
+            strides=[1, 1],
+            padding='SAME',
+            dilations=[1, 1],
+            data_format='NCHW',
+            name='convolution_478_',
+        ), # (111, 256, 8, 8)
+        scale=self._13ParallelBlock_01SequentialBlock_05BatchNorm_gamma, # (256)
+        offset=self._13ParallelBlock_01SequentialBlock_05BatchNorm_beta, # (256)
+        mean=self._13ParallelBlock_01SequentialBlock_05BatchNorm_runningMean, # (256)
+        variance=self._13ParallelBlock_01SequentialBlock_05BatchNorm_runningVar, # (256)
+        epsilon=2.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_479_',
+    )  
+    self._13ParallelBlock_01SequentialBlock_05BatchNorm_runningMean.assign(running_mean)  
+    self._13ParallelBlock_01SequentialBlock_05BatchNorm_runningVar.assign(running_var)  
+    (batchnorm39, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                tf.nn.relu(
+                    batchnorm38, # (111, 256, 8, 8)
+                    name='relu_481_',
+                ), # (111, 256, 8, 8)
+                filters=tf.transpose(
+                    self._13ParallelBlock_01SequentialBlock_07Conv2d_weight, # (1024, 256, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_480_',
+                ), # (1, 1, 256, 1024)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_482_',
+            ), # (111, 1024, 8, 8)
+            bias=self._13ParallelBlock_01SequentialBlock_07Conv2d_bias, # (1024)
+            data_format='NCHW',
+            name='bias_add_483_',
+        ), # (111, 1024, 8, 8)
+        scale=self._13ParallelBlock_01SequentialBlock_08BatchNorm_gamma, # (1024)
+        offset=self._13ParallelBlock_01SequentialBlock_08BatchNorm_beta, # (1024)
+        mean=self._13ParallelBlock_01SequentialBlock_08BatchNorm_runningMean, # (1024)
+        variance=self._13ParallelBlock_01SequentialBlock_08BatchNorm_runningVar, # (1024)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_484_',
+    )  
+    self._13ParallelBlock_01SequentialBlock_08BatchNorm_runningMean.assign(running_mean)  
+    self._13ParallelBlock_01SequentialBlock_08BatchNorm_runningVar.assign(running_var)  
+    val13 = tf.nn.relu(
+        tf.add(
+            batchnorm39, # (111, 1024, 8, 8)
+            val12, # (111, 1024, 8, 8)
+            name='add_485_',
+        ), # (111, 1024, 8, 8)
+        name='relu_486_',
+    )  
+    (batchnorm40, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                val13, # (111, 1024, 8, 8)
+                filters=tf.transpose(
+                    self._14ParallelBlock_01SequentialBlock_01Conv2d_weight, # (256, 1024, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_487_',
+                ), # (1, 1, 1024, 256)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_488_',
+            ), # (111, 256, 8, 8)
+            bias=self._14ParallelBlock_01SequentialBlock_01Conv2d_bias, # (256)
+            data_format='NCHW',
+            name='bias_add_489_',
+        ), # (111, 256, 8, 8)
+        scale=self._14ParallelBlock_01SequentialBlock_02BatchNorm_gamma, # (256)
+        offset=self._14ParallelBlock_01SequentialBlock_02BatchNorm_beta, # (256)
+        mean=self._14ParallelBlock_01SequentialBlock_02BatchNorm_runningMean, # (256)
+        variance=self._14ParallelBlock_01SequentialBlock_02BatchNorm_runningVar, # (256)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_490_',
+    )  
+    self._14ParallelBlock_01SequentialBlock_02BatchNorm_runningMean.assign(running_mean)  
+    self._14ParallelBlock_01SequentialBlock_02BatchNorm_runningVar.assign(running_var)  
+    (batchnorm41, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.convolution(
+            tf.nn.relu(
+                batchnorm40, # (111, 256, 8, 8)
+                name='relu_492_',
+            ), # (111, 256, 8, 8)
+            filters=tf.transpose(
+                self._14ParallelBlock_01SequentialBlock_04Conv2d_weight, # (256, 256, 3, 3)
+                perm=[2, 3, 1, 0],
+                name='transpose_491_',
+            ), # (3, 3, 256, 256)
+            strides=[1, 1],
+            padding='SAME',
+            dilations=[1, 1],
+            data_format='NCHW',
+            name='convolution_493_',
+        ), # (111, 256, 8, 8)
+        scale=self._14ParallelBlock_01SequentialBlock_05BatchNorm_gamma, # (256)
+        offset=self._14ParallelBlock_01SequentialBlock_05BatchNorm_beta, # (256)
+        mean=self._14ParallelBlock_01SequentialBlock_05BatchNorm_runningMean, # (256)
+        variance=self._14ParallelBlock_01SequentialBlock_05BatchNorm_runningVar, # (256)
+        epsilon=2.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_494_',
+    )  
+    self._14ParallelBlock_01SequentialBlock_05BatchNorm_runningMean.assign(running_mean)  
+    self._14ParallelBlock_01SequentialBlock_05BatchNorm_runningVar.assign(running_var)  
+    (batchnorm42, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                tf.nn.relu(
+                    batchnorm41, # (111, 256, 8, 8)
+                    name='relu_496_',
+                ), # (111, 256, 8, 8)
+                filters=tf.transpose(
+                    self._14ParallelBlock_01SequentialBlock_07Conv2d_weight, # (1024, 256, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_495_',
+                ), # (1, 1, 256, 1024)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_497_',
+            ), # (111, 1024, 8, 8)
+            bias=self._14ParallelBlock_01SequentialBlock_07Conv2d_bias, # (1024)
+            data_format='NCHW',
+            name='bias_add_498_',
+        ), # (111, 1024, 8, 8)
+        scale=self._14ParallelBlock_01SequentialBlock_08BatchNorm_gamma, # (1024)
+        offset=self._14ParallelBlock_01SequentialBlock_08BatchNorm_beta, # (1024)
+        mean=self._14ParallelBlock_01SequentialBlock_08BatchNorm_runningMean, # (1024)
+        variance=self._14ParallelBlock_01SequentialBlock_08BatchNorm_runningVar, # (1024)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_499_',
+    )  
+    self._14ParallelBlock_01SequentialBlock_08BatchNorm_runningMean.assign(running_mean)  
+    self._14ParallelBlock_01SequentialBlock_08BatchNorm_runningVar.assign(running_var)  
+    val14 = tf.nn.relu(
+        tf.add(
+            batchnorm42, # (111, 1024, 8, 8)
+            val13, # (111, 1024, 8, 8)
+            name='add_500_',
+        ), # (111, 1024, 8, 8)
+        name='relu_501_',
+    )  
+    (batchnorm43, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                val14, # (111, 1024, 8, 8)
+                filters=tf.transpose(
+                    self._15ParallelBlock_01SequentialBlock_01Conv2d_weight, # (512, 1024, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_502_',
+                ), # (1, 1, 1024, 512)
+                strides=[2, 2],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_503_',
+            ), # (111, 512, 4, 4)
+            bias=self._15ParallelBlock_01SequentialBlock_01Conv2d_bias, # (512)
+            data_format='NCHW',
+            name='bias_add_504_',
+        ), # (111, 512, 4, 4)
+        scale=self._15ParallelBlock_01SequentialBlock_02BatchNorm_gamma, # (512)
+        offset=self._15ParallelBlock_01SequentialBlock_02BatchNorm_beta, # (512)
+        mean=self._15ParallelBlock_01SequentialBlock_02BatchNorm_runningMean, # (512)
+        variance=self._15ParallelBlock_01SequentialBlock_02BatchNorm_runningVar, # (512)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_505_',
+    )  
+    self._15ParallelBlock_01SequentialBlock_02BatchNorm_runningMean.assign(running_mean)  
+    self._15ParallelBlock_01SequentialBlock_02BatchNorm_runningVar.assign(running_var)  
+    (batchnorm44, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.convolution(
+            tf.nn.relu(
+                batchnorm43, # (111, 512, 4, 4)
+                name='relu_507_',
+            ), # (111, 512, 4, 4)
+            filters=tf.transpose(
+                self._15ParallelBlock_01SequentialBlock_04Conv2d_weight, # (512, 512, 3, 3)
+                perm=[2, 3, 1, 0],
+                name='transpose_506_',
+            ), # (3, 3, 512, 512)
+            strides=[1, 1],
+            padding='SAME',
+            dilations=[1, 1],
+            data_format='NCHW',
+            name='convolution_508_',
+        ), # (111, 512, 4, 4)
+        scale=self._15ParallelBlock_01SequentialBlock_05BatchNorm_gamma, # (512)
+        offset=self._15ParallelBlock_01SequentialBlock_05BatchNorm_beta, # (512)
+        mean=self._15ParallelBlock_01SequentialBlock_05BatchNorm_runningMean, # (512)
+        variance=self._15ParallelBlock_01SequentialBlock_05BatchNorm_runningVar, # (512)
+        epsilon=2.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_509_',
+    )  
+    self._15ParallelBlock_01SequentialBlock_05BatchNorm_runningMean.assign(running_mean)  
+    self._15ParallelBlock_01SequentialBlock_05BatchNorm_runningVar.assign(running_var)  
+    (batchnorm45, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                tf.nn.relu(
+                    batchnorm44, # (111, 512, 4, 4)
+                    name='relu_511_',
+                ), # (111, 512, 4, 4)
+                filters=tf.transpose(
+                    self._15ParallelBlock_01SequentialBlock_07Conv2d_weight, # (2048, 512, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_510_',
+                ), # (1, 1, 512, 2048)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_512_',
+            ), # (111, 2048, 4, 4)
+            bias=self._15ParallelBlock_01SequentialBlock_07Conv2d_bias, # (2048)
+            data_format='NCHW',
+            name='bias_add_513_',
+        ), # (111, 2048, 4, 4)
+        scale=self._15ParallelBlock_01SequentialBlock_08BatchNorm_gamma, # (2048)
+        offset=self._15ParallelBlock_01SequentialBlock_08BatchNorm_beta, # (2048)
+        mean=self._15ParallelBlock_01SequentialBlock_08BatchNorm_runningMean, # (2048)
+        variance=self._15ParallelBlock_01SequentialBlock_08BatchNorm_runningVar, # (2048)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_514_',
+    )  
+    self._15ParallelBlock_01SequentialBlock_08BatchNorm_runningMean.assign(running_mean)  
+    self._15ParallelBlock_01SequentialBlock_08BatchNorm_runningVar.assign(running_var)  
+    (batchnorm46, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.convolution(
+            val14, # (111, 1024, 8, 8)
+            filters=tf.transpose(
+                self._15ParallelBlock_02SequentialBlock_01Conv2d_weight, # (2048, 1024, 1, 1)
+                perm=[2, 3, 1, 0],
+                name='transpose_515_',
+            ), # (1, 1, 1024, 2048)
+            strides=[2, 2],
+            padding='VALID',
+            dilations=[1, 1],
+            data_format='NCHW',
+            name='convolution_516_',
+        ), # (111, 2048, 4, 4)
+        scale=self._15ParallelBlock_02SequentialBlock_02BatchNorm_gamma, # (2048)
+        offset=self._15ParallelBlock_02SequentialBlock_02BatchNorm_beta, # (2048)
+        mean=self._15ParallelBlock_02SequentialBlock_02BatchNorm_runningMean, # (2048)
+        variance=self._15ParallelBlock_02SequentialBlock_02BatchNorm_runningVar, # (2048)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_517_',
+    )  
+    self._15ParallelBlock_02SequentialBlock_02BatchNorm_runningMean.assign(running_mean)  
+    self._15ParallelBlock_02SequentialBlock_02BatchNorm_runningVar.assign(running_var)  
+    val15 = tf.nn.relu(
+        tf.add(
+            batchnorm45, # (111, 2048, 4, 4)
+            batchnorm46, # (111, 2048, 4, 4)
+            name='add_518_',
+        ), # (111, 2048, 4, 4)
+        name='relu_519_',
+    )  
+    (batchnorm47, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                val15, # (111, 2048, 4, 4)
+                filters=tf.transpose(
+                    self._16ParallelBlock_01SequentialBlock_01Conv2d_weight, # (512, 2048, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_520_',
+                ), # (1, 1, 2048, 512)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_521_',
+            ), # (111, 512, 4, 4)
+            bias=self._16ParallelBlock_01SequentialBlock_01Conv2d_bias, # (512)
+            data_format='NCHW',
+            name='bias_add_522_',
+        ), # (111, 512, 4, 4)
+        scale=self._16ParallelBlock_01SequentialBlock_02BatchNorm_gamma, # (512)
+        offset=self._16ParallelBlock_01SequentialBlock_02BatchNorm_beta, # (512)
+        mean=self._16ParallelBlock_01SequentialBlock_02BatchNorm_runningMean, # (512)
+        variance=self._16ParallelBlock_01SequentialBlock_02BatchNorm_runningVar, # (512)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_523_',
+    )  
+    self._16ParallelBlock_01SequentialBlock_02BatchNorm_runningMean.assign(running_mean)  
+    self._16ParallelBlock_01SequentialBlock_02BatchNorm_runningVar.assign(running_var)  
+    (batchnorm48, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.convolution(
+            tf.nn.relu(
+                batchnorm47, # (111, 512, 4, 4)
+                name='relu_525_',
+            ), # (111, 512, 4, 4)
+            filters=tf.transpose(
+                self._16ParallelBlock_01SequentialBlock_04Conv2d_weight, # (512, 512, 3, 3)
+                perm=[2, 3, 1, 0],
+                name='transpose_524_',
+            ), # (3, 3, 512, 512)
+            strides=[1, 1],
+            padding='SAME',
+            dilations=[1, 1],
+            data_format='NCHW',
+            name='convolution_526_',
+        ), # (111, 512, 4, 4)
+        scale=self._16ParallelBlock_01SequentialBlock_05BatchNorm_gamma, # (512)
+        offset=self._16ParallelBlock_01SequentialBlock_05BatchNorm_beta, # (512)
+        mean=self._16ParallelBlock_01SequentialBlock_05BatchNorm_runningMean, # (512)
+        variance=self._16ParallelBlock_01SequentialBlock_05BatchNorm_runningVar, # (512)
+        epsilon=2.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_527_',
+    )  
+    self._16ParallelBlock_01SequentialBlock_05BatchNorm_runningMean.assign(running_mean)  
+    self._16ParallelBlock_01SequentialBlock_05BatchNorm_runningVar.assign(running_var)  
+    (batchnorm49, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                tf.nn.relu(
+                    batchnorm48, # (111, 512, 4, 4)
+                    name='relu_529_',
+                ), # (111, 512, 4, 4)
+                filters=tf.transpose(
+                    self._16ParallelBlock_01SequentialBlock_07Conv2d_weight, # (2048, 512, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_528_',
+                ), # (1, 1, 512, 2048)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_530_',
+            ), # (111, 2048, 4, 4)
+            bias=self._16ParallelBlock_01SequentialBlock_07Conv2d_bias, # (2048)
+            data_format='NCHW',
+            name='bias_add_531_',
+        ), # (111, 2048, 4, 4)
+        scale=self._16ParallelBlock_01SequentialBlock_08BatchNorm_gamma, # (2048)
+        offset=self._16ParallelBlock_01SequentialBlock_08BatchNorm_beta, # (2048)
+        mean=self._16ParallelBlock_01SequentialBlock_08BatchNorm_runningMean, # (2048)
+        variance=self._16ParallelBlock_01SequentialBlock_08BatchNorm_runningVar, # (2048)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_532_',
+    )  
+    self._16ParallelBlock_01SequentialBlock_08BatchNorm_runningMean.assign(running_mean)  
+    self._16ParallelBlock_01SequentialBlock_08BatchNorm_runningVar.assign(running_var)  
+    val16 = tf.nn.relu(
+        tf.add(
+            batchnorm49, # (111, 2048, 4, 4)
+            val15, # (111, 2048, 4, 4)
+            name='add_533_',
+        ), # (111, 2048, 4, 4)
+        name='relu_534_',
+    )  
+    (batchnorm50, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                val16, # (111, 2048, 4, 4)
+                filters=tf.transpose(
+                    self._17ParallelBlock_01SequentialBlock_01Conv2d_weight, # (512, 2048, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_535_',
+                ), # (1, 1, 2048, 512)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_536_',
+            ), # (111, 512, 4, 4)
+            bias=self._17ParallelBlock_01SequentialBlock_01Conv2d_bias, # (512)
+            data_format='NCHW',
+            name='bias_add_537_',
+        ), # (111, 512, 4, 4)
+        scale=self._17ParallelBlock_01SequentialBlock_02BatchNorm_gamma, # (512)
+        offset=self._17ParallelBlock_01SequentialBlock_02BatchNorm_beta, # (512)
+        mean=self._17ParallelBlock_01SequentialBlock_02BatchNorm_runningMean, # (512)
+        variance=self._17ParallelBlock_01SequentialBlock_02BatchNorm_runningVar, # (512)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_538_',
+    )  
+    self._17ParallelBlock_01SequentialBlock_02BatchNorm_runningMean.assign(running_mean)  
+    self._17ParallelBlock_01SequentialBlock_02BatchNorm_runningVar.assign(running_var)  
+    (batchnorm51, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.convolution(
+            tf.nn.relu(
+                batchnorm50, # (111, 512, 4, 4)
+                name='relu_540_',
+            ), # (111, 512, 4, 4)
+            filters=tf.transpose(
+                self._17ParallelBlock_01SequentialBlock_04Conv2d_weight, # (512, 512, 3, 3)
+                perm=[2, 3, 1, 0],
+                name='transpose_539_',
+            ), # (3, 3, 512, 512)
+            strides=[1, 1],
+            padding='SAME',
+            dilations=[1, 1],
+            data_format='NCHW',
+            name='convolution_541_',
+        ), # (111, 512, 4, 4)
+        scale=self._17ParallelBlock_01SequentialBlock_05BatchNorm_gamma, # (512)
+        offset=self._17ParallelBlock_01SequentialBlock_05BatchNorm_beta, # (512)
+        mean=self._17ParallelBlock_01SequentialBlock_05BatchNorm_runningMean, # (512)
+        variance=self._17ParallelBlock_01SequentialBlock_05BatchNorm_runningVar, # (512)
+        epsilon=2.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_542_',
+    )  
+    self._17ParallelBlock_01SequentialBlock_05BatchNorm_runningMean.assign(running_mean)  
+    self._17ParallelBlock_01SequentialBlock_05BatchNorm_runningVar.assign(running_var)  
+    (batchnorm52, running_mean, running_var) = tf.compat.v1.nn.fused_batch_norm(
+        tf.nn.bias_add(
+            tf.nn.convolution(
+                tf.nn.relu(
+                    batchnorm51, # (111, 512, 4, 4)
+                    name='relu_544_',
+                ), # (111, 512, 4, 4)
+                filters=tf.transpose(
+                    self._17ParallelBlock_01SequentialBlock_07Conv2d_weight, # (2048, 512, 1, 1)
+                    perm=[2, 3, 1, 0],
+                    name='transpose_543_',
+                ), # (1, 1, 512, 2048)
+                strides=[1, 1],
+                padding='VALID',
+                dilations=[1, 1],
+                data_format='NCHW',
+                name='convolution_545_',
+            ), # (111, 2048, 4, 4)
+            bias=self._17ParallelBlock_01SequentialBlock_07Conv2d_bias, # (2048)
+            data_format='NCHW',
+            name='bias_add_546_',
+        ), # (111, 2048, 4, 4)
+        scale=self._17ParallelBlock_01SequentialBlock_08BatchNorm_gamma, # (2048)
+        offset=self._17ParallelBlock_01SequentialBlock_08BatchNorm_beta, # (2048)
+        mean=self._17ParallelBlock_01SequentialBlock_08BatchNorm_runningMean, # (2048)
+        variance=self._17ParallelBlock_01SequentialBlock_08BatchNorm_runningVar, # (2048)
+        epsilon=1.0E-5,
+        is_training=True,
+        exponential_avg_factor=0.9,
+        data_format='NCHW',
+        name='fused_batch_norm_547_',
+    )  
+    self._17ParallelBlock_01SequentialBlock_08BatchNorm_runningMean.assign(running_mean)  
+    self._17ParallelBlock_01SequentialBlock_08BatchNorm_runningVar.assign(running_var)  
+    result = tf.reshape(
+        tf.nn.bias_add(
+            tf.matmul(
+                tf.reshape(
+                    tf.reshape(
+                        tf.reduce_mean(
+                            tf.nn.relu(
+                                tf.add(
+                                    batchnorm52, # (111, 2048, 4, 4)
+                                    val16, # (111, 2048, 4, 4)
+                                    name='add_548_',
+                                ), # (111, 2048, 4, 4)
+                                name='relu_549_',
+                            ), # (111, 2048, 4, 4)
+                            axis=[2, 3],
+                            name='reduce_mean_550_',
+                        ), # (111, 2048, 1, 1)
+                        shape=[-1, 2048],
+                        name='reshape_551_',
+                    ), # (111, 2048)
+                    shape=[-1, 2048],
+                    name='reshape_552_',
+                ), # (111, 2048)
+                b=self._20Linear_weight, # (10, 2048)
+                transpose_b=True,
+                name='matmul_553_',
+            ), # (111, 10)
+            bias=self._20Linear_bias, # (10)
+            data_format=None,
+            name='bias_add_554_',
+        ), # (111, 10)
+        shape=[-1, 10],
+        name='reshape_555_',
+    )
+    return result
+
+## 1
+def loss(label, prediction):
+    result = tf.reduce_mean(
+        tf.negative(
+            tf.gather(
+                tf.nn.log_softmax(
+                    prediction, # (111, 10)
+                    axis=-1,
+                    name='log_softmax_556_',
+                ), # (111, 10)
+                indices=label, # (111)
+                batch_dims=1,
+                name='gather_557_',
+            ), # (111, 1)
+            name='negative_558_',
+        ), # (111, 1)
+        name='reduce_mean_559_',
+    )
+    return result
+
+# number of epochs was 1
+# number of batches was 111
+


### PR DESCRIPTION
## Description ##

Supported by a dedicated training listener, algebraic operations executed during training can be recorded and stored as Python program.

- If this change is a backward incompatible change, why must this change be made?

In order not to record a concrete batch size that is used during training, -1 is now used at some places in the existing Java code as value for the batch dimension. This is backwards compatible as underlying engines would infer the right value from the size of the array.

- Interesting edge cases to note here

In case different epochs or even different batches within an epoch use different objective / loss functions, multiple objective / loss functions are generated (a Python comment will indicate how often they are "used"). The MNIST and ResNet examples only generated one objective/loss function which are unit-tested and also tested by me in a tensorflow program to yield the same results as the original DJL model. It will be interesting to test other models in the future.

The algebraic logging works only with mxnet as of now the PyTorch engine doesn't build up a data structure describing the executed operation and its arguments.
