### PR TITLE
[tokenizer] Fixes TextEmbeddingTranslator only uses CPU

### DIFF
--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/translator/TextEmbeddingTranslator.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/translator/TextEmbeddingTranslator.java
@@ -175,7 +175,6 @@ public class TextEmbeddingTranslator implements Translator<String, float[]> {
                 throw new AssertionError("Unexpected pooling mode: " + pooling);
         }
 
-        embedding = embedding.toDevice(Device.cpu(), false);
         if (denseModel != null) {
             NDArray weight = denseModel.get("linear.weight");
             NDArray bias = denseModel.get("linear.bias");


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
