### PR TITLE
[tokenizer] Ensure GPU is used in TextEmbeddingTranslator

### DIFF
--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/translator/TextEmbeddingTranslator.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/translator/TextEmbeddingTranslator.java
@@ -12,7 +12,6 @@
  */
 package ai.djl.huggingface.translator;
 
-import ai.djl.Device;
 import ai.djl.huggingface.tokenizers.Encoding;
 import ai.djl.huggingface.tokenizers.HuggingFaceTokenizer;
 import ai.djl.ndarray.NDArray;

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/translator/TextEmbeddingTranslator.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/translator/TextEmbeddingTranslator.java
@@ -78,7 +78,7 @@ public class TextEmbeddingTranslator implements Translator<String, float[]> {
     /** {@inheritDoc} */
     @Override
     public void prepare(TranslatorContext ctx) throws Exception {
-        NDManager manager = ctx.getPredictorManager().newSubManager(Device.cpu());
+        NDManager manager = ctx.getPredictorManager().newSubManager();
         if (dense != null) {
             Path file = Paths.get(dense);
             if (!file.isAbsolute()) {


### PR DESCRIPTION
This fixes https://github.com/deepjavalibrary/djl/issues/3211, where using `djl://ai.djl.huggingface.pytorch/sentence-transformers/clip-ViT-B-32-multilingual-v1` on 0.28.0 fails on a GPU machine with:
```
Caused by: ai.djl.engine.EngineException: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument mat2 in method wrapper_mm)
	at ai.djl.pytorch.jni.PyTorchLibrary.torchNNLinear(PyTorchLibrary.java) ~[pytorch-engine-0.28.0.jar:?]
	at ai.djl.pytorch.jni.JniUtils.linear(JniUtils.java:1376) ~[pytorch-engine-0.28.0.jar:?]
	at ai.djl.pytorch.engine.PtNDArrayEx.linear(PtNDArrayEx.java:397) ~[pytorch-engine-0.28.0.jar:?]
	at ai.djl.huggingface.translator.TextEmbeddingTranslator.processEmbedding(TextEmbeddingTranslator.java:181) ~[tokenizers-0.28.0.jar:?]
	at ai.djl.huggingface.translator.TextEmbeddingTranslator.batchProcessOutput(TextEmbeddingTranslator.java:144) ~[tokenizers-0.28.0.jar:?]
	at ai.djl.inference.Predictor.batchPredict(Predictor.java:190) ~[api-0.28.0.jar:?]
	at ai.djl.inference.Predictor.predict(Predictor.java:132) ~[api-0.28.0.jar:?]
```