### PR TITLE
[docs] Build versions.json before mike deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           path: docs/demos/jupyter
           key: ${{ runner.os }}-jupyter-${{ hashFiles('docs/demos/jupyter/*') }}
-          
+
       - name: Run Notebooks
         if: steps.jupyter-notebooks-cache.outputs.cache-hit != 'true'
         working-directory: docs/demos/jupyter
@@ -90,12 +90,11 @@ jobs:
           aws-region: us-east-2
 
       - name: Copy files to S3 with the AWS CLI
-        env: 
-           DJL_VERSION: ${{ github.event.inputs.version-number || 'master' }}
+        env:
+          DJL_VERSION: ${{ github.event.inputs.version-number || 'master' }}
         run: |
-          aws s3 cp versions.json s3://djl-ai/documentation/nightly/versions.json
-          git checkout -f gh-pages
           aws s3 sync $DJL_VERSION s3://djl-ai/documentation/nightly/$DJL_VERSION --delete
+          aws s3 cp versions.json s3://djl-ai/documentation/nightly/versions.json
           aws cloudfront create-invalidation --distribution-id E733IIDCG0G5U --paths "/*"
 
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -93,8 +93,8 @@ jobs:
         env:
           DJL_VERSION: ${{ github.event.inputs.version-number || 'master' }}
         run: |
-          aws s3 sync $DJL_VERSION s3://djl-ai/documentation/nightly/$DJL_VERSION --delete
-          aws s3 cp versions.json s3://djl-ai/documentation/nightly/versions.json
+          aws s3 sync $DJL_VERSION s3://djl-ai/documentation/$DJL_VERSION --delete
+          aws s3 cp versions.json s3://djl-ai/documentation/versions.json
           aws cloudfront create-invalidation --distribution-id E733IIDCG0G5U --paths "/*"
 
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -91,10 +91,11 @@ jobs:
 
       - name: Copy files to S3 with the AWS CLI
         env: 
-           DJL_VERSION: ${{ github.event.inputs.pt_version || 'master' }}
+           DJL_VERSION: ${{ github.event.inputs.version-number || 'master' }}
         run: |
-          aws s3 sync $DJL_VERSION s3://djl-ai/documentation/nightly/$DJL_VERSION --delete
           aws s3 cp versions.json s3://djl-ai/documentation/nightly/versions.json
+          git checkout -f gh-pages
+          aws s3 sync $DJL_VERSION s3://djl-ai/documentation/nightly/$DJL_VERSION --delete
           aws cloudfront create-invalidation --distribution-id E733IIDCG0G5U --paths "/*"
 
 

--- a/tools/scripts/build-website.sh
+++ b/tools/scripts/build-website.sh
@@ -2,7 +2,9 @@
 
 set -ex
 
-echo "generating versions.json" 
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "generating versions.json"
 current_version=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' "gradle/libs.versions.toml" | awk -F '.' '{print $2}')
 versions='[{"version":"master","title":"master","aliases":[]}'
 for i in {1..4}; do
@@ -10,21 +12,28 @@ for i in {1..4}; do
   versions="$versions, {\"version\":\"v$version\",\"title\":\"v$version\",\"aliases\":[]}"
 done
 versions="$versions]"
-echo "$versions" | jq "." > "./versions.json"
+echo "$versions" | jq "." > "$BASE_DIR/../../versions.json"
 
 VERSION_NUMBER=$1
 if [[ "$VERSION_NUMBER" == "" ]]; then
   VERSION_NUMBER=master
 fi
 
-BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
 echo "Updating online runner ..."
 python3 "$BASE_DIR/add_online_runner.py"
 
 # Configure Git User, mike will create gh-pages branch
-git config user.name "nobody"
-git config user.email "nobody@localhost"
+if [[ -z "$(git config user.name)" ]]; then
+  git config user.name "nobody"
+fi
+if [[ -z "$(git config user.email)" ]]; then
+  git config user.email "nobody@localhost"
+fi
 
 echo "Building docs for $VERSION_NUMBER"
 mike deploy "$VERSION_NUMBER" -F docs/mkdocs.yml -b gh-pages
+
+git stash
+git checkout gh-pages
+git stash pop
+

--- a/tools/scripts/build-website.sh
+++ b/tools/scripts/build-website.sh
@@ -2,17 +2,7 @@
 
 set -ex
 
-BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-echo "generating versions.json"
-current_version=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' "gradle/libs.versions.toml" | awk -F '.' '{print $2}')
-versions='[{"version":"master","title":"master","aliases":[]}'
-for i in {1..4}; do
-  version="0.$((current_version - i)).0"
-  versions="$versions, {\"version\":\"v$version\",\"title\":\"v$version\",\"aliases\":[]}"
-done
-versions="$versions]"
-echo "$versions" | jq "." > "$BASE_DIR/../../versions.json"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 VERSION_NUMBER=$1
 if [[ "$VERSION_NUMBER" == "" ]]; then
@@ -20,7 +10,7 @@ if [[ "$VERSION_NUMBER" == "" ]]; then
 fi
 
 echo "Updating online runner ..."
-python3 "$BASE_DIR/add_online_runner.py"
+python3 "$REPO_ROOT/tools/scripts/add_online_runner.py"
 
 # Configure Git User, mike will create gh-pages branch
 if [[ -z "$(git config user.name)" ]]; then
@@ -30,10 +20,18 @@ if [[ -z "$(git config user.email)" ]]; then
   git config user.email "nobody@localhost"
 fi
 
+echo "generating versions.json"
+current_version=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' "gradle/libs.versions.toml" | awk -F '.' '{print $2}')
+versions='[{"version":"master","title":"master","aliases":[]}'
+for i in {1..4}; do
+  version="0.$((current_version - i)).0"
+  versions="$versions, {\"version\":\"v$version\",\"title\":\"v$version\",\"aliases\":[]}"
+done
+versions="$versions]"
+
 echo "Building docs for $VERSION_NUMBER"
 mike deploy "$VERSION_NUMBER" -F docs/mkdocs.yml -b gh-pages
 
-git stash
 git checkout gh-pages
-git stash pop
 
+echo "$versions" | jq "." >"$REPO_ROOT/versions.json"

--- a/tools/scripts/build-website.sh
+++ b/tools/scripts/build-website.sh
@@ -2,6 +2,16 @@
 
 set -ex
 
+echo "generating versions.json" 
+current_version=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' "gradle/libs.versions.toml" | awk -F '.' '{print $2}')
+versions='[{"version":"master","title":"master","aliases":[]}'
+for i in {1..4}; do
+  version="0.$((current_version - i)).0"
+  versions="$versions, {\"version\":\"v$version\",\"title\":\"v$version\",\"aliases\":[]}"
+done
+versions="$versions]"
+echo "$versions" | jq "." > "./versions.json"
+
 VERSION_NUMBER=$1
 if [[ "$VERSION_NUMBER" == "" ]]; then
   VERSION_NUMBER=master
@@ -18,15 +28,3 @@ git config user.email "nobody@localhost"
 
 echo "Building docs for $VERSION_NUMBER"
 mike deploy "$VERSION_NUMBER" -F docs/mkdocs.yml -b gh-pages
-
-git checkout gh-pages
-
-echo "generating versions.json"
-current_version=$(awk -F '=' '/djl / {gsub(/ ?"/, "", $2); print $2}' "$BASE_DIR/../../gradle/libs.versions.toml" | awk -F '.' '{print $2}')
-versions='[{"version":"master","title":"master","aliases":[]}'
-for i in {1..4}; do
-  version="0.$((current_version - i)).0"
-  versions="$versions, {\"version\":\"$version\",\"title\":\"$version\",\"aliases\":[]}"
-done
-versions="$versions]"
-echo "$versions" | jq "." > "$BASE_DIR/../../versions.json"


### PR DESCRIPTION
Changes 
1. Moved code fore building versions.json before the mike deploy command 
2. Copy the versions.json to S3, then switch to gh-pages to upload new version 
3. Fixed typo in DJL_VERSION env in Copy files to S3 with the AWS CLI step 

Rationale:
I re-ordered the steps so the workflow would crash if there was an issue with creating the versions.json file before building all the documentation. The code responsible for building the versions.json was unable to access the .toml file from gh-pages. Thus, I refactored the code to generate and upload the versions.json file before uploading the new website directory. 