### PR TITLE
Correct CaptchaDataset options count to prevent torch.gather IndexError

### DIFF
--- a/basicdataset/src/main/java/ai/djl/basicdataset/cv/classification/CaptchaDataset.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/cv/classification/CaptchaDataset.java
@@ -49,7 +49,7 @@ public class CaptchaDataset extends RandomAccessDataset {
     public static final int IMAGE_WIDTH = 160;
     public static final int IMAGE_HEIGHT = 60;
     public static final int CAPTCHA_LENGTH = 6;
-    public static final int CAPTCHA_OPTIONS = 11;
+    public static final int CAPTCHA_OPTIONS = 12;
 
     private Usage usage;
     private List<String> items;


### PR DESCRIPTION
## Description ##
TrainCaptcha example fails with IndexError :

```java
Exception in thread "main" ai.djl.engine.EngineException: index 11 is out of bounds for dimension 1 with size 11
	at ai.djl.pytorch.jni.PyTorchLibrary.torchGather(Native Method)
	at ai.djl.pytorch.jni.JniUtils.pick(JniUtils.java:581)
	at ai.djl.pytorch.jni.JniUtils.indexAdv(JniUtils.java:417)
	at ai.djl.pytorch.engine.PtNDArrayIndexer.get(PtNDArrayIndexer.java:74)
	at ai.djl.ndarray.NDArray.get(NDArray.java:614)
	at ai.djl.ndarray.NDArray.get(NDArray.java:603)
```
The label ranges from 0-11 ( 11 label is for special case) , the total options count should be 12. 




- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here

