### PR TITLE
Thread-safe FaceDetectionTranslator

### DIFF
--- a/examples/src/main/java/ai/djl/examples/inference/face/FaceDetectionTranslator.java
+++ b/examples/src/main/java/ai/djl/examples/inference/face/FaceDetectionTranslator.java
@@ -40,8 +40,6 @@ public class FaceDetectionTranslator implements Translator<Image, DetectedObject
     private double[] variance;
     private int[][] scales;
     private int[] steps;
-    private int width;
-    private int height;
 
     public FaceDetectionTranslator(
             double confThresh,
@@ -61,8 +59,10 @@ public class FaceDetectionTranslator implements Translator<Image, DetectedObject
     /** {@inheritDoc} */
     @Override
     public NDList processInput(TranslatorContext ctx, Image input) {
-        width = input.getWidth();
-        height = input.getHeight();
+
+        ctx.setAttachment("width", input.getWidth());
+        ctx.setAttachment("height", input.getHeight());
+
         NDArray array = input.toNDArray(ctx.getNDManager(), Image.Flag.COLOR);
         array = array.transpose(2, 0, 1).flip(0); // HWC -> CHW RGB -> BGR
         // The network by default takes float32
@@ -78,6 +78,10 @@ public class FaceDetectionTranslator implements Translator<Image, DetectedObject
     /** {@inheritDoc} */
     @Override
     public DetectedObjects processOutput(TranslatorContext ctx, NDList list) {
+
+        int width = (int) ctx.getAttachment("width");
+        int height = (int) ctx.getAttachment("height");
+
         NDManager manager = ctx.getNDManager();
         double scaleXY = variance[0];
         double scaleWH = variance[1];


### PR DESCRIPTION
In my application, I employed the `FaceDetectionTranslator`, but encountered an issue with its lack of thread safety. When attempting to process multiple images simultaneously, `EngineError`s occurred. After investigation, I identified the root cause as being related to the variables for width and height.

Fortunately, the `TranslatorContext`'s capacity to carry attachments makes resolving this issue relatively straightforward.