### PR TITLE
fix issue with predictor not validating null NDList

### DIFF
--- a/api/src/main/java/ai/djl/inference/Predictor.java
+++ b/api/src/main/java/ai/djl/inference/Predictor.java
@@ -144,7 +144,10 @@ public class Predictor<I, O> implements AutoCloseable {
     protected NDList predictInternal(TranslatorContext ctx, NDList ndList)
             throws TranslateException {
         logger.trace("Predictor input data: {}", ndList);
-        if (ndList.isEmpty()) {
+        // TODO: this check was (partially) introduced in
+        // https://github.com/deepjavalibrary/djl/pull/3579,
+        // but should ideally not be needed.
+        if (ndList != null && ndList.isEmpty()) {
             return new NDList();
         }
         return block.forward(parameterStore, ndList, false);


### PR DESCRIPTION
## Description ##

This is a temporary workaround to immediately unblock CI on the djl-serving side. The issues we are facing on djl-serving were introduced in https://github.com/deepjavalibrary/djl/pull/3579, but i'm not clear on why the changes to Predictor introduced in that change are needed. 

It also seems that NDList in predictInternal can be null, but that hasn't been an issue so far from what I can tell. This should (hopefully) only be needed as a temporary fix to unblock some PRs on the serving side