### PR TITLE
Fix: Corrected 16-bit PCM normalization to avoid overflow issue

### DIFF
--- a/extensions/audio/src/main/java/ai/djl/audio/FFmpegAudioFactory.java
+++ b/extensions/audio/src/main/java/ai/djl/audio/FFmpegAudioFactory.java
@@ -89,12 +89,12 @@ public class FFmpegAudioFactory extends AudioFactory {
             if (buf instanceof ShortBuffer) {
                 ShortBuffer buffer = (ShortBuffer) buf;
                 for (int i = 0; i < buffer.limit(); i++) {
-                    list.add(buffer.get() / (float) Short.MAX_VALUE);
+                    list.add(buffer.get() / 32768.0f);
                 }
             } else if (buf instanceof IntBuffer) {
                 IntBuffer buffer = (IntBuffer) buf;
                 for (int i = 0; i < buffer.limit(); i++) {
-                    list.add(buffer.get() / (float) Integer.MAX_VALUE);
+                    list.add(buffer.get() / 2147483648.0f);
                 }
             } else {
                 throw new UnsupportedOperationException(


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- This PR fixes the incorrect normalization of 16-bit PCM samples.
- Previously, samples were divided by Short.MAX_VALUE (32767), causing -32768 to map slightly below -1.
- Now, division by 32768.0 ensures all values remain within [-1,1].