### PR TITLE
Resolve ClassCastException in Example TrainWithHPO

### DIFF
--- a/examples/src/main/java/ai/djl/examples/training/TrainWithHpo.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainWithHpo.java
@@ -15,6 +15,7 @@ package ai.djl.examples.training;
 import ai.djl.Model;
 import ai.djl.basicdataset.cv.classification.Mnist;
 import ai.djl.basicmodelzoo.basic.Mlp;
+import ai.djl.engine.Engine;
 import ai.djl.examples.training.util.Arguments;
 import ai.djl.ndarray.types.Shape;
 import ai.djl.nn.Block;
@@ -103,6 +104,7 @@ public final class TrainWithHpo {
                             .optUsage(usage)
                             .setSampling(arguments.getBatchSize(), true)
                             .optLimit(arguments.getLimit())
+                            .optManager(Engine.getEngine(arguments.getEngine()).newBaseManager())
                             .build();
             mnist.prepare(new ProgressBar());
             return mnist;

--- a/examples/src/main/java/ai/djl/examples/training/TrainWithOptimizers.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainWithOptimizers.java
@@ -181,11 +181,11 @@ public final class TrainWithOptimizers {
                         new Normalize(Cifar10.NORMALIZE_MEAN, Cifar10.NORMALIZE_STD));
         Cifar10 cifar10 =
                 Cifar10.builder()
+                       .optManager(Engine.getEngine(arguments.getEngine()).newBaseManager())
                         .optUsage(usage)
                         .setSampling(arguments.getBatchSize(), true)
                         .optLimit(arguments.getLimit())
                         .optPipeline(pipeline)
-                        .optManager(Engine.getEngine(arguments.getEngine()).newBaseManager())
                         .build();
         cifar10.prepare(new ProgressBar());
         return cifar10;

--- a/examples/src/main/java/ai/djl/examples/training/TrainWithOptimizers.java
+++ b/examples/src/main/java/ai/djl/examples/training/TrainWithOptimizers.java
@@ -16,6 +16,7 @@ import ai.djl.Model;
 import ai.djl.ModelException;
 import ai.djl.basicdataset.cv.classification.Cifar10;
 import ai.djl.basicmodelzoo.cv.classification.ResNetV1;
+import ai.djl.engine.Engine;
 import ai.djl.examples.training.util.Arguments;
 import ai.djl.metric.Metrics;
 import ai.djl.modality.Classifications;
@@ -184,6 +185,7 @@ public final class TrainWithOptimizers {
                         .setSampling(arguments.getBatchSize(), true)
                         .optLimit(arguments.getLimit())
                         .optPipeline(pipeline)
+                        .optManager(Engine.getEngine(arguments.getEngine()).newBaseManager())
                         .build();
         cifar10.prepare(new ProgressBar());
         return cifar10;


### PR DESCRIPTION
## Description ##
env: windows 


When running example **TrainWithHpo** or **TrainWithOptimizers**, a ClassCastException occurs:
```java
Exception in thread "main" java.lang.ClassCastException: class ai.djl.pytorch.engine.PtNDManager cannot be cast to class ai.djl.mxnet.engine.MxNDManager (ai.djl.pytorch.engine.PtNDManager and ai.djl.mxnet.engine.MxNDManager are in unnamed module of loader 'app')
	at ai.djl.mxnet.engine.MxNDArrayEx.getIndexer(MxNDArrayEx.java:1015)
	at ai.djl.ndarray.NDArray.get(NDArray.java:614)
	at ai.djl.training.dataset.ArrayDataset.getByIndices(ArrayDataset.java:118)
	at ai.djl.training.dataset.BulkDataIterable.fetch(BulkDataIterable.java:83)
	at ai.djl.training.dataset.DataIterable.next(DataIterable.java:145)
	at ai.djl.training.dataset.DataIterable.next(DataIterable.java:43)
	at ai.djl.training.EasyTrain.fit(EasyTrain.java:54)
	at ai.djl.training.hyperparameter.EasyHpo.train(EasyHpo.java:93)
```
The model is using the PyTorch engine (arguments.getEngine()), but the dataset is using the default engine (MXNet), causing an NDManager class mismatch.  ( macOs uses pyTorch as default engine, no exception )

## Fix ##
Ensure the dataset uses the same engine as the model by passing arguments.getEngine() when creating the dataset.

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
