### PR TITLE
[rust] Fix NDArrayTests failure on cuda

### DIFF
--- a/extensions/tokenizers/src/test/java/ai/djl/engine/rust/NDArrayTests.java
+++ b/extensions/tokenizers/src/test/java/ai/djl/engine/rust/NDArrayTests.java
@@ -107,11 +107,13 @@ public class NDArrayTests {
             NDArray int32 = int8.toType(DataType.INT32, false);
             NDArray uint32 = int32.toType(DataType.UINT32, false);
             NDArray int64 = uint32.toType(DataType.INT64, false);
-            NDArray f16 = int64.toType(DataType.FLOAT16, false);
+            NDArray bool = int64.toType(DataType.BOOLEAN, false);
+            Assert.assertTrue(bool.getBoolean());
+            NDArray f16 = int32.toType(DataType.FLOAT16, false);
             NDArray bf16 = f16.toType(DataType.BFLOAT16, false);
             NDArray f32 = bf16.toType(DataType.FLOAT32, false);
             NDArray f64 = f32.toType(DataType.FLOAT64, false);
-            NDArray bool = f64.toType(DataType.BOOLEAN, false);
+            bool = f64.toType(DataType.BOOLEAN, false);
             Assert.assertTrue(bool.getBoolean());
         }
     }
@@ -219,10 +221,12 @@ public class NDArrayTests {
             expected = manager.create(new float[] {4f});
             Assert.assertEquals(array.expandDims(0), expected);
 
+            // TODO: Add zero-dim test back once the bug is fixed in candle
+            // https://github.com/huggingface/candle/issues/2327
             // zero-dim
-            array = manager.create(new Shape(2, 1, 0));
-            expected = manager.create(new Shape(2, 1, 1, 0));
-            Assert.assertEquals(array.expandDims(2), expected);
+            // array = manager.create(new Shape(2, 1, 0));
+            // expected = manager.create(new Shape(2, 1, 1, 0));
+            // Assert.assertEquals(array.expandDims(2), expected);
         }
     }
 

--- a/extensions/tokenizers/src/test/java/ai/djl/engine/rust/NDArrayTests.java
+++ b/extensions/tokenizers/src/test/java/ai/djl/engine/rust/NDArrayTests.java
@@ -19,6 +19,7 @@ import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.testing.Assertions;
+import ai.djl.testing.TestRequirements;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -106,14 +107,24 @@ public class NDArrayTests {
             NDArray int8 = uint8.toType(DataType.INT8, false);
             NDArray int32 = int8.toType(DataType.INT32, false);
             NDArray uint32 = int32.toType(DataType.UINT32, false);
-            NDArray int64 = uint32.toType(DataType.INT64, false);
-            NDArray bool = int64.toType(DataType.BOOLEAN, false);
-            Assert.assertTrue(bool.getBoolean());
-            NDArray f16 = int32.toType(DataType.FLOAT16, false);
+            NDArray f16 = uint32.toType(DataType.FLOAT16, false);
             NDArray bf16 = f16.toType(DataType.BFLOAT16, false);
             NDArray f32 = bf16.toType(DataType.FLOAT32, false);
             NDArray f64 = f32.toType(DataType.FLOAT64, false);
-            bool = f64.toType(DataType.BOOLEAN, false);
+            NDArray bool = f64.toType(DataType.BOOLEAN, false);
+            Assert.assertTrue(bool.getBoolean());
+        }
+    }
+
+    @Test
+    public void testI64toF16() {
+        TestRequirements.notGpu();
+        try (NDManager manager = NDManager.newBaseManager("Rust")) {
+            NDArray array = manager.create(2);
+            Assert.assertEquals(array.getDataType(), DataType.INT32);
+            NDArray int64 = array.toType(DataType.INT64, false);
+            NDArray f16 = int64.toType(DataType.FLOAT16, false);
+            NDArray bool = f16.toType(DataType.BOOLEAN, false);
             Assert.assertTrue(bool.getBoolean());
         }
     }
@@ -221,12 +232,10 @@ public class NDArrayTests {
             expected = manager.create(new float[] {4f});
             Assert.assertEquals(array.expandDims(0), expected);
 
-            // TODO: Add zero-dim test back once the bug is fixed in candle
-            // https://github.com/huggingface/candle/issues/2327
             // zero-dim
-            // array = manager.create(new Shape(2, 1, 0));
-            // expected = manager.create(new Shape(2, 1, 1, 0));
-            // Assert.assertEquals(array.expandDims(2), expected);
+            array = manager.create(new Shape(2, 1, 0));
+            expected = manager.create(new Shape(2, 1, 1, 0));
+            Assert.assertEquals(array.expandDims(2), expected);
         }
     }
 

--- a/testing/src/main/java/ai/djl/testing/TestRequirements.java
+++ b/testing/src/main/java/ai/djl/testing/TestRequirements.java
@@ -58,6 +58,13 @@ public final class TestRequirements {
         }
     }
 
+    /** Requires the test runs on non-GPU. */
+    public static void notGpu() {
+        if (Engine.getInstance().getGpuCount() > 0) {
+            throw new SkipException("This test requires non-GPU to run");
+        }
+    }
+
     /** Requires that the test runs on macOS M1. */
     public static void macosM1() {
         if (!System.getProperty("os.name").toLowerCase().startsWith("mac")


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Fix NDArrayTests failure on cuda

1) ai.djl.engine.rust.NDArrayTests.testExpandDim: This is candle bug. I raised an issue in candle. I will add the code back once it's fixed.


```
ai.djl.engine.EngineException: DriverError(CUDA_ERROR_INVALID_VALUE, "invalid argument")
	at app//ai.djl.engine.rust.RustLibrary.contentEqual(Native Method)
	at app//ai.djl.engine.rust.RsNDArray.contentEquals(RsNDArray.java:368)
	at app//ai.djl.engine.rust.RsNDArray.equals(RsNDArray.java:1615)
	at app//org.testng.Assert.areEqualImpl(Assert.java:180)
	at app//org.testng.Assert.assertEqualsImpl(Assert.java:148)
	at app//org.testng.Assert.assertEquals(Assert.java:132)
	at app//org.testng.Assert.assertEquals(Assert.java:644)
	at app//ai.djl.engine.rust.NDArrayTests.testExpandDim(NDArrayTests.java:225)

```

2) ai.djl.engine.rust.NDArrayTests.testToDataType: Changed to cast int32 to float16 since cast_i64_f16 is not supported.

```
ai.djl.engine.EngineException: Cuda(Load { cuda: DriverError(CUDA_ERROR_NOT_FOUND, "named symbol not found"), module_name: "cast_i64_f16" })
	at app//ai.djl.engine.rust.RustLibrary.toDataType(Native Method)
	at app//ai.djl.engine.rust.RsNDArray.toType(RsNDArray.java:175)
	at app//ai.djl.engine.rust.RsNDArray.toType(RsNDArray.java:35)
	at app//ai.djl.engine.rust.NDArrayTests.testToDataType(NDArrayTests.java:110)

```