### PR TITLE
[api] Upgrades commons compress to 1.26.0 for CVE

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,7 +1,9 @@
 dependencies {
     api "com.google.code.gson:gson:${gson_version}"
     api "net.java.dev.jna:jna:${jna_version}"
-    api "org.apache.commons:commons-compress:${commons_compress_version}"
+    api ("org.apache.commons:commons-compress:${commons_compress_version}") {
+        exclude group: "org.apache.commons", module: "commons-lang3"
+    }
     api "org.slf4j:slf4j-api:${slf4j_version}"
 
     testImplementation("org.testng:testng:${testng_version}") {

--- a/api/src/main/java/ai/djl/util/TarUtils.java
+++ b/api/src/main/java/ai/djl/util/TarUtils.java
@@ -15,7 +15,7 @@ package ai.djl.util;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
-import org.apache.commons.compress.utils.CloseShieldFilterInputStream;
+import org.apache.commons.io.input.CloseShieldInputStream;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -44,7 +44,7 @@ public final class TarUtils {
         } else {
             bis = new BufferedInputStream(is);
         }
-        bis = new CloseShieldFilterInputStream(bis);
+        bis = CloseShieldInputStream.wrap(bis);
         try (TarArchiveInputStream tis = new TarArchiveInputStream(bis)) {
             TarArchiveEntry entry;
             while ((entry = tis.getNextEntry()) != null) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ lightgbm_version=3.2.110
 rapis_version=22.12.0
 
 commons_cli_version=1.6.0
-commons_compress_version=1.25.0
+commons_compress_version=1.26.0
 commons_csv_version=1.10.0
 commons_logging_version=1.2
 gson_version=2.10.1


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
