### PR TITLE
Fix dimension check when reshaping offsets in SeqBatcher

### DIFF
--- a/api/src/main/java/ai/djl/modality/nlp/generate/SeqBatcher.java
+++ b/api/src/main/java/ai/djl/modality/nlp/generate/SeqBatcher.java
@@ -51,7 +51,7 @@ public class SeqBatcher {
         this.manager = manager.newSubManager();
         this.data = data;
         this.batchUid = batchUid.getShape().dimension() == 2 ? batchUid : batchUid.reshape(-1, 1);
-        this.offSets = offSets.getShape().hashCode() == 2 ? offSets : offSets.reshape(-1, 1);
+        this.offSets = offSets.getShape().dimension() == 2 ? offSets : offSets.reshape(-1, 1);
         batchSize = data.getPastOutputIds().getShape().get(0);
         seqLength = data.getPastOutputIds().getShape().get(1);
         exitIndexEndPosition = new ConcurrentHashMap<>();


### PR DESCRIPTION
## Description ##

In SeqBatcher Constructor, hashCode() can not be used for dimension check:
```
this.offSets = offSets.getShape().hashCode() == 2 ? offSets : offSets.reshape(-1, 1);
```
should be:
```
this.offSets = offSets.getShape().dimension() == 2 ? offSets : offSets.reshape(-1, 1);
```

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
