### PR TITLE
[pytorch] Update supported versions of pytorch for 0.32.0

### DIFF
--- a/.github/workflows/nightly_publish.yml
+++ b/.github/workflows/nightly_publish.yml
@@ -175,11 +175,12 @@ jobs:
             ${{ runner.os }}-gradle-
       - name: Publish to snapshot repository
         if: ${{ github.event.inputs.mode == '' || github.event.inputs.mode == 'snapshot' }}
+        # PT 1.13.1 is for PT 1.x support, and CUDA 11.x support
+        # PT 2.3.1 is for CUDA 12.1 support
+        # PT 2.5.1 is for CUDA 12.4 support
         run: |
           ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=1.13.1 -Psnapshot
-          ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=2.1.2 -Psnapshot
           ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=2.3.1 -Psnapshot
-          ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=2.4.0 -Psnapshot
           ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=2.5.1 -Psnapshot
           ./gradlew clean engines:ml:xgboost:publish -Pgpu -Psnapshot
           ./gradlew clean publish -Psnapshot

--- a/engines/pytorch/pytorch-engine/README.md
+++ b/engines/pytorch/pytorch-engine/README.md
@@ -51,6 +51,7 @@ The following table illustrates which pytorch version that DJL supports:
 
 | PyTorch engine version | PyTorch native library version            |
 |------------------------|-------------------------------------------|
+| pytorch-engine:0.32.0  | 1.13.1, 2.3.1, **2.5.1**                  |
 | pytorch-engine:0.31.0  | 1.13.1, 2.1.2, 2.3.1, 2.4.0, **2.5.1**    |
 | pytorch-engine:0.30.0  | 1.13.1, 2.1.2, 2.3.1, **2.4.0**           |
 | pytorch-engine:0.29.0  | 1.13.1, 2.1.2, 2.2.2, **2.3.1**           |


### PR DESCRIPTION
## Description ##

Dropping PT 2.1.2 and PT 2.4.0 versions for 0.32.0
- PT 2.1.2 is not needed since 2.3.1 is supported for cu121
- PT 2.4.0 is not needed since 2.5.1 is supported for cu124
