### PR TITLE
[Lgbm] support multi classification

### DIFF
--- a/engines/ml/lightgbm/src/main/java/ai/djl/ml/lightgbm/jni/JniUtils.java
+++ b/engines/ml/lightgbm/src/main/java/ai/djl/ml/lightgbm/jni/JniUtils.java
@@ -83,8 +83,15 @@ public final class JniUtils {
             SWIGTYPE_p_p_void model, int iterations, LgbmNDArray a) {
         SWIGTYPE_p_long_long outLength = lightgbmlib.new_int64_tp();
         SWIGTYPE_p_double outBuffer = null;
+        SWIGTYPE_p_int numClasses = lightgbmlib.new_intp();
         try {
-            outBuffer = lightgbmlib.new_doubleArray(2L * a.getRows());
+            int outFlag =
+                    lightgbmlib.LGBM_BoosterGetNumClasses(
+                            lightgbmlib.voidpp_value(model), numClasses);
+            checkCall(outFlag);
+            int classes = lightgbmlib.intp_value(numClasses);
+
+            outBuffer = lightgbmlib.new_doubleArray((long) classes * a.getRows());
             int result =
                     lightgbmlib.LGBM_BoosterPredictForMat(
                             lightgbmlib.voidpp_value(model),
@@ -130,6 +137,7 @@ public final class JniUtils {
             if (outBuffer != null) {
                 lightgbmlib.delete_doubleArray(outBuffer);
             }
+            lightgbmlib.delete_intp(numClasses);
         }
     }
 


### PR DESCRIPTION
## Description ##
https://github.com/deepjavalibrary/djl/issues/3223

This PR introduces an enhancement to the LightGBM inference functionality, specifically targeting multi-classification tasks. It modifies the inferenceMat method to dynamically allocate output buffer size based on the number of classes in the model, thus enabling support for multi-class predictions.

Key Changes:
- The method now retrieves the number of classes in the model using LGBM_BoosterGetNumClasses and allocates the output buffer (outBuffer) accordingly. This ensures that the buffer size is sufficient for storing prediction results for all classes.
- This change is backward compatible as it extends the existing functionality without altering the method signature or expected input/output types. It enhances the method's capability to handle multi-classification tasks, which was previously not explicitly supported.
