### PR TITLE
[ci] fix ci to test windows properly

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -25,8 +25,9 @@ jobs:
     if: github.repository == 'deepjavalibrary/djl'
     runs-on: ${{ matrix.operating-system }}
     strategy:
+      fail-fast: false
       matrix:
-        operating-system: [ ubuntu-latest, macos-latest ]
+        operating-system: [ ubuntu-latest, macos-latest, windows-latest ]
 
     steps:
       - uses: actions/checkout@v4
@@ -85,7 +86,7 @@ jobs:
         run: ./gradlew :engines:pytorch:pytorch-native:compileJNI
       - name: Test ONNX Runtime
         run: |
-          ./gradlew -Dai.djl.default_engine=OnnxRuntime :integration:clean :integration:test
+          ./gradlew "-Dai.djl.default_engine=OnnxRuntime" :integration:clean :integration:test
       - name: Build with Gradle
         run: ./gradlew build :jacoco:testCodeCoverageReport
       - name: Upload test results
@@ -102,55 +103,3 @@ jobs:
           files: ./jacoco/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
           fail_ci_if_error: false
           path_to_write_report: ./codecov_report.txt
-
-  # Windows platform for testing hybrid engines
-  build-windows:
-    if: github.repository == 'deepjavalibrary/djl'
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'corretto'
-          java-version: 17
-      # Enable gradle cache: https://github.com/actions/cache/blob/master/examples.md#java---gradle
-      - uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('*/build.gradle.kts', 'engines/**/build.gradle.kts', 'extensions/**/build.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-      - uses: dorny/paths-filter@v2
-        id: sentencepiece_changes
-        with:
-          filters: |
-            src:
-              - 'extensions/sentencepiece/**'
-      - name: Compile Sentencepiece JNI
-        if: steps.sentencepiece_changes.outputs.src == 'true'
-        run: ./gradlew :extensions:sentencepiece:compileJNI
-      - uses: dorny/paths-filter@v2
-        id: pytorch_changes
-        with:
-          filters: |
-            src:
-              - 'engines/pytorch/pytorch-native/**'
-      - name: Compile PyTorch JNI
-        if: steps.pytorch_changes.outputs.src == 'true'
-        run: ./gradlew :engines:pytorch:pytorch-native:compileJNI
-      - uses: dorny/paths-filter@v2
-        id: tokenizers_changes
-        with:
-          filters: |
-            src:
-              - 'extensions/tokenizers/**'
-      - name: Compile tokenizers JNI
-        if: steps.tokenizers_changes.outputs.src == 'true'
-        run: ./gradlew :extensions:tokenizers:compileJNI
-      - name: Integration tests
-        # MXNet integration test on Github Action fail due to memory limitation on Windows
-        run: |
-          ./gradlew -Pjni "-Dai.djl.default_engine=PyTorch" test -x examples:test
-          ./gradlew -Pjni --rerun-tasks "-Dai.djl.default_engine=TensorFlow" test -x examples:test
-          ./gradlew --rerun-tasks "-Dai.djl.default_engine=OnnxRuntime" :integration:test

--- a/.github/workflows/nightly_publish.yml
+++ b/.github/workflows/nightly_publish.yml
@@ -15,8 +15,9 @@ jobs:
     if: github.repository == 'deepjavalibrary/djl'
     runs-on: ${{ matrix.operating-system }}
     strategy:
+      fail-fast: false
       matrix:
-        operating-system: [ macos-latest, ubuntu-latest ]
+        operating-system: [ macos-latest, ubuntu-latest, windows-latest ]
 
     steps:
       - uses: actions/checkout@v4
@@ -52,6 +53,7 @@ jobs:
     if: github.repository == 'deepjavalibrary/djl'
     runs-on: ${{ matrix.operating-system }}
     strategy:
+      fail-fast: false
       matrix:
         operating-system: [ macos-latest, ubuntu-latest, windows-latest ]
 
@@ -76,8 +78,9 @@ jobs:
     if: github.repository == 'deepjavalibrary/djl'
     runs-on: ${{ matrix.operating-system }}
     strategy:
+      fail-fast: false
       matrix:
-        operating-system: [ ubuntu-latest, windows-latest ]
+        operating-system: [ macos-latest, ubuntu-latest, windows-latest ]
 
     steps:
       - uses: actions/checkout@v4
@@ -95,6 +98,30 @@ jobs:
             ${{ runner.os }}-gradle-
       - name: Test with Gradle
         run: ./gradlew :integration:test "-Dai.djl.default_engine=TensorFlow"
+
+  test-onnx:
+    if: github.repository == 'deepjavalibrary/djl'
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ macos-latest, ubuntu-latest, windows-latest ]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: 17
+      - uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('*/build.gradle.kts', 'engines/**/build.gradle.kts', 'extensions/**/build.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Test with Gradle
+        run: ./gradlew :integration:test "-Dai.djl.default_engine=OnnxRuntime"
 
   test-aarch64:
     if: github.repository == 'deepjavalibrary/djl'


### PR DESCRIPTION
## Description ##

The continuous workflow for windows is busted, and we've had a silent failure in that test for a long time. 

The issue is that we run 3 separate tests in the final github step of continuous/build-windows, but the success/failure outcome is only dependent on the final command we run. Specifically, we run:
```
./gradlew -Pjni "-Dai.djl.default_engine=PyTorch" test -x examples:test
./gradlew -Pjni --rerun-tasks "-Dai.djl.default_engine=TensorFlow" test -x examples:test
./gradlew --rerun-tasks "-Dai.djl.default_engine=OnnxRuntime" :integration:test
```

When this runs if the 3rd line succeeds, it hides any failure that occurs in the previous two lines.

This change refactors the continuous workflow by unifying the windows test into the existing mac/linux tests, which function as expected. The separate stage for windows may have made sense sometime in the past, it no longer needs to be separate.

I have also modified the nightly-publish workflow to ensure that we test all 3 major OS's across each of the suites. I have also specified fail-fast: false to ensure no short-circuiting of tests due to failures.