### PR TITLE
[rust] Make tensor contiguous in rotary embedding

### DIFF
--- a/extensions/tokenizers/rust/src/models/gte.rs
+++ b/extensions/tokenizers/rust/src/models/gte.rs
@@ -134,8 +134,8 @@ impl RotaryEmbedding {
         let (_b_sz, _h, seq_len, _n_embd) = q.dims4()?;
         let cos = self.cos.narrow(0, 0, seq_len)?;
         let sin = self.sin.narrow(0, 0, seq_len)?;
-        let q_embed = rotary_emb::rope(q, &cos, &sin)?;
-        let k_embed = rotary_emb::rope(k, &cos, &sin)?;
+        let q_embed = rotary_emb::rope(&q.contiguous()?, &cos, &sin)?;
+        let k_embed = rotary_emb::rope(&k.contiguous()?, &cos, &sin)?;
         Ok((q_embed, k_embed))
     }
 }


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
