### PR TITLE
[pytorch] Upgrade to PyTorch 2.1.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 djl_version=0.28.0
 mxnet_version=1.9.1
-pytorch_version=2.1.1
+pytorch_version=2.1.2
 tensorflow_version=2.10.1
 tflite_version=2.6.2
 trt_version=8.4.1


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Upgrade to PyTorch 2.1.2 since Neuronx need PyTorch 2.1.2 native.