### PR TITLE
[api] Allows to use relative jar uri for cache folder name

### DIFF
--- a/api/src/main/java/ai/djl/repository/JarRepository.java
+++ b/api/src/main/java/ai/djl/repository/JarRepository.java
@@ -42,13 +42,16 @@ public class JarRepository extends AbstractRepository {
     private String artifactId;
     private String modelName;
     private String queryString;
+    private String originalUri;
 
     private Metadata metadata;
     private boolean resolved;
 
-    JarRepository(String name, URI uri, String fileName, String queryString) {
+    JarRepository(String name, URI uri, String fileName, URI realUri) {
         super(name, uri);
-        this.queryString = queryString;
+        this.uri = realUri;
+        queryString = uri.getRawQuery();
+        originalUri = uri.toString();
         modelName = arguments.get("model_name");
         artifactId = arguments.get("artifact_id");
         if (artifactId == null) {
@@ -123,8 +126,14 @@ public class JarRepository extends AbstractRepository {
         metadata = new Metadata.MatchAllMetadata();
         metadata.setArtifactId(artifactId);
         metadata.setArtifacts(Collections.singletonList(artifact));
-        String hash =
-                Utils.hash(queryString == null ? uri.toString() : uri.toString() + queryString);
+        String hashKey;
+        if (Boolean.parseBoolean(arguments.get("ignore_real_uri"))) {
+            hashKey = originalUri;
+        } else {
+            hashKey = queryString == null ? uri.toString() : uri.toString() + queryString;
+        }
+
+        String hash = Utils.hash(hashKey);
         MRL mrl = model(Application.UNDEFINED, DefaultModelZoo.GROUP_ID, hash);
         metadata.setRepositoryUri(mrl.toURI());
 

--- a/api/src/main/java/ai/djl/repository/RepositoryFactoryImpl.java
+++ b/api/src/main/java/ai/djl/repository/RepositoryFactoryImpl.java
@@ -144,7 +144,6 @@ class RepositoryFactoryImpl implements RepositoryFactory {
         @Override
         public Repository newInstance(String name, URI uri) {
             String p = uri.getPath();
-            String queryString = uri.getRawQuery();
             if (p.startsWith("/")) {
                 p = p.substring(1);
             }
@@ -152,19 +151,22 @@ class RepositoryFactoryImpl implements RepositoryFactory {
             if (u == null) {
                 throw new IllegalArgumentException("Resource not found: " + uri);
             }
+
+            URI realUri;
             try {
-                uri = u.toURI();
+                // resolve real uri: jar:file:/path/my_lib.jar!/model.zip
+                realUri = u.toURI();
             } catch (URISyntaxException e) {
                 throw new IllegalArgumentException("Resource not found: " + uri, e);
             }
 
-            Path path = Paths.get(parseFilePath(uri));
+            Path path = Paths.get(parseFilePath(realUri));
             String fileName = path.toFile().getName();
             if (FilenameUtils.isArchiveFile(fileName)) {
                 fileName = FilenameUtils.getNamePart(fileName);
             }
 
-            return new JarRepository(name, uri, fileName, queryString);
+            return new JarRepository(name, uri, fileName, realUri);
         }
 
         /** {@inheritDoc} */

--- a/api/src/test/java/ai/djl/repository/JarRepositoryTest.java
+++ b/api/src/test/java/ai/djl/repository/JarRepositoryTest.java
@@ -45,7 +45,7 @@ public class JarRepositoryTest {
         URL[] url = {jarFile.toUri().toURL()};
         try {
             Thread.currentThread().setContextClassLoader(new URLClassLoader(url));
-            Repository repo = Repository.newInstance("test", "jar:///test.zip?hash=1");
+            Repository repo = Repository.newInstance("test", "jar:///test.zip");
             Assert.assertEquals("test", repo.getName());
             Assert.assertTrue(repo.isRemote());
 
@@ -55,6 +55,12 @@ public class JarRepositoryTest {
             Artifact artifact = repo.resolve(list.get(0), null);
             repo.prepare(artifact);
             Assert.assertEquals(1, artifact.getFiles().size());
+
+            repo = Repository.newInstance("test", "jar:///test.zip?ignore_real_uri=true");
+            list = repo.getResources();
+            artifact = repo.resolve(list.get(0), null);
+            Path p = repo.getResourceDirectory(artifact);
+            Assert.assertFalse(Files.exists(p));
         } finally {
             Thread.currentThread().setContextClassLoader(null);
         }


### PR DESCRIPTION
Fixes: #3025

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
