### PR TITLE
Fix a typo in `android/tokenizer-native/build.gradle`

### DIFF
--- a/android/tokenizer-native/build.gradle
+++ b/android/tokenizer-native/build.gradle
@@ -108,7 +108,7 @@ afterEvaluate {
 
 tasks.register('processResources') {
     doLast {
-        def url = "https://publish.djl.ai/tokenizer/${tokenizers_version}/jnilib/${djl_version}/android"
+        def url = "https://publish.djl.ai/tokenizers/${tokenizers_version}/jnilib/${djl_version}/android"
         def abis = ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]
         abis.each { abi ->
             def downloadPath = new URL("${url}/${abi}/libdjl_tokenizer.so")


### PR DESCRIPTION
## Description ##

I misspelt the URL in the tokenizer-native android package.

https://github.com/deepjavalibrary/djl/blob/88f7c4e7dccf891b9814d2a97c9542f8e830e2f1/android/tokenizer-native/build.gradle#L111

tokenizer -> tokenizers

This should fix the build failure at https://github.com/deepjavalibrary/djl/actions/runs/11889040754/job/33124806716#step:5:180