### PR TITLE
CI: setup cargo-ndk for huggingface tokenizers android builds

### DIFF
--- a/.github/workflows/native_jni_s3_huggingface_android.yml
+++ b/.github/workflows/native_jni_s3_huggingface_android.yml
@@ -31,6 +31,15 @@ jobs:
             ${{ runner.os }}-gradle-
       - name: Install NDK
         run: echo "y" | sudo ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install "ndk;${NDK_VERSION}"
+      - name: Install Rust
+        run: |
+          source "$HOME/.cargo/env"
+          cargo install cargo-ndk
+          rustup target add \
+            aarch64-linux-android \
+            armv7-linux-androideabi \
+            x86_64-linux-android \
+            i686-linux-android
       - name: build android
         run: |
           export ANDROID_NDK=${ANDROID_SDK_ROOT}/ndk/${NDK_VERSION}


### PR DESCRIPTION
## Description ##

Looking at https://github.com/deepjavalibrary/djl/actions/runs/11880763848/job/33104304871#step:6:55, I think I didn't install `cargo-ndk` and also required SDKs properly.

Follow-up of https://github.com/deepjavalibrary/djl/pull/3532

I've tried testing it in my fork: https://github.com/naveen521kk/djl/actions/runs/11881317929/job/33105511288 (it fails because it doesn't have access to the AWS resources).
