### PR TITLE
Fix the out of bounds exception when using an init image

### DIFF
--- a/examples/src/main/java/ai/djl/examples/inference/stablediffusion/StableDiffusionModel.java
+++ b/examples/src/main/java/ai/djl/examples/inference/stablediffusion/StableDiffusionModel.java
@@ -130,7 +130,7 @@ public class StableDiffusionModel {
             // Step 3: Start iterating/generating
             ProgressBar pb = new ProgressBar("Generating", steps);
             pb.start(0);
-            for (int i = 0; i < steps; i++) {
+            for (int i = 0; i < scheduler.getTimesteps().length; i++) {
                 long t = scheduler.getTimesteps()[i];
                 NDArray latentModelOutput = latent.concat(latent);
                 NDArray noisePred =


### PR DESCRIPTION
Brief description of this PR:

When using an init image with the StableDiffusionModel#generateImageFromImage method, an out-of-bounds exception occurs. This happens because the number of steps is less than the actual length of scheduler.getTimesteps().

This PR updates the loop count to use scheduler.getTimesteps().length instead of steps to prevent the exception.



