### PR TITLE
Remove unnecessary exclusion for testng

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -11,9 +11,7 @@ dependencies {
     }
     api(libs.slf4j.api)
 
-    testImplementation(libs.testng) {
-        exclude("junit", "junit")
-    }
+    testImplementation(libs.testng)
     testImplementation(libs.slf4j.simple)
     testRuntimeOnly(project(":engines:pytorch:pytorch-model-zoo"))
     testRuntimeOnly(project(":engines:pytorch:pytorch-jni"))

--- a/djl-zero/build.gradle.kts
+++ b/djl-zero/build.gradle.kts
@@ -10,9 +10,7 @@ dependencies {
     testImplementation(libs.slf4j.simple)
 
     testImplementation(project(":testing"))
-    testImplementation(libs.testng) {
-        exclude("junit", "junit")
-    }
+    testImplementation(libs.testng)
 
     // Current engines and model zoos used for inference
     // runtimeOnly(project(":engines:pytorch:pytorch-engine"))

--- a/engines/mxnet/jnarator/build.gradle.kts
+++ b/engines/mxnet/jnarator/build.gradle.kts
@@ -10,9 +10,7 @@ dependencies {
     api(libs.antlrRuntime)
     api(libs.apache.log4j.slf4j)
 
-    testImplementation(libs.testng) {
-        exclude("junit", "junit")
-    }
+    testImplementation(libs.testng)
 }
 
 tasks {

--- a/engines/pytorch/pytorch-engine/build.gradle.kts
+++ b/engines/pytorch/pytorch-engine/build.gradle.kts
@@ -8,9 +8,7 @@ group = "ai.djl.pytorch"
 dependencies {
     api(project(":api"))
 
-    testImplementation(libs.testng) {
-        exclude("junit", "junit")
-    }
+    testImplementation(libs.testng)
     testImplementation(libs.slf4j.simple)
     testImplementation(project(":testing"))
     testRuntimeOnly(project(":engines:pytorch:pytorch-model-zoo"))

--- a/engines/pytorch/pytorch-model-zoo/build.gradle.kts
+++ b/engines/pytorch/pytorch-model-zoo/build.gradle.kts
@@ -10,9 +10,7 @@ group = "ai.djl.pytorch"
 dependencies {
     api(project(":engines:pytorch:pytorch-engine"))
 
-    testImplementation(libs.testng) {
-        exclude("junit", "junit")
-    }
+    testImplementation(libs.testng)
     testImplementation(libs.slf4j.simple)
     testImplementation(project(":testing"))
 }

--- a/engines/tensorrt/build.gradle.kts
+++ b/engines/tensorrt/build.gradle.kts
@@ -9,9 +9,7 @@ group = "ai.djl.tensorrt"
 dependencies {
     api(project(":api"))
 
-    testImplementation(libs.testng) {
-        exclude("junit", "junit")
-    }
+    testImplementation(libs.testng)
     testImplementation(libs.slf4j.simple)
     testRuntimeOnly(project(":engines:pytorch:pytorch-model-zoo"))
     testRuntimeOnly(project(":engines:pytorch:pytorch-engine"))

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -18,9 +18,7 @@ dependencies {
     runtimeOnly(project(":engines:onnxruntime:onnxruntime-engine"))
     runtimeOnly("com.microsoft.onnxruntime:onnxruntime-extensions:${libs.versions.onnxruntimeExtensions.get()}")
 
-    testImplementation(libs.testng) {
-        exclude("junit", "junit")
-    }
+    testImplementation(libs.testng)
 }
 
 application {

--- a/extensions/aws-ai/build.gradle.kts
+++ b/extensions/aws-ai/build.gradle.kts
@@ -12,9 +12,7 @@ dependencies {
 
     testImplementation(project(":engines:pytorch:pytorch-model-zoo"))
 
-    testImplementation(libs.testng) {
-        exclude("junit", "junit")
-    }
+    testImplementation(libs.testng)
     testImplementation(libs.apache.log4j.slf4j)
 }
 

--- a/model-zoo/build.gradle.kts
+++ b/model-zoo/build.gradle.kts
@@ -8,9 +8,7 @@ plugins {
 dependencies {
     api(project(":api"))
 
-    testImplementation(libs.testng) {
-        exclude("junit", "junit")
-    }
+    testImplementation(libs.testng)
     testImplementation(libs.slf4j.simple)
 }
 

--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     api(project(":api"))
-    api(libs.testng) { exclude("junit", "junit") }
+    api(libs.testng)
 }
 
 tasks.compileJava {


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

testng 7.x no longer depends on junit