### PR TITLE
[rust] Fix bert model classifier loading

### DIFF
--- a/extensions/tokenizers/rust/src/models/bert.rs
+++ b/extensions/tokenizers/rust/src/models/bert.rs
@@ -492,7 +492,16 @@ impl BertClassificationHead {
             Ok(layer) => Some(layer),
             Err(_) => None,
         };
-        let output = Linear::load(vb.pp("classifier"), config.hidden_size, n_classes, None)?;
+        let output = match Linear::load(vb.pp("classifier"), config.hidden_size, n_classes, None) {
+            Ok(output) => output,
+            Err(err) => {
+                if let Ok(output) = Linear::load(vb, config.hidden_size, n_classes, None) {
+                    output
+                } else {
+                    return Err(err);
+                }
+            }
+        };
 
         Ok(Self {
             pooler,


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
