### PR TITLE
support includeTokenTypes in TextEmbeddingBatchTranslator

### DIFF
--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/translator/TextEmbeddingBatchTranslator.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/translator/TextEmbeddingBatchTranslator.java
@@ -28,16 +28,19 @@ public class TextEmbeddingBatchTranslator implements NoBatchifyTranslator<String
     private Batchifier batchifier;
     private boolean normalize;
     private String pooling;
+    private boolean includeTokenTypes;
 
     TextEmbeddingBatchTranslator(
             HuggingFaceTokenizer tokenizer,
             Batchifier batchifier,
             String pooling,
-            boolean normalize) {
+            boolean normalize,
+            boolean includeTokenTypes) {
         this.tokenizer = tokenizer;
         this.batchifier = batchifier;
         this.pooling = pooling;
         this.normalize = normalize;
+        this.includeTokenTypes = includeTokenTypes;
     }
 
     /** {@inheritDoc} */
@@ -48,7 +51,7 @@ public class TextEmbeddingBatchTranslator implements NoBatchifyTranslator<String
         ctx.setAttachment("encodings", encodings);
         NDList[] batch = new NDList[encodings.length];
         for (int i = 0; i < encodings.length; ++i) {
-            batch[i] = encodings[i].toNDList(manager, false);
+            batch[i] = encodings[i].toNDList(manager, includeTokenTypes);
         }
         return batchifier.batchify(batch);
     }

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/translator/TextEmbeddingTranslator.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/translator/TextEmbeddingTranslator.java
@@ -81,7 +81,7 @@ public class TextEmbeddingTranslator implements Translator<String, float[]> {
     @Override
     public TextEmbeddingBatchTranslator toBatchTranslator(Batchifier batchifier) {
         tokenizer.enableBatch();
-        return new TextEmbeddingBatchTranslator(tokenizer, batchifier, pooling, normalize);
+        return new TextEmbeddingBatchTranslator(tokenizer, batchifier, pooling, normalize, includeTokenTypes);
     }
 
     static NDArray processEmbedding(

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/translator/TextEmbeddingTranslator.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/translator/TextEmbeddingTranslator.java
@@ -81,7 +81,8 @@ public class TextEmbeddingTranslator implements Translator<String, float[]> {
     @Override
     public TextEmbeddingBatchTranslator toBatchTranslator(Batchifier batchifier) {
         tokenizer.enableBatch();
-        return new TextEmbeddingBatchTranslator(tokenizer, batchifier, pooling, normalize, includeTokenTypes);
+        return new TextEmbeddingBatchTranslator(
+                tokenizer, batchifier, pooling, normalize, includeTokenTypes);
     }
 
     static NDArray processEmbedding(


### PR DESCRIPTION
## Description ##

This allows embedding models to obtain token_type_ids from encodings in TextEmbeddingBatchTranslator (TextEmbeddingTranslator already supports it).