### PR TITLE
[tokenizers] Fixes memory leak when there is overflowing tokens

### DIFF
--- a/extensions/tokenizers/rust/src/lib.rs
+++ b/extensions/tokenizers/rust/src/lib.rs
@@ -498,6 +498,17 @@ pub extern "system" fn Java_ai_djl_huggingface_tokenizers_jni_TokenizersLibrary_
 }
 
 #[no_mangle]
+pub extern "system" fn Java_ai_djl_huggingface_tokenizers_jni_TokenizersLibrary_getOverflowCount(
+    _: JNIEnv,
+    _: JObject,
+    handle: jlong,
+) -> jint {
+    let encoding = cast_handle::<Encoding>(handle);
+    let count = encoding.get_overflowing().len();
+    count as jint
+}
+
+#[no_mangle]
 pub extern "system" fn Java_ai_djl_huggingface_tokenizers_jni_TokenizersLibrary_getOverflowing<
     'local,
 >(

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizer.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizer.java
@@ -608,7 +608,7 @@ public final class HuggingFaceTokenizer extends NativeResource<Long> implements 
         long[] specialTokenMask = TokenizersLibrary.LIB.getSpecialTokenMask(encoding);
         CharSpan[] charSpans = TokenizersLibrary.LIB.getTokenCharSpans(encoding);
 
-        int overFlowCount = TokenizersLibrary.LIB.getOverflowCount();
+        int overFlowCount = TokenizersLibrary.LIB.getOverflowCount(encoding);
         boolean exceedMaxLength = overFlowCount > 0;
         Encoding[] overflowing;
         if (withOverflowingTokens) {

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizer.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/HuggingFaceTokenizer.java
@@ -608,10 +608,11 @@ public final class HuggingFaceTokenizer extends NativeResource<Long> implements 
         long[] specialTokenMask = TokenizersLibrary.LIB.getSpecialTokenMask(encoding);
         CharSpan[] charSpans = TokenizersLibrary.LIB.getTokenCharSpans(encoding);
 
-        long[] overflowingHandles = TokenizersLibrary.LIB.getOverflowing(encoding);
-        boolean exceedMaxLength = overflowingHandles.length > 0;
+        int overFlowCount = TokenizersLibrary.LIB.getOverflowCount();
+        boolean exceedMaxLength = overFlowCount > 0;
         Encoding[] overflowing;
         if (withOverflowingTokens) {
+            long[] overflowingHandles = TokenizersLibrary.LIB.getOverflowing(encoding);
             overflowing = new Encoding[overflowingHandles.length];
             for (int i = 0; i < overflowingHandles.length; ++i) {
                 overflowing[i] = toEncoding(overflowingHandles[i], true);

--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/TokenizersLibrary.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/TokenizersLibrary.java
@@ -60,6 +60,8 @@ public final class TokenizersLibrary {
 
     public native long[] getOverflowing(long encoding);
 
+    public native int getOverflowCount(long encoding);
+
     public native String decode(long tokenizer, long[] ids, boolean addSpecialTokens);
 
     public native String getTruncationStrategy(long tokenizer);


### PR DESCRIPTION
Fixes #3316

If you call TokenizersLibrary.LIB.getOverflowing you must also clean up all overflow encodings.

If withOverflowingTokens was false no Encodings where generated leaving jni Encoding handles that would not be properly deleted.

This introduces a new native method where you can inquire about number of overflow tokens without using any jni resources. And you will now only call TokenizersLibrary.LIB.getOverflowing(encoding) if withOverflowingTokens is true.

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
