### PR TITLE
Correct 'Load Model' documentation: method ImageClassificationTranslator.builder().setSynsetArtifactName() does not exist

### DIFF
--- a/docs/load_model.md
+++ b/docs/load_model.md
@@ -70,7 +70,7 @@ The following shows how to load a pre-trained model from a file path:
 ```java
 Criteria<Image, Classifications> criteria = Criteria.builder()
         .setTypes(Image.class, Classifications.class) // defines input and output data type
-        .optTranslator(ImageClassificationTranslator.builder().setSynsetArtifactName("synset.txt").build())
+        .optTranslator(ImageClassificationTranslator.builder().optSynsetArtifactName("synset.txt").build())
         .optModelPath(Paths.get("/var/models/my_resnet50")) // search models in specified path
         .optModelName("model/resnet50") // specify model file prefix
         .build();

--- a/docs/load_model.md
+++ b/docs/load_model.md
@@ -123,7 +123,7 @@ Current supported URL scheme:
 ```java
 Criteria<Image, Classifications> criteria = Criteria.builder()
         .setTypes(Image.class, Classifications.class) // defines input and output data type
-        .optTranslator(ImageClassificationTranslator.builder().setSynsetArtifactName("synset.txt").build())
+        .optTranslator(ImageClassificationTranslator.builder().optSynsetArtifactName("synset.txt").build())
         .optModelUrls("https://resources.djl.ai/benchmark/squeezenet_v1.1.tar.gz") // search models in specified path
         .build();
 


### PR DESCRIPTION
## Description ##

In the [Load models from the local file system](https://djl.ai/docs/load_model.html) section, the provided code example incorrectly uses the method _**.setSynsetArtifactName("synset.txt")**_  It should be  **_.optSynsetArtifactName("synset.txt")_**.

