### PR TITLE
[djl-convert] Remove onnxruntime from djl-convert requirements.txt

### DIFF
--- a/extensions/tokenizers/src/main/python/requirements.txt
+++ b/extensions/tokenizers/src/main/python/requirements.txt
@@ -3,6 +3,6 @@ transformers
 sentence-transformers
 torch
 protobuf==3.20.2
-optimum[exporters,onnxruntime]
+optimum[exporters]
 safetensors
 requests


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Remove onnxruntime from djl-convert requirements.txt, in order to put djl-convert to requirements-lmi.txt

See https://github.com/deepjavalibrary/djl-serving/pull/2615#discussion_r1868369448