### PR TITLE
[Lgbm] fix LgbmNDArray replaced.close() release data problem

### DIFF
--- a/engines/ml/lightgbm/src/main/java/ai/djl/ml/lightgbm/LgbmNDArray.java
+++ b/engines/ml/lightgbm/src/main/java/ai/djl/ml/lightgbm/LgbmNDArray.java
@@ -155,13 +155,11 @@ public class LgbmNDArray extends NDArrayAdapter {
     public void intern(NDArray replaced) {
         LgbmNDArray array = (LgbmNDArray) replaced;
 
-        final SWIGTYPE_p_float floatData =
-                floatDataRef.getAndSet(array.floatDataRef.getAndSet(null));
+        SWIGTYPE_p_float floatData = floatDataRef.getAndSet(array.floatDataRef.getAndSet(null));
         if (floatData != null) {
             lightgbmlib.delete_floatArray(floatData);
         }
-        final SWIGTYPE_p_double doubleData =
-                doubleDataRef.getAndSet(array.doubleDataRef.getAndSet(null));
+        SWIGTYPE_p_double doubleData = doubleDataRef.getAndSet(array.doubleDataRef.getAndSet(null));
         if (doubleData != null) {
             lightgbmlib.delete_doubleArray(doubleData);
         }
@@ -185,11 +183,11 @@ public class LgbmNDArray extends NDArrayAdapter {
     @Override
     public void close() {
         super.close();
-        final SWIGTYPE_p_float floatData = floatDataRef.getAndSet(null);
+        SWIGTYPE_p_float floatData = floatDataRef.getAndSet(null);
         if (floatData != null) {
             lightgbmlib.delete_floatArray(floatData);
         }
-        final SWIGTYPE_p_double doubleData = doubleDataRef.getAndSet(null);
+        SWIGTYPE_p_double doubleData = doubleDataRef.getAndSet(null);
         if (doubleData != null) {
             lightgbmlib.delete_doubleArray(doubleData);
         }

--- a/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_torch_pointwise.cc
+++ b/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_torch_pointwise.cc
@@ -356,7 +356,7 @@ JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchAtan(JNIEnv*
 }
 
 JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchAtan2(
-JNIEnv* env, jobject jthis, jlong jself, jlong jother) {
+    JNIEnv* env, jobject jthis, jlong jself, jlong jother) {
   API_BEGIN()
   const auto* self_ptr = reinterpret_cast<torch::Tensor*>(jself);
   const auto* other_ptr = reinterpret_cast<torch::Tensor*>(jother);

--- a/engines/pytorch/pytorch-native/src/main/native/djl_pytorch_utils.h
+++ b/engines/pytorch/pytorch-native/src/main/native/djl_pytorch_utils.h
@@ -18,8 +18,9 @@
 #include <jni.h>
 #include <torch/csrc/api/include/torch/enum.h>
 #include <torch/script.h>
-#include <variant>
+
 #include <iostream>
+#include <variant>
 
 #include "djl_pytorch_jni_log.h"
 


### PR DESCRIPTION
## Description ##
In `LgbmNDArray`, within the `intern` method, closing the `replaced` data leads to the release of `floatData` and `doubleData`. This action results in the premature release of `floatData` and `doubleData`.


```java
@Override
public void intern(NDArray replaced) {
    if (floatData != null) {
        lightgbmlib.delete_floatArray(floatData);
    }
    if (doubleData != null) {
        lightgbmlib.delete_doubleArray(doubleData);
    }
    LgbmNDArray array = (LgbmNDArray) replaced;
    data = array.data;
    handle = array.handle;
    format = array.format;
    floatData = array.floatData;
    doubleData = array.doubleData;
    typeConstant = array.typeConstant;
    shape = array.shape;
    dataType = array.dataType;
    replaced.close();
}

@Override
public void close() {
    super.close();
    if (floatData != null) {
        lightgbmlib.delete_floatArray(floatData);
    }
    if (doubleData != null) {
        lightgbmlib.delete_doubleArray(doubleData);
    }
}
```

