### PR TITLE
[fix] Fix resource leak in file operations by using try-with-resources

### DIFF
--- a/api/src/main/java/ai/djl/util/ClassLoaderUtils.java
+++ b/api/src/main/java/ai/djl/util/ClassLoaderUtils.java
@@ -62,10 +62,11 @@ public final class ClassLoaderUtils {
             // we only consider .class files and skip .java files
             List<Path> jarFiles;
             if (Files.isDirectory(path)) {
-                jarFiles =
-                        Files.list(path)
-                                .filter(p -> p.toString().endsWith(".jar"))
-                                .collect(Collectors.toList());
+                try (Stream<Path> stream = Files.list(path)) {
+                    jarFiles = stream
+                            .filter(p -> p.toString().endsWith(".jar"))
+                            .collect(Collectors.toList());
+                }
             } else {
                 jarFiles = Collections.emptyList();
             }
@@ -111,10 +112,12 @@ public final class ClassLoaderUtils {
             logger.trace("Directory not exists: {}", dir);
             return null;
         }
-        Collection<Path> files =
-                Files.walk(dir)
-                        .filter(p -> Files.isRegularFile(p) && p.toString().endsWith(".class"))
-                        .collect(Collectors.toList());
+        Collection<Path> files;
+        try (Stream<Path> stream = Files.walk(dir)) {
+            files = stream
+                    .filter(p -> Files.isRegularFile(p) && p.toString().endsWith(".class"))
+                    .collect(Collectors.toList());
+        }
         for (Path file : files) {
             Path p = dir.relativize(file);
             String className = p.toString();

--- a/api/src/main/java/ai/djl/util/Utils.java
+++ b/api/src/main/java/ai/djl/util/Utils.java
@@ -42,6 +42,7 @@ import java.util.Scanner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /** A class containing utility methods. */
 public final class Utils {
@@ -105,17 +106,15 @@ public final class Utils {
      * @param dir the directory to be removed
      */
     public static void deleteQuietly(Path dir) {
-        try {
-            Files.walk(dir)
-                    .sorted(Comparator.reverseOrder())
-                    .forEach(
-                            path -> {
-                                try {
-                                    Files.deleteIfExists(path);
-                                } catch (IOException ignore) {
-                                    // ignore
-                                }
-                            });
+        try (Stream<Path> stream = Files.walk(dir)) {
+            stream.sorted(Comparator.reverseOrder())
+                    .forEach(path -> {
+                        try {
+                            Files.deleteIfExists(path);
+                        } catch (IOException ignore) {
+                            // ignore
+                        }
+                    });
         } catch (IOException ignore) {
             // ignore
         }
@@ -255,19 +254,20 @@ public final class Utils {
      */
     public static int getCurrentEpoch(Path modelDir, String modelName) throws IOException {
         final Pattern pattern = Pattern.compile(Pattern.quote(modelName) + "-(\\d{4}).params");
-        List<Integer> checkpoints =
-                Files.walk(modelDir, 1, FileVisitOption.FOLLOW_LINKS)
-                        .map(
-                                p -> {
-                                    Matcher m = pattern.matcher(p.toFile().getName());
-                                    if (m.matches()) {
-                                        return Integer.parseInt(m.group(1));
-                                    }
-                                    return null;
-                                })
-                        .filter(Objects::nonNull)
-                        .sorted()
-                        .collect(Collectors.toList());
+        List<Integer> checkpoints;
+        try (Stream<Path> stream = Files.walk(modelDir, 1, FileVisitOption.FOLLOW_LINKS)) {
+            checkpoints = stream
+                    .map(p -> {
+                        Matcher m = pattern.matcher(p.toFile().getName());
+                        if (m.matches()) {
+                            return Integer.parseInt(m.group(1));
+                        }
+                        return null;
+                    })
+                    .filter(Objects::nonNull)
+                    .sorted()
+                    .collect(Collectors.toList());
+        }
         if (checkpoints.isEmpty()) {
             return -1;
         }
@@ -380,12 +380,11 @@ public final class Utils {
      */
     public static Path getNestedModelDir(Path modelDir) {
         if (Files.isDirectory(modelDir)) {
-            try {
+            try (Stream<Path> stream = Files.list(modelDir)) {
                 // handle actual model directory is subdirectory case
-                List<Path> files =
-                        Files.list(modelDir)
-                                .filter(p -> !p.getFileName().toString().startsWith("."))
-                                .collect(Collectors.toList());
+                List<Path> files = stream
+                        .filter(p -> !p.getFileName().toString().startsWith("."))
+                        .collect(Collectors.toList());
                 if (files.size() == 1 && Files.isDirectory(files.get(0))) {
                     return files.get(0);
                 }


### PR DESCRIPTION
## Description ##

Addresses issue where file descriptors were not being closed properly in several utility methods:

- `ai.djl.util.Utils.deleteQuietly`
- `ai.djl.util.Utils.getCurrentEpoch`
- `ai.djl.util.Utils.getNestedModelDir`
- `ai.djl.util.ClassLoaderUtils.findImplementation`
- `ai.djl.util.ClassLoaderUtils.scanDirectory`

By incorporating try-with-resources statements, this commit ensures that streams opened via `Files.list()` and `Files.walk()` are automatically closed, preventing potential file descriptor exhaustion and adhering to best practices in resource management.
