### PR TITLE
[mxnet-model-zoo] Adds missing translatorFactory in metadata

### DIFF
--- a/engines/mxnet/mxnet-model-zoo/src/test/resources/mlrepo/model/cv/instance_segmentation/ai/djl/mxnet/mask_rcnn/metadata.json
+++ b/engines/mxnet/mxnet-model-zoo/src/test/resources/mlrepo/model/cv/instance_segmentation/ai/djl/mxnet/mask_rcnn/metadata.json
@@ -57,7 +57,8 @@
       },
       "arguments": {
         "normalize": true,
-        "synsetFileName": "classes.txt"
+        "synsetFileName": "classes.txt",
+        "translatorFactory": "ai.djl.modality.cv.translator.InstanceSegmentationTranslatorFactory"
       },
       "files": {
         "classes": {


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
