### PR TITLE
[ci] refactor cloudwatch metric publishing to avoid needing changes i…

### DIFF
--- a/.github/workflows/codeql-analysis-java.yml
+++ b/.github/workflows/codeql-analysis-java.yml
@@ -73,10 +73,3 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
-
-  publish-success-metric:
-    needs: [ analyze ]
-    if: always()
-    uses: ./.github/workflows/publish-job-success.yml
-    with:
-      metric-name: DJL-CodeQL-Failure

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -57,10 +57,3 @@ jobs:
           file: docker/spark/Dockerfile
           build-args: DJL_VERSION=${DJL_VERSION}
           tags: deepjavalibrary/djl-spark:${{ env.DJL_VERSION }}-cpu
-
-  publish-success-metric:
-    needs: [ publish ]
-    if: always()
-    uses: ./.github/workflows/publish-job-success.yml
-    with:
-      metric-name: DJL-SparkDockerPublish-Failure

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -65,10 +65,3 @@ jobs:
         run: |
           aws s3 sync ../site s3://djl-ai/documentation/nightly --delete
           aws cloudfront create-invalidation --distribution-id E733IIDCG0G5U --paths "/*"
-
-  publish-success-metric:
-    needs: [ documentation ]
-    if: always()
-    uses: ./.github/workflows/publish-job-success.yml
-    with:
-      metric-name: DJL-DocumentationPublish-Failure

--- a/.github/workflows/native_jni_s3_paddle.yml
+++ b/.github/workflows/native_jni_s3_paddle.yml
@@ -108,10 +108,3 @@ jobs:
           PADDLE_VERSION="$(cat gradle.properties | awk -F '=' '/paddlepaddle_version/ {print $2}')"
           aws s3 sync jnilib s3://djl-ai/publish/paddlepaddle-${PADDLE_VERSION}/jnilib
           aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/paddlepaddle-${PADDLE_VERSION}/jnilib*"
-
-  publish-success-metric:
-    needs: [ publish ]
-    if: always()
-    uses: ./.github/workflows/publish-job-success.yml
-    with:
-      metric-name: DJL-NativeJNIPaddleS3Publish-Failure

--- a/.github/workflows/native_jni_s3_pytorch.yml
+++ b/.github/workflows/native_jni_s3_pytorch.yml
@@ -306,10 +306,3 @@ jobs:
           cd /home/ubuntu/djl_benchmark_script/scripts
           instance_id=${{ needs.create-aarch64-runner.outputs.aarch64_instance_id }}
           ./stop_instance.sh $instance_id
-
-  publish-success-metric:
-    needs: [ build-pytorch-jni-macos, build-pytorch-jni-linux, build-pytorch-jni-precxx11, build-pytorch-jni-windows, build-pytorch-jni-arm64-macos, stop-runners ]
-    if: always()
-    uses: ./.github/workflows/publish-job-success.yml
-    with:
-      metric-name: DJL-NativeJNIPytorchS3Publish-Failure

--- a/.github/workflows/native_jni_s3_pytorch_android.yml
+++ b/.github/workflows/native_jni_s3_pytorch_android.yml
@@ -43,10 +43,3 @@ jobs:
           PYTORCH_VERSION=${PYTORCH_VERSION:-$(cat gradle.properties | awk -F '=' '/pytorch_version/ {print $2}')}
           aws s3 sync engines/pytorch/pytorch-native/jnilib s3://djl-ai/publish/pytorch/${PYTORCH_VERSION}/jnilib
           aws cloudfront create-invalidation --distribution-id E371VB8JQ6NRVY --paths "/pytorch/${PYTORCH_VERSION}/jnilib*"
-
-  publish-success-metric:
-    needs: [ build-pytorch-jni-android ]
-    if: always()
-    uses: ./.github/workflows/publish-job-success.yml
-    with:
-      metric-name: DJL-NativeJNIPytorchAndroidS3Publish-Failure

--- a/.github/workflows/nightly_android.yml
+++ b/.github/workflows/nightly_android.yml
@@ -31,10 +31,3 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: cd android/core && ./gradlew cAT
-
-  publish-success-metric:
-    needs: [ build ]
-    if: always()
-    uses: ./.github/workflows/publish-job-success.yml
-    with:
-      metric-name: DJL-AndroidIntegrationTests-Failure

--- a/.github/workflows/nightly_publish.yml
+++ b/.github/workflows/nightly_publish.yml
@@ -255,10 +255,3 @@ jobs:
           cd /home/ubuntu/djl_benchmark_script/scripts
           instance_id=${{ needs.create-runners.outputs.gpu_1_instance_id }}
           ./stop_instance.sh $instance_id
-
-  publish-success-metric:
-    needs: [ publish, stop-runners ]
-    if: always()
-    uses: ./.github/workflows/publish-job-success.yml
-    with:
-      metric-name: DJL-NightlyIntegrationTestsPublish-Failure

--- a/.github/workflows/publish-job-success.yml
+++ b/.github/workflows/publish-job-success.yml
@@ -1,16 +1,16 @@
 name: Publish Job Success Metric to CloudWatch
 
 on:
-  workflow_call:
-    inputs:
-      metric-name:
-        description: "The name of the job to publish a metric for"
-        type: string
-        required: true
+  workflow_run:
+    workflows: "*"
+    types:
+      - completed
+    branches:
+      - master
 
 jobs:
   publish-job-success-to-cloudwatch:
-    if: ${{ github.event_name == 'schedule' }}
+    if: ${{ github.event.workflow_run.event == "schedule" }}
     runs-on: [ self-hosted, scheduler ]
     steps:
       - name: Configure AWS Credentials
@@ -18,10 +18,16 @@ jobs:
         with:
           aws-region: us-west-2
       - name: Publish Job Success Metric
+        env:
+          WORKFLOW_NAME: ${{ github.event.workflow_run.display_title }}
+          REPO_NAME: ${{ github.event.workflow_run.repository.name }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         run: |
-          [[ ${{ job.status }} == "success" ]]
+          workflow_name=$(echo "$WORKFLOW_NAME" | tr -d ' ')
+          metric_name="${REPO_NAME}-${workflow_name}-Failure"
+          [[ "$CONCLUSION" == "success" ]]
           failedBuild=$?
           aws cloudwatch put-metric-data --namespace GithubCI \
-            --metric-name ${{ inputs.metric-name }} \
+            --metric-name "$metric_name" \
             --value $failedBuild \
             --unit Count

--- a/.github/workflows/publish_android_packages.yml
+++ b/.github/workflows/publish_android_packages.yml
@@ -50,10 +50,3 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingPassword }}
           ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.ORG_GRADLE_PROJECT_ossrhUsername }}
           ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.ORG_GRADLE_PROJECT_ossrhPassword }}
-
-  publish-success-metric:
-    needs: [ release-android ]
-    if: always()
-    uses: ./.github/workflows/publish-job-success.yml
-    with:
-      metric-name: DJL-AndroidPublish-Failurei

--- a/.github/workflows/serving_publish.yml
+++ b/.github/workflows/serving_publish.yml
@@ -105,10 +105,3 @@ jobs:
           ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.ORG_GRADLE_PROJECT_ossrhUsername }}
           ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.ORG_GRADLE_PROJECT_ossrhPassword }}
           DJL_STAGING: ${{ github.event.inputs.repo-id }}
-
-  publish-success-metric:
-    needs: [ publish ]
-    if: always()
-    uses: ./.github/workflows/publish-job-success.yml
-    with:
-      metric-name: DJL-DJLServingPublish-Failure


### PR DESCRIPTION
…n primary workflows

## Description ##

TLDR: Fixes cw metric publishing for scheduled workflow runs

The problem with the previous implementation of publishing metrics to cw for failed builds is that there is no simple way to parse the overall status of an in progress workflow (previous implementation is broken). To do so, we'd need to annotate each step with an id and parse the `steps` context, or have each step output it's status and parse all the outputs to determine the status.

Instead, we can use a workflow triggered by the `workflow_run` event for `completed` workflows. This triggered workflow can parse the status, name, and repo of the triggering workflow and use that to publish reliable metrics to CloudWatch.

I have tested this in a personal repo here https://github.com/siddvenk/github-workflow-testing/actions/workflows/forking-workflow.yml, and it works as expected.

The other benefit here is we don't have to change any of the existing workflows, or new workflows to include a step to publish metrics. The CW publishing workflow only runs for workflows triggered by the scheduled event on the master branch of the repo.

One thing this does not achieve is publishing fine-grained metrics indicating which step of a workflow failed. That could be nice, but I think it's not necessary since we really just need to be alerted whenever a workflow fails.
