### PR TITLE
remove status from log4j configuration of status logger

### DIFF
--- a/engines/mxnet/jnarator/src/main/resources/log4j2.xml
+++ b/engines/mxnet/jnarator/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN">
+<Configuration>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout pattern="[%highlight{%-5level}] %msg%n%throwable"/>

--- a/examples/src/main/resources/log4j2.xml
+++ b/examples/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN">
+<Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
       <PatternLayout

--- a/extensions/aws-ai/src/test/resources/log4j2.xml
+++ b/extensions/aws-ai/src/test/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN">
+<Configuration>
     <Appenders>
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout

--- a/integration/src/main/resources/log4j2.xml
+++ b/integration/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN">
+<Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
       <PatternLayout


### PR DESCRIPTION
## Description ##

`status` configuration in log4j is deprecated as of 2.24.x https://logging.apache.org/log4j/2.x/manual/configuration.html#configuration-attribute-status

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
