### PR TITLE
[pytorch-model-zoo]: fix PtSsdTranslator.Builder.self()

### DIFF
--- a/engines/pytorch/pytorch-model-zoo/src/main/java/ai/djl/pytorch/zoo/cv/objectdetection/PtSsdTranslator.java
+++ b/engines/pytorch/pytorch-model-zoo/src/main/java/ai/djl/pytorch/zoo/cv/objectdetection/PtSsdTranslator.java
@@ -232,7 +232,7 @@ public class PtSsdTranslator extends ObjectDetectionTranslator {
         /** {@inheritDoc} */
         @Override
         protected Builder self() {
-            return null;
+            return this;
         }
 
         /** {@inheritDoc} */


### PR DESCRIPTION
## Description ##
Fix #3203 (ai.djl.pytorch.zoo.cv.objectdetection.PtSsdTranslator.Builder.self() to return 'this' instead of 'null')
