### PR TITLE
[examples] fixing some dependencies and test requirements

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -39,6 +39,11 @@
             <version>1.9.0</version>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.17.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j2-impl</artifactId>
             <version>2.24.1</version>

--- a/examples/src/test/java/ai/djl/examples/training/TrainBertOnGoemotionsTest.java
+++ b/examples/src/test/java/ai/djl/examples/training/TrainBertOnGoemotionsTest.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.examples.training;
 
+import ai.djl.testing.TestRequirements;
 import ai.djl.translate.TranslateException;
 
 import org.testng.annotations.Test;
@@ -22,6 +23,8 @@ public class TrainBertOnGoemotionsTest {
 
     @Test
     public void testTrainBert() throws IOException, TranslateException {
+        TestRequirements.engine("PyTorch", "OnnxRuntime");
+
         String[] args = {"-g", "1", "-m", "1", "-e", "1"};
         TrainBertOnGoemotions.runExample(args);
     }

--- a/examples/src/test/java/ai/djl/examples/training/TrainBertTest.java
+++ b/examples/src/test/java/ai/djl/examples/training/TrainBertTest.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.examples.training;
 
+import ai.djl.testing.TestRequirements;
 import ai.djl.translate.TranslateException;
 
 import org.testng.annotations.Test;
@@ -22,6 +23,8 @@ public class TrainBertTest {
 
     @Test
     public void testTrainBert() throws IOException, TranslateException {
+        TestRequirements.engine("PyTorch", "OnnxRuntime");
+
         String[] args = {"-g", "1", "-m", "1", "-e", "1"};
         TrainBertOnCode.runExample(args);
     }

--- a/examples/src/test/java/ai/djl/examples/training/TrainMnistTest.java
+++ b/examples/src/test/java/ai/djl/examples/training/TrainMnistTest.java
@@ -15,6 +15,7 @@ package ai.djl.examples.training;
 import ai.djl.ModelException;
 import ai.djl.examples.inference.cv.ImageClassification;
 import ai.djl.modality.Classifications;
+import ai.djl.testing.TestRequirements;
 import ai.djl.training.TrainingResult;
 import ai.djl.translate.TranslateException;
 
@@ -27,6 +28,8 @@ public class TrainMnistTest {
 
     @Test
     public void testTrainMnist() throws ModelException, TranslateException, IOException {
+        TestRequirements.engine("PyTorch", "TensorFlow", "OnnxRuntime");
+
         double expectedProb;
         if (Boolean.getBoolean("nightly")) {
             String[] args = new String[] {"-g", "1"};

--- a/examples/src/test/java/ai/djl/examples/training/TrainMnistWithLSTMTest.java
+++ b/examples/src/test/java/ai/djl/examples/training/TrainMnistWithLSTMTest.java
@@ -12,6 +12,7 @@
  */
 package ai.djl.examples.training;
 
+import ai.djl.testing.TestRequirements;
 import ai.djl.training.TrainingResult;
 import ai.djl.translate.TranslateException;
 
@@ -24,6 +25,8 @@ public class TrainMnistWithLSTMTest {
 
     @Test
     public void testTrainMnistWithLSTM() throws IOException, TranslateException {
+        TestRequirements.engine("PyTorch", "TensorFlow", "OnnxRuntime");
+
         String[] args = {"-g", "1", "-e", "1", "-m", "2"};
         TrainingResult result = TrainMnistWithLSTM.runExample(args);
         Assert.assertNotNull(result);

--- a/examples/src/test/java/ai/djl/examples/training/TrainTicTacToeTest.java
+++ b/examples/src/test/java/ai/djl/examples/training/TrainTicTacToeTest.java
@@ -13,6 +13,7 @@
 package ai.djl.examples.training;
 
 import ai.djl.engine.Engine;
+import ai.djl.testing.TestRequirements;
 import ai.djl.training.TrainingResult;
 
 import org.testng.Assert;
@@ -24,6 +25,8 @@ public class TrainTicTacToeTest {
 
     @Test
     public void testTrainTicTacToe() throws IOException {
+        TestRequirements.engine("PyTorch");
+
         Engine engine = Engine.getEngine("PyTorch");
         if (Boolean.getBoolean("nightly") && engine.getGpuCount() > 0) {
             String[] args = new String[] {"-g", "1", "-e", "6"};

--- a/examples/src/test/java/ai/djl/examples/training/TrainTimeSeriesTest.java
+++ b/examples/src/test/java/ai/djl/examples/training/TrainTimeSeriesTest.java
@@ -13,6 +13,7 @@
 
 package ai.djl.examples.training;
 
+import ai.djl.testing.TestRequirements;
 import ai.djl.training.TrainingResult;
 import ai.djl.translate.TranslateException;
 
@@ -25,6 +26,8 @@ public class TrainTimeSeriesTest {
 
     @Test
     public void testTrainTimeSeries() throws TranslateException, IOException {
+        TestRequirements.engine("PyTorch", "OnnxRuntime");
+
         String[] args = {"-g", "1", "-e", "5", "-b", "32"};
         TrainingResult result = TrainTimeSeries.runExample(args);
         Assert.assertNotNull(result);


### PR DESCRIPTION
## Description ##

I was doing some testing the examples with ObjectDetection example, with four of the engines our examples support. PyTorch, TensorFlow, OnnxRuntime and MXNet. 

```
export DJL_DEFAULT_ENGINE=[PyTorch, OnnxRuntime, MXNet, TensorFlow]
./gradlew run && mvn package && mvn exec:java -Dexec.mainClass="ai.djl.examples.inference.cv.ObjectDetection"

```

- mvn package was failing because it did not have the common-io version. The error I got was ` NoClassDefFound org/apache/commons/io/input/UnsynchronizedBufferedReader`
- Some of the tests are not supported by some of the engines, because the operations that were used by these examples are not implemented for these engines. Since the default engine is PyTorch, it was succeeding in the CI. Excluding the tests the are not supported by the engines. 
