### PR TITLE
Add NDArray diagonal

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/NDArray.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArray.java
@@ -4216,6 +4216,66 @@ public interface NDArray extends NDResource, BytesSupplier {
     NDArray cumSum(int axis);
 
     /**
+     * Return specified diagonals.
+     *
+     * <p>Examples
+     *
+     * <pre>
+     * jshell&gt; NDArray array = manager.arange(9.0f).reshape(3, 3);
+     * jshell&gt; array.diagonal();
+     * ND: (3) cpu() float32
+     * [0., 4., 8.]
+     * </pre>
+     *
+     * @return specified diagonals
+     */
+    NDArray diagonal();
+
+    /**
+     * Return specified diagonals.
+     *
+     * <p>Examples
+     *
+     * <pre>
+     * jshell&gt; NDArray array = manager.arange(9.0f).reshape(3, 3);
+     * jshell&gt; array.diagonal(1);
+     * ND: (2) cpu() float32
+     * [1., 5.]
+     * jshell&gt; array.diagonal(-1);
+     * ND: (2) cpu() float32
+     * [3., 7.]
+     * </pre>
+     *
+     * @param offset Offset of the diagonal from the main diagonal. Can be positive or negative.
+     * @return specified diagonals
+     */
+    NDArray diagonal(int offset);
+
+    /**
+     * Return specified diagonals.
+     *
+     * <p>Examples
+     *
+     * <pre>
+     * jshell&gt; NDArray array = manager.arange(27f).reshape(3, 3, 3);
+     * jshell&gt; array.diagonal(0, 1, 2);
+     * ND: (3, 3) cpu() float32
+     * [[ 0.,  4.,  8.],
+     * [ 9., 13., 17.],
+     * [18., 22., 26.],
+     * ]
+     * </pre>
+     *
+     * @param offset Offset of the diagonal from the main diagonal. Can be positive or negative.
+     * @param axis1 Axis to be used as the first axis of the 2-D sub-arrays from which the diagonals
+     *     should be taken.
+     * @param axis2 Axis to be used as the second axis of the 2-D sub-arrays from which the
+     *     diagonals should be taken.
+     * @return specified diagonals
+     */
+    NDArray diagonal(int offset, int axis1, int axis2);
+
+    /**
      * Replace the handle of the NDArray with the other. The NDArray used for replacement will be
      * killed.
      *

--- a/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
@@ -1040,6 +1040,24 @@ public abstract class NDArrayAdapter implements NDArray {
 
     /** {@inheritDoc} */
     @Override
+    public NDArray diagonal() {
+        return getAlternativeArray().diagonal(0);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray diagonal(int offset) {
+        return getAlternativeArray().diagonal(offset);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray diagonal(int offset, int axis1, int axis2) {
+        return getAlternativeArray().diagonal(offset, axis1, axis2);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public NDArray isInfinite() {
         return getAlternativeArray().isInfinite();
     }

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
@@ -1355,6 +1355,24 @@ public class MxNDArray extends NativeResource<Pointer> implements LazyNDArray {
 
     /** {@inheritDoc} */
     @Override
+    public NDArray diagonal() {
+        throw new UnsupportedOperationException();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray diagonal(int offset) {
+        throw new UnsupportedOperationException();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray diagonal(int offset, int axis1, int axis2) {
+        throw new UnsupportedOperationException();
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void intern(NDArray replaced) {
         MxNDArray arr = (MxNDArray) replaced;
         Pointer oldHandle = handle.getAndSet(arr.handle.getAndSet(null));

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -1290,6 +1290,24 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
 
     /** {@inheritDoc} */
     @Override
+    public NDArray diagonal() {
+        return JniUtils.diagonal(this, 0, 0, 1);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray diagonal(int offset) {
+        return JniUtils.diagonal(this, offset, 0, 1);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray diagonal(int offset, int axis1, int axis2) {
+        return JniUtils.diagonal(this, offset, axis1, axis2);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void intern(NDArray replaced) {
         PtNDArray arr = (PtNDArray) replaced;
         Long oldHandle = handle.getAndSet(arr.handle.getAndSet(null));

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/JniUtils.java
@@ -943,6 +943,12 @@ public final class JniUtils {
                 ndArray.getManager(), PyTorchLibrary.LIB.torchCumSum(ndArray.getHandle(), dim));
     }
 
+    public static PtNDArray diagonal(PtNDArray ndArray, long offset, long axis1, long axis2) {
+        return new PtNDArray(
+                ndArray.getManager(),
+                PyTorchLibrary.LIB.torchDiagonal(ndArray.getHandle(), offset, axis1, axis2));
+    }
+
     public static PtNDArray oneHot(PtNDArray ndArray, int depth, DataType dataType) {
         return new PtNDArray(
                         ndArray.getManager(),

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/jni/PyTorchLibrary.java
@@ -268,6 +268,8 @@ final class PyTorchLibrary {
 
     native long torchCumSum(long handle, long dim);
 
+    native long torchDiagonal(long handle, long offset, long axis1, long axis2);
+
     native long torchFlatten(long handle, long startDim, long endDim);
 
     native long torchFft(long handle, long length, long axis);

--- a/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_torch_other.cc
+++ b/engines/pytorch/pytorch-native/src/main/native/ai_djl_pytorch_jni_PyTorchLibrary_torch_other.cc
@@ -137,3 +137,12 @@ JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchViewAsComple
   API_END_RETURN()
 #endif
 }
+
+JNIEXPORT jlong JNICALL Java_ai_djl_pytorch_jni_PyTorchLibrary_torchDiagonal(
+    JNIEnv* env, jobject jthis, jlong jhandle, jlong offset, jlong axis1, jlong axis2) {
+  API_BEGIN()
+  const auto* tensor_ptr = reinterpret_cast<torch::Tensor*>(jhandle);
+  const auto* result_ptr = new torch::Tensor(tensor_ptr->diagonal(offset, axis1, axis2));
+  return reinterpret_cast<uintptr_t>(result_ptr);
+  API_END_RETURN()
+}

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
@@ -1465,6 +1465,24 @@ public class TfNDArray extends NativeResource<TFE_TensorHandle> implements NDArr
 
     /** {@inheritDoc} */
     @Override
+    public NDArray diagonal() {
+        return manager.opExecutor("DiagPart").addInput(this).buildSingletonOrThrow();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray diagonal(int offset) {
+        throw new UnsupportedOperationException();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray diagonal(int offset, int axis1, int axis2) {
+        throw new UnsupportedOperationException();
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void intern(NDArray replaced) {
         throw new UnsupportedOperationException("Not implemented");
     }

--- a/extensions/tokenizers/src/main/java/ai/djl/engine/rust/RsNDArray.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/engine/rust/RsNDArray.java
@@ -1278,6 +1278,24 @@ public class RsNDArray extends NativeResource<Long> implements NDArray {
 
     /** {@inheritDoc} */
     @Override
+    public NDArray diagonal() {
+        throw new UnsupportedOperationException();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray diagonal(int offset) {
+        throw new UnsupportedOperationException();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDArray diagonal(int offset, int axis1, int axis2) {
+        throw new UnsupportedOperationException();
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void intern(NDArray replaced) {
         RsNDArray arr = (RsNDArray) replaced;
         Long oldHandle = handle.getAndSet(arr.handle.getAndSet(null));

--- a/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayOtherOpTest.java
+++ b/integration/src/main/java/ai/djl/integration/tests/ndarray/NDArrayOtherOpTest.java
@@ -527,6 +527,32 @@ public class NDArrayOtherOpTest {
         }
     }
 
+    @Test
+    public void testDiagonal() {
+        try (NDManager manager = NDManager.newBaseManager(TestUtils.getEngine())) {
+            NDArray array = manager.arange(4.0f).reshape(2, 2);
+            NDArray expected = manager.create(new float[] {0f, 3f});
+            Assert.assertEquals(array.diagonal(), expected);
+
+            array = manager.arange(9.0f).reshape(3, 3);
+            expected = manager.create(new float[] {0f, 4f, 8f});
+            Assert.assertEquals(array.diagonal(), expected);
+
+            array = manager.arange(9.0f).reshape(3, 3);
+            expected = manager.create(new float[] {1f, 5f});
+            Assert.assertEquals(array.diagonal(1), expected);
+
+            array = manager.arange(9.0f).reshape(3, 3);
+            expected = manager.create(new float[] {3f, 7f});
+            Assert.assertEquals(array.diagonal(-1), expected);
+
+            array = manager.arange(27f).reshape(3, 3, 3);
+            expected =
+                    manager.create(new float[][] {{0f, 4f, 8f}, {9f, 13f, 17f}, {18f, 22f, 26f}});
+            Assert.assertEquals(array.diagonal(0, 1, 2), expected);
+        }
+    }
+
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testTile() {
         try (NDManager manager = NDManager.newBaseManager(TestUtils.getEngine())) {


### PR DESCRIPTION
## Description ##

Add NDArray diagonal

- In the case of TensorFlow, [DiagPart](https://www.tensorflow.org/api_docs/cc/class/tensorflow/ops/diag-part) was used instead of [Diag](https://www.tensorflow.org/api_docs/cc/class/tensorflow/ops/diag) to produce results in the same format as PyTorch.
- In the case of Apache MXNet, It is identified as a retired project, so it was handled with `UnsupportedOperationException` without additional searching.

close https://github.com/deepjavalibrary/djl/issues/2835.