### PR TITLE
[djl-import] Fixes missing trust-remote-code arg for import model zoo

### DIFF
--- a/extensions/tokenizers/src/main/python/djl_converter/arg_parser.py
+++ b/extensions/tokenizers/src/main/python/djl_converter/arg_parser.py
@@ -45,9 +45,10 @@ def converter_args():
     parser.add_argument(
         "--trust-remote-code",
         action="store_true",
-        help=
-        "Allows to use custom code for the modeling hosted in the model repository. This option should only be set for repositories you trust and in which you have read the code, as it will execute on your local machine arbitrary code present in the model repository."
-    )
+        help="Allows to use custom code for the modeling hosted in the model"
+        " repository. This option should only be set for repositories you trust and in which"
+        " you have read the code, as it will execute on your local machine arbitrary code"
+        " present in the model repository.")
 
     args = parser.parse_args()
     if args.output_dir is None:
@@ -84,6 +85,13 @@ def importer_args():
         help="Model category to convert",
     )
     group.add_argument("-m", "--model-name", help="Model name to convert")
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Allows to use custom code for the modeling hosted in the model"
+        " repository. This option should only be set for repositories you trust and in which"
+        " you have read the code, as it will execute on your local machine arbitrary code"
+        " present in the model repository.")
 
     args = parser.parse_args()
     if args.output_dir is None:


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
