### PR TITLE
[fix] fix RepositoryFactoryImpl getSupportedScheme return value

### DIFF
--- a/api/src/main/java/ai/djl/repository/RepositoryFactoryImpl.java
+++ b/api/src/main/java/ai/djl/repository/RepositoryFactoryImpl.java
@@ -99,7 +99,7 @@ class RepositoryFactoryImpl implements RepositoryFactory {
     /** {@inheritDoc} */
     @Override
     public Set<String> getSupportedScheme() {
-        return Collections.emptySet();
+        return REGISTRY.keySet();
     }
 
     static void registerRepositoryFactory(RepositoryFactory factory) {


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- getSupportedScheme func in RepositoryFactoryImpl clz return empty set, it seems not correspond to the registerRepositoryFactory func.
