### PR TITLE
Fix incorrect return value in getImageHeight method

### DIFF
--- a/basicdataset/src/main/java/ai/djl/basicdataset/cv/classification/AbstractImageFolder.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/cv/classification/AbstractImageFolder.java
@@ -150,7 +150,7 @@ public abstract class AbstractImageFolder extends ImageClassificationDataset {
     /** {@inheritDoc} */
     @Override
     public Optional<Integer> getImageHeight() {
-        return Optional.ofNullable(imageWidth);
+        return Optional.ofNullable(imageHeight);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
## Description ##
 a bug in the `getImageHeight` method of the `AbstractImageFolder` class where it was incorrectly returning the `imageWidth` value instead of `imageHeight`.


Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
