### PR TITLE
make SimpleTokenizer use the delimiter, not " "

### DIFF
--- a/api/src/main/java/ai/djl/modality/nlp/preprocess/SimpleTokenizer.java
+++ b/api/src/main/java/ai/djl/modality/nlp/preprocess/SimpleTokenizer.java
@@ -32,13 +32,13 @@ public class SimpleTokenizer implements Tokenizer {
         this.delimiter = delimiter;
     }
 
-    /** Creates an instance of {@code SimpleTokenizer} with the default delimiter. */
+    /** Creates an instance of {@code SimpleTokenizer} with the default delimiter (" "). */
     public SimpleTokenizer() {}
 
     /** {@inheritDoc} */
     @Override
     public List<String> tokenize(String sentence) {
-        return Arrays.asList(sentence.split(" "));
+        return Arrays.asList(sentence.split(delimiter));
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Like the title says, there is an error in the class `ai.djl.modality.nlp.preprocess.SimpleTokenizer`. It uses `" "` for tokenizing instead of the provided delimiter.