### PR TITLE
[fix] Fix HfModelZoo and LlamaModelZoo concurrent init problem

### DIFF
--- a/engines/llama/src/main/java/ai/djl/llama/zoo/LlamaModelZoo.java
+++ b/engines/llama/src/main/java/ai/djl/llama/zoo/LlamaModelZoo.java
@@ -39,6 +39,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.GZIPInputStream;
 
 /** LlamaModelZoo is a repository that contains llama.cpp models. */
@@ -52,7 +53,7 @@ public class LlamaModelZoo extends ModelZoo {
 
     private static final long ONE_DAY = Duration.ofDays(1).toMillis();
 
-    private boolean initialized;
+    private final AtomicBoolean initialized = new AtomicBoolean(false);
 
     LlamaModelZoo() {}
 
@@ -83,7 +84,7 @@ public class LlamaModelZoo extends ModelZoo {
     }
 
     private void init() {
-        if (!initialized) {
+        if (initialized.compareAndSet(false, true)) {
             Application app = Application.NLP.TEXT_GENERATION;
             Map<String, ModelDetail> map = listModels(app);
             for (Map.Entry<String, ModelDetail> entry : map.entrySet()) {
@@ -95,7 +96,6 @@ public class LlamaModelZoo extends ModelZoo {
                     }
                 }
             }
-            initialized = true;
         }
     }
 

--- a/engines/llama/src/main/java/ai/djl/llama/zoo/LlamaModelZoo.java
+++ b/engines/llama/src/main/java/ai/djl/llama/zoo/LlamaModelZoo.java
@@ -13,9 +13,7 @@
 package ai.djl.llama.zoo;
 
 import ai.djl.Application;
-import ai.djl.engine.Engine;
 import ai.djl.repository.Repository;
-import ai.djl.repository.Version;
 import ai.djl.repository.zoo.ModelLoader;
 import ai.djl.repository.zoo.ModelZoo;
 import ai.djl.util.ClassLoaderUtils;
@@ -41,7 +39,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.GZIPInputStream;
 
 /** LlamaModelZoo is a repository that contains llama.cpp models. */
@@ -55,7 +52,7 @@ public class LlamaModelZoo extends ModelZoo {
 
     private static final long ONE_DAY = Duration.ofDays(1).toMillis();
 
-    private volatile boolean initialized = false;
+    private volatile boolean initialized; // NOPMD
 
     LlamaModelZoo() {}
 
@@ -113,7 +110,7 @@ public class LlamaModelZoo extends ModelZoo {
             if (Files.notExists(dir)) {
                 Files.createDirectories(dir);
             } else if (!Files.isDirectory(dir)) {
-                logger.warn("Failed initialize cache directory: " + dir);
+                logger.warn("Failed initialize cache directory: {}", dir);
                 return Collections.emptyMap();
             }
             Type type = new TypeToken<Map<String, ModelDetail>>() {}.getType();

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/zoo/HfModelZoo.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/zoo/HfModelZoo.java
@@ -55,7 +55,7 @@ public class HfModelZoo extends ModelZoo {
 
     private static final long ONE_DAY = Duration.ofDays(1).toMillis();
 
-    private final AtomicBoolean initialized = new AtomicBoolean(false);
+    private volatile boolean initialized = false;
 
     HfModelZoo() {}
 
@@ -86,13 +86,18 @@ public class HfModelZoo extends ModelZoo {
     }
 
     private void init() {
-        if (initialized.compareAndSet(false, true)) {
-            Version version = new Version(Engine.getDjlVersion());
-            addModels(NLP.FILL_MASK, version);
-            addModels(NLP.QUESTION_ANSWER, version);
-            addModels(NLP.TEXT_CLASSIFICATION, version);
-            addModels(NLP.TEXT_EMBEDDING, version);
-            addModels(NLP.TOKEN_CLASSIFICATION, version);
+        if (!initialized) {
+            synchronized (HfModelZoo.class) {
+                if (!initialized) {
+                    Version version = new Version(Engine.getDjlVersion());
+                    addModels(NLP.FILL_MASK, version);
+                    addModels(NLP.QUESTION_ANSWER, version);
+                    addModels(NLP.TEXT_CLASSIFICATION, version);
+                    addModels(NLP.TEXT_EMBEDDING, version);
+                    addModels(NLP.TOKEN_CLASSIFICATION, version);
+                    initialized = true;
+                }
+            }
         }
     }
 

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/zoo/HfModelZoo.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/zoo/HfModelZoo.java
@@ -41,7 +41,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.GZIPInputStream;
 
 /** HfModelZoo is a repository that contains HuggingFace models. */
@@ -55,7 +54,7 @@ public class HfModelZoo extends ModelZoo {
 
     private static final long ONE_DAY = Duration.ofDays(1).toMillis();
 
-    private volatile boolean initialized = false;
+    private volatile boolean initialized; // NOPMD
 
     HfModelZoo() {}
 
@@ -128,7 +127,7 @@ public class HfModelZoo extends ModelZoo {
             if (Files.notExists(dir)) {
                 Files.createDirectories(dir);
             } else if (!Files.isDirectory(dir)) {
-                logger.warn("Failed initialize cache directory: " + dir);
+                logger.warn("Failed initialize cache directory: {}", dir);
                 return Collections.emptyMap();
             }
             Type type = new TypeToken<Map<String, Map<String, Object>>>() {}.getType();

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/zoo/HfModelZoo.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/zoo/HfModelZoo.java
@@ -41,6 +41,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.GZIPInputStream;
 
 /** HfModelZoo is a repository that contains HuggingFace models. */
@@ -54,7 +55,7 @@ public class HfModelZoo extends ModelZoo {
 
     private static final long ONE_DAY = Duration.ofDays(1).toMillis();
 
-    private boolean initialized;
+    private final AtomicBoolean initialized = new AtomicBoolean(false);
 
     HfModelZoo() {}
 
@@ -85,14 +86,13 @@ public class HfModelZoo extends ModelZoo {
     }
 
     private void init() {
-        if (!initialized) {
+        if (initialized.compareAndSet(false, true)) {
             Version version = new Version(Engine.getDjlVersion());
             addModels(NLP.FILL_MASK, version);
             addModels(NLP.QUESTION_ANSWER, version);
             addModels(NLP.TEXT_CLASSIFICATION, version);
             addModels(NLP.TEXT_EMBEDDING, version);
             addModels(NLP.TOKEN_CLASSIFICATION, version);
-            initialized = true;
         }
     }
 


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Brief description of what this PR is about
- This PR addresses a potential thread safety issue in the **ai.djl.huggingface.zoo.HfModelZoo** and **ai.djl.llama.zoo.LlamaModelZoo** classes. Both classes utilize an init method for initialization and are designed as singletons(**ai/djl/repository/zoo/ModelZoo.java:39**), which may be accessed by multiple threads simultaneously. However, the init methods do not currently implement any mechanism to ensure thread safety. This PR proposes changes to synchronize the init methods to prevent concurrent initialization issues.

If this change is a backward incompatible change, why must this change be made?
- This change is not a backward incompatible change. It is a necessary enhancement to ensure that the initialization process of the singletons is thread-safe, thus preventing potential race conditions and data corruption when used in a multi-threaded environment.