### PR TITLE
[rust] Remove 0-dimension tensor compare in NDArrayTests

### DIFF
--- a/extensions/tokenizers/src/test/java/ai/djl/engine/rust/NDArrayTests.java
+++ b/extensions/tokenizers/src/test/java/ai/djl/engine/rust/NDArrayTests.java
@@ -232,10 +232,12 @@ public class NDArrayTests {
             expected = manager.create(new float[] {4f});
             Assert.assertEquals(array.expandDims(0), expected);
 
+            // TODO: Add zero-dim test back once the bug is fixed in candle
+            // https://github.com/huggingface/candle/issues/2327
             // zero-dim
-            array = manager.create(new Shape(2, 1, 0));
-            expected = manager.create(new Shape(2, 1, 1, 0));
-            Assert.assertEquals(array.expandDims(2), expected);
+            // array = manager.create(new Shape(2, 1, 0));
+            // expected = manager.create(new Shape(2, 1, 1, 0));
+            // Assert.assertEquals(array.expandDims(2), expected);
         }
     }
 


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
