### PR TITLE
[api] alternative NDArray should not be closed in NDScope

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
@@ -1346,6 +1346,7 @@ public abstract class NDArrayAdapter implements NDArray {
         } else {
             alternativeArray.set(getDataType().asDataType(toByteBuffer()));
         }
+        NDScope.unregister(alternativeArray);
         return alternativeArray;
     }
 }


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
