### PR TITLE
[fix][ci] avoid early exit of script for failure case

### DIFF
--- a/.github/workflows/publish-job-success.yml
+++ b/.github/workflows/publish-job-success.yml
@@ -30,8 +30,7 @@ jobs:
         run: |
           workflow_name=$(echo "$WORKFLOW_NAME" | tr -d ' ')
           metric_name="${REPO_NAME}-${workflow_name}-Failure"
-          [[ "$CONCLUSION" == "success" ]]
-          failedBuild=$?
+          failedBuild=$([ "$CONCLUSION" == "success" ]; echo $?)
           aws cloudwatch put-metric-data --namespace GithubCI \
             --metric-name "$metric_name" \
             --value $failedBuild \


### PR DESCRIPTION
## Description ##

publish-job-success workflow exits with failure because one of the script steps returns exit code 1 when the triggering workflow fails.
