### PR TITLE
[api] Fixes unitest

### DIFF
--- a/api/src/test/java/ai/djl/util/cuda/CudaUtilsTest.java
+++ b/api/src/test/java/ai/djl/util/cuda/CudaUtilsTest.java
@@ -28,7 +28,11 @@ public class CudaUtilsTest {
     @Test
     public void testCudaUtils() {
         if (!CudaUtils.hasCuda()) {
-            Assert.assertThrows(CudaUtils::getCudaVersionString);
+            try {
+                CudaUtils.getCudaVersionString();
+            } catch (IllegalStateException | IllegalArgumentException ignore) {
+                // ignore exception
+            }
             Assert.assertThrows(() -> CudaUtils.getComputeCapability(0));
             Assert.assertThrows(() -> CudaUtils.getGpuMemory(Device.gpu()));
             return;


### PR DESCRIPTION
The test was failing on the machine installed cuda but no GPU

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
