### PR TITLE
[pytorch] Updates PyTorch to 2.7.0

### DIFF
--- a/.github/workflows/nightly_publish.yml
+++ b/.github/workflows/nightly_publish.yml
@@ -206,11 +206,15 @@ jobs:
         # PT 2.1.2 is for Neuron support (latest supported version on neuron)
         # PT 2.3.1 is for CUDA 12.1 support
         # PT 2.5.1 is for CUDA 12.4 support
+        # PT 2.6.0 is for CUDA 12.4 support
+        # PT 2.7.0 is for CUDA 12.4 support
         run: |
           ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=1.13.1 -Psnapshot
           ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=2.1.2 -Psnapshot
           ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=2.3.1 -Psnapshot
           ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=2.5.1 -Psnapshot
+          ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=2.6.0 -Psnapshot
+          ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=2.7.0 -Psnapshot
           ./gradlew clean engines:ml:xgboost:publish -Pgpu -Psnapshot
           ./gradlew clean publish -Psnapshot
           cd bom
@@ -227,6 +231,8 @@ jobs:
           ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=2.1.2 -P${{ github.event.inputs.mode }}
           ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=2.3.1 -P${{ github.event.inputs.mode }}
           ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=2.5.1 -P${{ github.event.inputs.mode }}
+          ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=2.6.0 -P${{ github.event.inputs.mode }}
+          ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=2.7.0 -P${{ github.event.inputs.mode }}
           ./gradlew clean engines:ml:xgboost:publish -Pgpu -P${{ github.event.inputs.mode }}
           ./gradlew clean publish -P${{ github.event.inputs.mode }}
           cd bom

--- a/.github/workflows/nightly_publish.yml
+++ b/.github/workflows/nightly_publish.yml
@@ -207,7 +207,7 @@ jobs:
         # PT 2.3.1 is for CUDA 12.1 support
         # PT 2.5.1 is for CUDA 12.4 support
         # PT 2.6.0 is for CUDA 12.4 support
-        # PT 2.7.0 is for CUDA 12.4 support
+        # PT 2.7.0 is for CUDA 12.8 support
         run: |
           ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=1.13.1 -Psnapshot
           ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=2.1.2 -Psnapshot

--- a/.github/workflows/nightly_publish.yml
+++ b/.github/workflows/nightly_publish.yml
@@ -215,6 +215,7 @@ jobs:
           ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=2.5.1 -Psnapshot
           ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=2.6.0 -Psnapshot
           ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=2.7.0 -Psnapshot
+          ./gradlew clean engines:pytorch:pytorch-jni:publish -Ppt_version=2.7.1 -Psnapshot
           ./gradlew clean engines:ml:xgboost:publish -Pgpu -Psnapshot
           ./gradlew clean publish -Psnapshot
           cd bom

--- a/engines/pytorch/pytorch-engine/README.md
+++ b/engines/pytorch/pytorch-engine/README.md
@@ -49,38 +49,38 @@ ways to specify PyTorch version:
 
 The following table illustrates which pytorch version that DJL supports:
 
-| PyTorch engine version | PyTorch native library version            |
-|------------------------|-------------------------------------------|
-| pytorch-engine:0.33.0  | 1.13.1, 2.1.2, 2.3.1, **2.5.1**           |
-| pytorch-engine:0.32.0  | 1.13.1, 2.1.2, 2.3.1, **2.5.1**           |
-| pytorch-engine:0.31.0  | 1.13.1, 2.1.2, 2.3.1, 2.4.0, **2.5.1**    |
-| pytorch-engine:0.30.0  | 1.13.1, 2.1.2, 2.3.1, **2.4.0**           |
-| pytorch-engine:0.29.0  | 1.13.1, 2.1.2, 2.2.2, **2.3.1**           |
-| pytorch-engine:0.28.0  | 1.13.1, 2.1.2, **2.2.2**                  |
-| pytorch-engine:0.27.0  | 1.13.1, **2.1.1**                         |
-| pytorch-engine:0.26.0  | 1.13.1, 2.0.1, **2.1.1**                  |
-| pytorch-engine:0.25.0  | 1.11.0, 1.12.1, **1.13.1**, 2.0.1         |
-| pytorch-engine:0.24.0  | 1.11.0, 1.12.1, **1.13.1**, 2.0.1         |
-| pytorch-engine:0.23.0  | 1.11.0, 1.12.1, **1.13.1**, 2.0.1         |
-| pytorch-engine:0.22.1  | 1.11.0, 1.12.1, **1.13.1**, 2.0.0         |
-| pytorch-engine:0.21.0  | 1.11.0, 1.12.1, **1.13.1**                |
-| pytorch-engine:0.20.0  | 1.11.0, 1.12.1, **1.13.0**                |
-| pytorch-engine:0.19.0  | 1.10.0, 1.11.0, **1.12.1**                |
-| pytorch-engine:0.18.0  | 1.9.1, 1.10.0, **1.11.0**                 |
-| pytorch-engine:0.17.0  | 1.9.1, 1.10.0, 1.11.0                     |
-| pytorch-engine:0.16.0  | 1.8.1, 1.9.1, 1.10.0                      |
-| pytorch-engine:0.15.0  | pytorch-native-auto: 1.8.1, 1.9.1, 1.10.0 |
-| pytorch-engine:0.14.0  | pytorch-native-auto: 1.8.1, 1.9.0, 1.9.1  |
-| pytorch-engine:0.13.0  | pytorch-native-auto:1.9.0                 |
-| pytorch-engine:0.12.0  | pytorch-native-auto:1.8.1                 |
-| pytorch-engine:0.11.0  | pytorch-native-auto:1.8.1                 |
-| pytorch-engine:0.10.0  | pytorch-native-auto:1.7.1                 |
-| pytorch-engine:0.9.0   | pytorch-native-auto:1.7.0                 |
-| pytorch-engine:0.8.0   | pytorch-native-auto:1.6.0                 |
-| pytorch-engine:0.7.0   | pytorch-native-auto:1.6.0                 |
-| pytorch-engine:0.6.0   | pytorch-native-auto:1.5.0                 |
-| pytorch-engine:0.5.0   | pytorch-native-auto:1.4.0                 |
-| pytorch-engine:0.4.0   | pytorch-native-auto:1.4.0                 |
+| PyTorch engine version | PyTorch native library version                   |
+|------------------------|--------------------------------------------------|
+| pytorch-engine:0.33.0  | 1.13.1, 2.1.2, 2.3.1, 2.5.1, 2.6.0, **2.7.0**    |
+| pytorch-engine:0.32.0  | 1.13.1, 2.1.2, 2.3.1, **2.5.1**                  |
+| pytorch-engine:0.31.0  | 1.13.1, 2.1.2, 2.3.1, 2.4.0, **2.5.1**           |
+| pytorch-engine:0.30.0  | 1.13.1, 2.1.2, 2.3.1, **2.4.0**                  |
+| pytorch-engine:0.29.0  | 1.13.1, 2.1.2, 2.2.2, **2.3.1**                  |
+| pytorch-engine:0.28.0  | 1.13.1, 2.1.2, **2.2.2**                         |
+| pytorch-engine:0.27.0  | 1.13.1, **2.1.1**                                |
+| pytorch-engine:0.26.0  | 1.13.1, 2.0.1, **2.1.1**                         |
+| pytorch-engine:0.25.0  | 1.11.0, 1.12.1, **1.13.1**, 2.0.1                |
+| pytorch-engine:0.24.0  | 1.11.0, 1.12.1, **1.13.1**, 2.0.1                |
+| pytorch-engine:0.23.0  | 1.11.0, 1.12.1, **1.13.1**, 2.0.1                |
+| pytorch-engine:0.22.1  | 1.11.0, 1.12.1, **1.13.1**, 2.0.0                |
+| pytorch-engine:0.21.0  | 1.11.0, 1.12.1, **1.13.1**                       |
+| pytorch-engine:0.20.0  | 1.11.0, 1.12.1, **1.13.0**                       |
+| pytorch-engine:0.19.0  | 1.10.0, 1.11.0, **1.12.1**                       |
+| pytorch-engine:0.18.0  | 1.9.1, 1.10.0, **1.11.0**                        |
+| pytorch-engine:0.17.0  | 1.9.1, 1.10.0, 1.11.0                            |
+| pytorch-engine:0.16.0  | 1.8.1, 1.9.1, 1.10.0                             |
+| pytorch-engine:0.15.0  | pytorch-native-auto: 1.8.1, 1.9.1, 1.10.0        |
+| pytorch-engine:0.14.0  | pytorch-native-auto: 1.8.1, 1.9.0, 1.9.1         |
+| pytorch-engine:0.13.0  | pytorch-native-auto:1.9.0                        |
+| pytorch-engine:0.12.0  | pytorch-native-auto:1.8.1                        |
+| pytorch-engine:0.11.0  | pytorch-native-auto:1.8.1                        |
+| pytorch-engine:0.10.0  | pytorch-native-auto:1.7.1                        |
+| pytorch-engine:0.9.0   | pytorch-native-auto:1.7.0                        |
+| pytorch-engine:0.8.0   | pytorch-native-auto:1.6.0                        |
+| pytorch-engine:0.7.0   | pytorch-native-auto:1.6.0                        |
+| pytorch-engine:0.6.0   | pytorch-native-auto:1.5.0                        |
+| pytorch-engine:0.5.0   | pytorch-native-auto:1.4.0                        |
+| pytorch-engine:0.4.0   | pytorch-native-auto:1.4.0                        |
 
 ### BOM support
 

--- a/engines/pytorch/pytorch-engine/README.md
+++ b/engines/pytorch/pytorch-engine/README.md
@@ -49,38 +49,38 @@ ways to specify PyTorch version:
 
 The following table illustrates which pytorch version that DJL supports:
 
-| PyTorch engine version | PyTorch native library version                   |
-|------------------------|--------------------------------------------------|
-| pytorch-engine:0.33.0  | 1.13.1, 2.1.2, 2.3.1, 2.5.1, 2.6.0, **2.7.0**    |
-| pytorch-engine:0.32.0  | 1.13.1, 2.1.2, 2.3.1, **2.5.1**                  |
-| pytorch-engine:0.31.0  | 1.13.1, 2.1.2, 2.3.1, 2.4.0, **2.5.1**           |
-| pytorch-engine:0.30.0  | 1.13.1, 2.1.2, 2.3.1, **2.4.0**                  |
-| pytorch-engine:0.29.0  | 1.13.1, 2.1.2, 2.2.2, **2.3.1**                  |
-| pytorch-engine:0.28.0  | 1.13.1, 2.1.2, **2.2.2**                         |
-| pytorch-engine:0.27.0  | 1.13.1, **2.1.1**                                |
-| pytorch-engine:0.26.0  | 1.13.1, 2.0.1, **2.1.1**                         |
-| pytorch-engine:0.25.0  | 1.11.0, 1.12.1, **1.13.1**, 2.0.1                |
-| pytorch-engine:0.24.0  | 1.11.0, 1.12.1, **1.13.1**, 2.0.1                |
-| pytorch-engine:0.23.0  | 1.11.0, 1.12.1, **1.13.1**, 2.0.1                |
-| pytorch-engine:0.22.1  | 1.11.0, 1.12.1, **1.13.1**, 2.0.0                |
-| pytorch-engine:0.21.0  | 1.11.0, 1.12.1, **1.13.1**                       |
-| pytorch-engine:0.20.0  | 1.11.0, 1.12.1, **1.13.0**                       |
-| pytorch-engine:0.19.0  | 1.10.0, 1.11.0, **1.12.1**                       |
-| pytorch-engine:0.18.0  | 1.9.1, 1.10.0, **1.11.0**                        |
-| pytorch-engine:0.17.0  | 1.9.1, 1.10.0, 1.11.0                            |
-| pytorch-engine:0.16.0  | 1.8.1, 1.9.1, 1.10.0                             |
-| pytorch-engine:0.15.0  | pytorch-native-auto: 1.8.1, 1.9.1, 1.10.0        |
-| pytorch-engine:0.14.0  | pytorch-native-auto: 1.8.1, 1.9.0, 1.9.1         |
-| pytorch-engine:0.13.0  | pytorch-native-auto:1.9.0                        |
-| pytorch-engine:0.12.0  | pytorch-native-auto:1.8.1                        |
-| pytorch-engine:0.11.0  | pytorch-native-auto:1.8.1                        |
-| pytorch-engine:0.10.0  | pytorch-native-auto:1.7.1                        |
-| pytorch-engine:0.9.0   | pytorch-native-auto:1.7.0                        |
-| pytorch-engine:0.8.0   | pytorch-native-auto:1.6.0                        |
-| pytorch-engine:0.7.0   | pytorch-native-auto:1.6.0                        |
-| pytorch-engine:0.6.0   | pytorch-native-auto:1.5.0                        |
-| pytorch-engine:0.5.0   | pytorch-native-auto:1.4.0                        |
-| pytorch-engine:0.4.0   | pytorch-native-auto:1.4.0                        |
+| PyTorch engine version | PyTorch native library version                          |
+|------------------------|---------------------------------------------------------|
+| pytorch-engine:0.33.0  | 1.13.1, 2.1.2, 2.3.1, 2.5.1, 2.6.0, 2.7.0, **2.7.1**    |
+| pytorch-engine:0.32.0  | 1.13.1, 2.1.2, 2.3.1, **2.5.1**                         |
+| pytorch-engine:0.31.0  | 1.13.1, 2.1.2, 2.3.1, 2.4.0, **2.5.1**                  |
+| pytorch-engine:0.30.0  | 1.13.1, 2.1.2, 2.3.1, **2.4.0**                         |
+| pytorch-engine:0.29.0  | 1.13.1, 2.1.2, 2.2.2, **2.3.1**                         |
+| pytorch-engine:0.28.0  | 1.13.1, 2.1.2, **2.2.2**                                |
+| pytorch-engine:0.27.0  | 1.13.1, **2.1.1**                                       |
+| pytorch-engine:0.26.0  | 1.13.1, 2.0.1, **2.1.1**                                |
+| pytorch-engine:0.25.0  | 1.11.0, 1.12.1, **1.13.1**, 2.0.1                       |
+| pytorch-engine:0.24.0  | 1.11.0, 1.12.1, **1.13.1**, 2.0.1                       |
+| pytorch-engine:0.23.0  | 1.11.0, 1.12.1, **1.13.1**, 2.0.1                       |
+| pytorch-engine:0.22.1  | 1.11.0, 1.12.1, **1.13.1**, 2.0.0                       |
+| pytorch-engine:0.21.0  | 1.11.0, 1.12.1, **1.13.1**                              |
+| pytorch-engine:0.20.0  | 1.11.0, 1.12.1, **1.13.0**                              |
+| pytorch-engine:0.19.0  | 1.10.0, 1.11.0, **1.12.1**                              |
+| pytorch-engine:0.18.0  | 1.9.1, 1.10.0, **1.11.0**                               |
+| pytorch-engine:0.17.0  | 1.9.1, 1.10.0, 1.11.0                                   |
+| pytorch-engine:0.16.0  | 1.8.1, 1.9.1, 1.10.0                                    |
+| pytorch-engine:0.15.0  | pytorch-native-auto: 1.8.1, 1.9.1, 1.10.0               |
+| pytorch-engine:0.14.0  | pytorch-native-auto: 1.8.1, 1.9.0, 1.9.1                |
+| pytorch-engine:0.13.0  | pytorch-native-auto:1.9.0                               |
+| pytorch-engine:0.12.0  | pytorch-native-auto:1.8.1                               |
+| pytorch-engine:0.11.0  | pytorch-native-auto:1.8.1                               |
+| pytorch-engine:0.10.0  | pytorch-native-auto:1.7.1                               |
+| pytorch-engine:0.9.0   | pytorch-native-auto:1.7.0                               |
+| pytorch-engine:0.8.0   | pytorch-native-auto:1.6.0                               |
+| pytorch-engine:0.7.0   | pytorch-native-auto:1.6.0                               |
+| pytorch-engine:0.6.0   | pytorch-native-auto:1.5.0                               |
+| pytorch-engine:0.5.0   | pytorch-native-auto:1.4.0                               |
+| pytorch-engine:0.4.0   | pytorch-native-auto:1.4.0                               |
 
 ### BOM support
 

--- a/engines/pytorch/pytorch-jni/build.gradle.kts
+++ b/engines/pytorch/pytorch-jni/build.gradle.kts
@@ -37,7 +37,12 @@ tasks {
                 "osx-aarch64/cpu/libdjl_torch.dylib",
                 "win-x86_64/cpu/djl_torch.dll"
             ) + when {
-                ptVersion.matches(Regex("2.[4-7].\\d")) -> listOf(
+                ptVersion.matches(Regex("2.7.\\d")) -> listOf(
+                    "linux-x86_64/cu128/libdjl_torch.so",
+                    "linux-x86_64/cu128-precxx11/libdjl_torch.so",
+                    "win-x86_64/cu128/djl_torch.dll"
+                )
+                ptVersion.matches(Regex("2.[4-6].\\d")) -> listOf(
                     "linux-x86_64/cu124/libdjl_torch.so",
                     "linux-x86_64/cu124-precxx11/libdjl_torch.so",
                     "win-x86_64/cu124/djl_torch.dll"

--- a/engines/pytorch/pytorch-jni/build.gradle.kts
+++ b/engines/pytorch/pytorch-jni/build.gradle.kts
@@ -37,7 +37,7 @@ tasks {
                 "osx-aarch64/cpu/libdjl_torch.dylib",
                 "win-x86_64/cpu/djl_torch.dll"
             ) + when {
-                ptVersion.matches(Regex("2.[4-5].\\d")) -> listOf(
+                ptVersion.matches(Regex("2.[4-7].\\d")) -> listOf(
                     "linux-x86_64/cu124/libdjl_torch.so",
                     "linux-x86_64/cu124-precxx11/libdjl_torch.so",
                     "win-x86_64/cu124/djl_torch.dll"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ format.version = "1.1"
 
 [versions]
 djl = "0.34.0"
-pytorch = "2.5.1"
+pytorch = "2.7.0"
 tensorflow = "2.16.1"
 tensorflowCore = "1.0.0-rc.1"
 mxnet = "1.9.1"
@@ -83,4 +83,3 @@ antlrRuntime = { module = "org.antlr:antlr4-runtime", version.ref = "antlr" }
 testng = { module = "org.testng:testng", version.ref = "testng" }
 junit = { module = "junit:junit", version.ref = "junit" }
 mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
-


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Updates PyTorch to 2.7.0. Changes inspired by this PR: https://github.com/deepjavalibrary/djl/pull/3517. 

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
