### PR TITLE
[examples] Remove symbolic training for MXNet

### DIFF
--- a/api/src/main/java/ai/djl/repository/zoo/BaseModelLoader.java
+++ b/api/src/main/java/ai/djl/repository/zoo/BaseModelLoader.java
@@ -195,11 +195,19 @@ public class BaseModelLoader implements ModelLoader {
             throws IOException {
         Model model = Model.newInstance(name, device, engine);
         if (block == null) {
-            String className = (String) arguments.get("blockFactory");
-            BlockFactory factory =
-                    ClassLoaderUtils.findImplementation(modelPath, BlockFactory.class, className);
-            if (factory != null) {
-                block = factory.newBlock(model, modelPath, arguments);
+            Object bf = arguments.get("blockFactory");
+            if (bf instanceof BlockFactory) {
+                block = ((BlockFactory) bf).newBlock(model, modelPath, arguments);
+            } else {
+                String className = (String) bf;
+                BlockFactory factory =
+                        ClassLoaderUtils.findImplementation(
+                                modelPath, BlockFactory.class, className);
+                if (factory != null) {
+                    block = factory.newBlock(model, modelPath, arguments);
+                } else if (className != null) {
+                    throw new IllegalArgumentException("Failed to load BlockFactory: " + className);
+                }
             }
         }
         if (block != null) {

--- a/examples/src/main/java/ai/djl/examples/training/util/Arguments.java
+++ b/examples/src/main/java/ai/djl/examples/training/util/Arguments.java
@@ -33,7 +33,6 @@ public class Arguments {
     protected int epoch;
     protected int batchSize;
     protected int maxGpus;
-    protected boolean isSymbolic;
     protected boolean preTrained;
     protected String outputDir;
     protected long limit;
@@ -60,7 +59,6 @@ public class Arguments {
         } else {
             batchSize = maxGpus > 0 ? 32 * maxGpus : 32;
         }
-        isSymbolic = cmd.hasOption("symbolic-model");
         preTrained = cmd.hasOption("pre-trained");
 
         if (cmd.hasOption("output-dir")) {
@@ -127,12 +125,6 @@ public class Arguments {
                         .desc("Max number of GPUs to use for training")
                         .build());
         options.addOption(
-                Option.builder("s")
-                        .longOpt("symbolic-model")
-                        .argName("SYMBOLIC")
-                        .desc("Use symbolic model, use imperative model if false")
-                        .build());
-        options.addOption(
                 Option.builder("p")
                         .longOpt("pre-trained")
                         .argName("PRE-TRAINED")
@@ -188,10 +180,6 @@ public class Arguments {
 
     public Device[] getMaxGpus() {
         return Engine.getEngine(engine).getDevices(maxGpus);
-    }
-
-    public boolean isSymbolic() {
-        return isSymbolic;
     }
 
     public boolean isPreTrained() {

--- a/examples/src/test/java/ai/djl/examples/training/TrainResNetTest.java
+++ b/examples/src/test/java/ai/djl/examples/training/TrainResNetTest.java
@@ -26,40 +26,20 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 
 public class TrainResNetTest {
+
     private static final int SEED = 1234;
 
     @Test
     public void testTrainResNet() throws ModelException, IOException, TranslateException {
-        TestRequirements.linux();
-
-        // Limit max 4 gpu for cifar10 training to make it converge faster.
-        // and only train 10 batch for unit test.
-        // only MXNet support symbolic model
-        String[] args = {"-e", "2", "-g", "4", "-m", "10", "-s", "-p", "--engine", "MXNet"};
-
-        TrainingResult result = TrainResnetWithCifar10.runExample(args);
-        Assert.assertNotNull(result);
-    }
-
-    @Test
-    public void testTrainResNetSymbolicNightly()
-            throws ModelException, IOException, TranslateException {
-        TestRequirements.linux();
         TestRequirements.nightly();
-        TestRequirements.gpu("MXNet");
 
         // Limit max 4 gpu for cifar10 training to make it converge faster.
         // and only train 10 batch for unit test.
         // only MXNet support symbolic model
-        String[] args = {"-e", "10", "-g", "4", "-s", "-p", "--engine", "MXNet"};
-
-        Engine.getEngine("MXNet").setRandomSeed(SEED);
+        String[] args = {"-e", "2", "-g", "4", "-m", "10", "-p"};
         TrainingResult result = TrainResnetWithCifar10.runExample(args);
-        Assert.assertNotNull(result);
 
-        Assert.assertTrue(result.getTrainEvaluation("Accuracy") >= 0.8f);
-        Assert.assertTrue(result.getValidateEvaluation("Accuracy") >= 0.68f);
-        Assert.assertTrue(result.getValidateLoss() < 1.1);
+        Assert.assertNotNull(result);
     }
 
     @Test
@@ -67,13 +47,13 @@ public class TrainResNetTest {
             throws ModelException, IOException, TranslateException {
         TestRequirements.linux();
         TestRequirements.nightly();
-        TestRequirements.gpu("MXNet");
+        TestRequirements.gpu("PyTorch");
 
         // Limit max 4 gpu for cifar10 training to make it converge faster.
         // and only train 10 batch for unit test.
-        String[] args = {"-e", "10", "-g", "4", "--engine", "MXNet"};
+        String[] args = {"-e", "10", "-g", "4"};
 
-        Engine.getEngine("MXNet").setRandomSeed(SEED);
+        Engine.getEngine("PyTorch").setRandomSeed(SEED);
         TrainingResult result = TrainResnetWithCifar10.runExample(args);
         Assert.assertNotNull(result);
 


### PR DESCRIPTION
1. Remove symbolic model training form MXNet
2. Use block factory to load DJL trained model
3. Refactory BaseModelLoader

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
