### PR TITLE
[Lgbm] support multi type prediction

### DIFF
--- a/engines/ml/lightgbm/src/main/java/ai/djl/ml/lightgbm/LgbmModel.java
+++ b/engines/ml/lightgbm/src/main/java/ai/djl/ml/lightgbm/LgbmModel.java
@@ -17,6 +17,7 @@ import ai.djl.Model;
 import ai.djl.ml.lightgbm.jni.JniUtils;
 import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.types.DataType;
+import ai.djl.translate.ArgumentsUtil;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -56,6 +57,12 @@ public class LgbmModel extends BaseModel {
             }
         }
         block = JniUtils.loadModel((LgbmNDManager) manager, modelFile.toAbsolutePath().toString());
+        if (options != null) {
+            String inferenceType = ArgumentsUtil.stringValue(options, "inference_type");
+            if (inferenceType != null) {
+                setInferenceType(inferenceType);
+            }
+        }
     }
 
     private Path findModelFile(String prefix) {
@@ -97,21 +104,22 @@ public class LgbmModel extends BaseModel {
     }
 
     /**
-     * Sets the inference type of the model based on the given string. Supported inference types
-     * include NORMAL, RAW_SCORE, LEAF_INDEX, CONTRIB.
+     * Sets the inference type of the model based on the given string.
      *
-     * @param inferenceType The string representing the inference type.
-     * @throws IllegalArgumentException if the given inference type is not supported.
+     * <p>Supported inference types include NORMAL, RAW_SCORE, LEAF_INDEX, CONTRIB.
+     *
+     * @param inferenceType the string representing the inference type
+     * @throws IllegalArgumentException if the given inference type is not supported
      */
     public void setInferenceType(String inferenceType) {
         ((LgbmSymbolBlock) block).setInferenceType(inferenceType);
     }
 
     /**
-     * Gets the string representation of the current model inference type.
+     * Returns the string representation of the current model inference type.
      *
-     * @return The string representation of the current inference type.
-     * @throws IllegalStateException if the current inference type is unknown.
+     * @return the string representation of the current inference type
+     * @throws IllegalStateException if the current inference type is unknown
      */
     public String getInferenceType() {
         return ((LgbmSymbolBlock) block).getInferenceType();

--- a/engines/ml/lightgbm/src/main/java/ai/djl/ml/lightgbm/LgbmModel.java
+++ b/engines/ml/lightgbm/src/main/java/ai/djl/ml/lightgbm/LgbmModel.java
@@ -95,4 +95,25 @@ public class LgbmModel extends BaseModel {
         }
         super.close();
     }
+
+    /**
+     * Sets the inference type of the model based on the given string. Supported inference types
+     * include NORMAL, RAW_SCORE, LEAF_INDEX, CONTRIB.
+     *
+     * @param inferenceType The string representing the inference type.
+     * @throws IllegalArgumentException if the given inference type is not supported.
+     */
+    public void setInferenceType(String inferenceType) {
+        ((LgbmSymbolBlock) block).setInferenceType(inferenceType);
+    }
+
+    /**
+     * Gets the string representation of the current model inference type.
+     *
+     * @return The string representation of the current inference type.
+     * @throws IllegalStateException if the current inference type is unknown.
+     */
+    public String getInferenceType() {
+        return ((LgbmSymbolBlock) block).getInferenceType();
+    }
 }

--- a/engines/ml/lightgbm/src/main/java/ai/djl/ml/lightgbm/LgbmSymbolBlock.java
+++ b/engines/ml/lightgbm/src/main/java/ai/djl/ml/lightgbm/LgbmSymbolBlock.java
@@ -69,7 +69,7 @@ public class LgbmSymbolBlock extends AbstractSymbolBlock implements AutoCloseabl
         try (LgbmNDManager sub = (LgbmNDManager) manager.newSubManager()) {
             LgbmNDArray lgbmNDArray = sub.from(array);
             Pair<Integer, ByteBuffer> result =
-                    JniUtils.inference(handle.get(), iterations, lgbmNDArray, inferenceType);
+                    JniUtils.inference(getHandle(), iterations, lgbmNDArray, inferenceType);
 
             NDArray ret =
                     manager.create(
@@ -135,19 +135,16 @@ public class LgbmSymbolBlock extends AbstractSymbolBlock implements AutoCloseabl
     }
 
     String getInferenceType() {
-        if (this.inferenceType == lightgbmlibConstants.C_API_PREDICT_NORMAL) {
+        if (inferenceType == lightgbmlibConstants.C_API_PREDICT_NORMAL) {
             return "NORMAL";
-        } else if (this.inferenceType == lightgbmlibConstants.C_API_PREDICT_RAW_SCORE) {
+        } else if (inferenceType == lightgbmlibConstants.C_API_PREDICT_RAW_SCORE) {
             return "RAW_SCORE";
-        } else if (this.inferenceType == lightgbmlibConstants.C_API_PREDICT_LEAF_INDEX) {
+        } else if (inferenceType == lightgbmlibConstants.C_API_PREDICT_LEAF_INDEX) {
             return "LEAF_INDEX";
-        } else if (this.inferenceType == lightgbmlibConstants.C_API_PREDICT_CONTRIB) {
+        } else if (inferenceType == lightgbmlibConstants.C_API_PREDICT_CONTRIB) {
             return "CONTRIB";
         } else {
-            throw new IllegalStateException(
-                    "Unknown inference type: "
-                            + this.inferenceType
-                            + ". Please ensure a correct inference type is set.");
+            throw new AssertionError("Unexpected inference type: " + inferenceType);
         }
     }
 }

--- a/engines/ml/lightgbm/src/test/java/ai/djl/ml/lightgbm/LgbmModelTest.java
+++ b/engines/ml/lightgbm/src/test/java/ai/djl/ml/lightgbm/LgbmModelTest.java
@@ -48,16 +48,30 @@ public class LgbmModelTest {
                         .setTypes(NDList.class, NDList.class)
                         .optModelPath(modelDir)
                         .optModelName("quadratic")
+                        .optOption("inference_type", "NORMAL")
                         .build();
 
         try (ZooModel<NDList, NDList> model = criteria.loadModel();
                 Predictor<NDList, NDList> predictor = model.newPredictor()) {
+            LgbmModel lgbm = (LgbmModel) model.getWrappedModel();
+            Assert.assertEquals(lgbm.getInferenceType(), "NORMAL");
             try (NDManager manager = NDManager.newBaseManager()) {
                 NDArray array = manager.ones(new Shape(10, 4));
                 NDList output = predictor.predict(new NDList(array));
                 Assert.assertEquals(output.singletonOrThrow().getDataType(), DataType.FLOAT32);
                 Assert.assertEquals(output.singletonOrThrow().getShape().size(), 10);
             }
+
+            lgbm.setInferenceType("RAW_SCORE");
+            Assert.assertEquals(lgbm.getInferenceType(), "RAW_SCORE");
+
+            lgbm.setInferenceType("LEAF_INDEX");
+            Assert.assertEquals(lgbm.getInferenceType(), "LEAF_INDEX");
+
+            lgbm.setInferenceType("CONTRIB");
+            Assert.assertEquals(lgbm.getInferenceType(), "CONTRIB");
+
+            Assert.assertThrows(() -> lgbm.setInferenceType("invalid"));
         }
     }
 }


### PR DESCRIPTION
## Description ##
This PR is primarily aimed at implementing data inference functionality using the LightGBM model, supporting various types of inference including Raw Score, Leaf Index, and Feature Contribution. The inference task is accomplished through JNI calls to the LightGBM C API, and the results are returned in the form of a ByteBuffer for further processing.

- **Backward Incompatible Changes**: There are no backward incompatible changes in this update. It mainly introduces new functionalities without altering the behavior of existing features. Therefore, existing code and functionalities should not be affected by this change.
- **Interesting Edge Cases to Note**:
  - When the prediction type is Leaf Index, although the LightGBM C API returns the results as floating-point numbers (`double`), these values are actually integer indices. Therefore, when processing these values, it might be necessary to convert them into integer types.