### PR TITLE
[ci] Update tensorrt native build container

### DIFF
--- a/.github/workflows/native_jni_s3_tensorrt.yml
+++ b/.github/workflows/native_jni_s3_tensorrt.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   build-tensorrt-jni-linux:
     runs-on: ubuntu-latest
-    container: deepjavalibrary/ubuntu18.04:tensorrt-cuda116
+    container: nvcr.io/nvidia/tensorrt:22.07-py3
     steps:
       - name: Install Environment
         run: pip3 install awscli --upgrade


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Update tensorrt native build container. To fix the build failure:

```
Run actions/checkout@v3
  with:
    repository: deepjavalibrary/djl
    token: ***
    ssh-strict: true
    ssh-user: git
    persist-credentials: true
    clean: true
    sparse-checkout-cone-mode: true
    fetch-depth: 1
    fetch-tags: false
    show-progress: true
    lfs: false
    submodules: false
    set-safe-directory: true
/usr/bin/docker exec  9ac06233246d88f35f3935ea5249fd86d8a56e2b13bee361a4bc0fd7d0eb51dc sh -c "cat /etc/*release | grep ^ID"
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
```