### PR TITLE
Ensure the alternative ND manager can use GPUs

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
@@ -62,7 +62,13 @@ public abstract class BaseNDManager implements NDManager {
         uid = UUID.randomUUID().toString();
         Engine engine = getEngine().getAlternativeEngine();
         if (engine != null) {
-            alternativeManager = engine.newBaseManager(Device.cpu());
+            try {
+                // Try to use the same device for efficiency.
+                alternativeManager = engine.newBaseManager(device);
+            } catch (RuntimeException | UnsatisfiedLinkError ignore) {
+                // Use the default device instead.
+                alternativeManager = engine.newBaseManager();
+            }
         }
     }
 

--- a/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
@@ -62,13 +62,8 @@ public abstract class BaseNDManager implements NDManager {
         uid = UUID.randomUUID().toString();
         Engine engine = getEngine().getAlternativeEngine();
         if (engine != null) {
-            try {
-                // Try to use the same device for efficiency.
-                alternativeManager = engine.newBaseManager(device);
-            } catch (RuntimeException | UnsatisfiedLinkError ignore) {
-                // Use the default device instead.
-                alternativeManager = engine.newBaseManager();
-            }
+            // Use the default device
+            alternativeManager = engine.newBaseManager();
         }
     }
 


### PR DESCRIPTION
This makes a massive performance difference when using OnnxRuntime, which delegates to PyTorch for some NDArray operations.  This almost makes OnnxRuntime run as fast compared to PyTorch.  Without this change, OnnxRuntime was over 3 times slower.
