### PR TITLE
Fix earlystopping metric issue #3722

### DIFF
--- a/api/src/main/java/ai/djl/training/listener/EarlyStoppingListener.java
+++ b/api/src/main/java/ai/djl/training/listener/EarlyStoppingListener.java
@@ -122,7 +122,7 @@ public final class EarlyStoppingListener implements TrainingListener {
         }
     }
 
-    private static double getMetric(TrainingResult trainingResult) {
+    private double getMetric(TrainingResult trainingResult) {
         if ("validateLoss".equals(monitoredMetric)) {
             Float vLoss = trainingResult.getValidateLoss();
             return vLoss != null ? vLoss : Double.NaN;

--- a/api/src/main/java/ai/djl/training/listener/EarlyStoppingListener.java
+++ b/api/src/main/java/ai/djl/training/listener/EarlyStoppingListener.java
@@ -246,6 +246,12 @@ public final class EarlyStoppingListener implements TrainingListener {
             return this;
         }
 
+        /**
+         * Sets the name of the metric to monitor for early stopping.
+         *
+         * @param metricName the name of the metric (e.g., "validateLoss", "trainAccuracy", etc.)
+         * @return this builder instance
+         */
         public Builder optMonitoredMetric(String metricName) {
             this.monitoredMetric = metricName;
             return this;

--- a/api/src/main/java/ai/djl/training/listener/EarlyStoppingListener.java
+++ b/api/src/main/java/ai/djl/training/listener/EarlyStoppingListener.java
@@ -122,16 +122,17 @@ public final class EarlyStoppingListener implements TrainingListener {
         }
     }
 
-    private static double getLoss(TrainingResult trainingResult) {
-        Float vLoss = trainingResult.getValidateLoss();
-        if (vLoss != null) {
-            return vLoss;
+    private static double getMetric(TrainingResult trainingResult) {
+        if ("validateLoss".equals(monitoredMetric)) {
+            Float vLoss = trainingResult.getValidateLoss();
+            return vLoss != null ? vLoss : Double.NaN;
+        } else if ("trainLoss".equals(monitoredMetric)) {
+            Float tLoss = trainingResult.getTrainLoss();
+            return tLoss != null ? tLoss : Double.NaN;
+        } else {
+            Float val = trainingResult.getEvaluations().get(monitoredMetric);
+            return val != null ? val : Double.NaN;
         }
-        Float tLoss = trainingResult.getTrainLoss();
-        if (tLoss == null) {
-            return Double.NaN;
-        }
-        return tLoss;
     }
 
     /** {@inheritDoc} */

--- a/api/src/main/java/ai/djl/training/listener/EarlyStoppingListener.java
+++ b/api/src/main/java/ai/djl/training/listener/EarlyStoppingListener.java
@@ -264,7 +264,12 @@ public final class EarlyStoppingListener implements TrainingListener {
          */
         public EarlyStoppingListener build() {
             return new EarlyStoppingListener(
-                    objectiveSuccess, minEpochs, maxMillis, earlyStopPctImprovement, epochPatience, monitoredMetric);
+                    objectiveSuccess,
+                    minEpochs,
+                    maxMillis,
+                    earlyStopPctImprovement,
+                    epochPatience,
+                    monitoredMetric);
         }
     }
 

--- a/api/src/main/java/ai/djl/training/listener/EarlyStoppingListener.java
+++ b/api/src/main/java/ai/djl/training/listener/EarlyStoppingListener.java
@@ -125,13 +125,13 @@ public final class EarlyStoppingListener implements TrainingListener {
     private double getMetric(TrainingResult trainingResult) {
         if ("validateLoss".equals(monitoredMetric)) {
             Float vLoss = trainingResult.getValidateLoss();
-            return vLoss != null ? vLoss : Double.NaN;
+            return vLoss != null ? vLoss.doubleValue() : Double.NaN;
         } else if ("trainLoss".equals(monitoredMetric)) {
             Float tLoss = trainingResult.getTrainLoss();
-            return tLoss != null ? tLoss : Double.NaN;
+            return tLoss != null ? tLoss.doubleValue() : Double.NaN;
         } else {
             Float val = trainingResult.getEvaluations().get(monitoredMetric);
-            return val != null ? val : Double.NaN;
+            return val != null ? val.doubleValue() : Double.NaN;
         }
     }
 

--- a/api/src/main/java/ai/djl/training/listener/EarlyStoppingListener.java
+++ b/api/src/main/java/ai/djl/training/listener/EarlyStoppingListener.java
@@ -84,14 +84,14 @@ public final class EarlyStoppingListener implements TrainingListener {
     public void onEpoch(Trainer trainer) {
         int currentEpoch = trainer.getTrainingResult().getEpoch();
         // stopping criteria
-        final double loss = getLoss(trainer.getTrainingResult());
+        final double metricValue = getMetric(trainer.getTrainingResult());
         if (currentEpoch >= minEpochs) {
-            if (loss < objectiveSuccess) {
+            if (metricValue < objectiveSuccess) {
                 throw new EarlyStoppedException(
                         currentEpoch,
                         String.format(
                                 "validation loss %s < objectiveSuccess %s",
-                                loss, objectiveSuccess));
+                                metricValue, objectiveSuccess));
             }
             long elapsedMillis = System.currentTimeMillis() - startTimeMills;
             if (elapsedMillis >= maxMillis) {
@@ -102,7 +102,7 @@ public final class EarlyStoppingListener implements TrainingListener {
             // consider early stopping?
             if (Double.isFinite(prevLoss)) {
                 double goalImprovement = prevLoss * (100 - earlyStopPctImprovement) / 100.0;
-                boolean improved = loss <= goalImprovement; // false if any NANs
+                boolean improved = metricValue <= goalImprovement; // false if any NANs
                 if (improved) {
                     numberOfEpochsWithoutImprovements = 0;
                 } else {
@@ -117,8 +117,8 @@ public final class EarlyStoppingListener implements TrainingListener {
                 }
             }
         }
-        if (Double.isFinite(loss)) {
-            prevLoss = loss;
+        if (Double.isFinite(metricValue)) {
+            prevLoss = metricValue;
         }
     }
 

--- a/api/src/main/java/ai/djl/training/listener/EarlyStoppingListener.java
+++ b/api/src/main/java/ai/djl/training/listener/EarlyStoppingListener.java
@@ -62,17 +62,21 @@ public final class EarlyStoppingListener implements TrainingListener {
     private double prevLoss;
     private int numberOfEpochsWithoutImprovements;
 
+    private final String monitoredMetric;
+
     private EarlyStoppingListener(
             double objectiveSuccess,
             int minEpochs,
             long maxMillis,
             double earlyStopPctImprovement,
-            int earlyStopPatience) {
+            int earlyStopPatience,
+            String monitoredMetric) {
         this.objectiveSuccess = objectiveSuccess;
         this.minEpochs = minEpochs;
         this.maxMillis = maxMillis;
         this.earlyStopPctImprovement = earlyStopPctImprovement;
         this.epochPatience = earlyStopPatience;
+        this.monitoredMetric = monitoredMetric;
     }
 
     /** {@inheritDoc} */

--- a/api/src/main/java/ai/djl/training/listener/EarlyStoppingListener.java
+++ b/api/src/main/java/ai/djl/training/listener/EarlyStoppingListener.java
@@ -246,6 +246,11 @@ public final class EarlyStoppingListener implements TrainingListener {
             return this;
         }
 
+        public Builder optMonitoredMetric(String metricName) {
+            this.monitoredMetric = metricName;
+            return this;
+        }
+
         /**
          * Builds a {@link EarlyStoppingListener} with the specified values.
          *

--- a/api/src/main/java/ai/djl/training/listener/EarlyStoppingListener.java
+++ b/api/src/main/java/ai/djl/training/listener/EarlyStoppingListener.java
@@ -177,6 +177,7 @@ public final class EarlyStoppingListener implements TrainingListener {
         private long maxMillis;
         private double earlyStopPctImprovement;
         private int epochPatience;
+        private String monitoredMetric;
 
         /** Constructs a {@link Builder} with default values. */
         public Builder() {
@@ -185,6 +186,7 @@ public final class EarlyStoppingListener implements TrainingListener {
             this.maxMillis = Long.MAX_VALUE;
             this.earlyStopPctImprovement = 0;
             this.epochPatience = 0;
+            this.monitoredMetric = "validateLoss";
         }
 
         /**
@@ -251,7 +253,7 @@ public final class EarlyStoppingListener implements TrainingListener {
          */
         public EarlyStoppingListener build() {
             return new EarlyStoppingListener(
-                    objectiveSuccess, minEpochs, maxMillis, earlyStopPctImprovement, epochPatience);
+                    objectiveSuccess, minEpochs, maxMillis, earlyStopPctImprovement, epochPatience, monitoredMetric);
         }
     }
 

--- a/api/src/main/java/ai/djl/training/listener/EarlyStoppingListener.java
+++ b/api/src/main/java/ai/djl/training/listener/EarlyStoppingListener.java
@@ -59,7 +59,7 @@ public final class EarlyStoppingListener implements TrainingListener {
     private final int epochPatience;
 
     private long startTimeMills;
-    private double prevLoss;
+    private double prevMetricValue;
     private int numberOfEpochsWithoutImprovements;
 
     private final String monitoredMetric;
@@ -100,8 +100,8 @@ public final class EarlyStoppingListener implements TrainingListener {
                         String.format("%s ms elapsed >= %s maxMillis", elapsedMillis, maxMillis));
             }
             // consider early stopping?
-            if (Double.isFinite(prevLoss)) {
-                double goalImprovement = prevLoss * (100 - earlyStopPctImprovement) / 100.0;
+            if (Double.isFinite(prevMetricValue)) {
+                double goalImprovement = prevMetricValue * (100 - earlyStopPctImprovement) / 100.0;
                 boolean improved = metricValue <= goalImprovement; // false if any NANs
                 if (improved) {
                     numberOfEpochsWithoutImprovements = 0;
@@ -118,7 +118,7 @@ public final class EarlyStoppingListener implements TrainingListener {
             }
         }
         if (Double.isFinite(metricValue)) {
-            prevLoss = metricValue;
+            prevMetricValue = metricValue;
         }
     }
 
@@ -151,7 +151,7 @@ public final class EarlyStoppingListener implements TrainingListener {
     @Override
     public void onTrainingBegin(Trainer trainer) {
         this.startTimeMills = System.currentTimeMillis();
-        this.prevLoss = Double.NaN;
+        this.prevMetricValue = Double.NaN;
         this.numberOfEpochsWithoutImprovements = 0;
     }
 


### PR DESCRIPTION
## Description
This PR fixes issue #3722  by extending the `EarlyStoppingListener` to support `"trainLoss"` as a valid monitored metric in addition to the default `"validateLoss"`.

Previously, if a user specified `"trainLoss"` via `.optMonitoredMetric("trainLoss")`, the early stopping logic would not behave as expected because `TrainingResult.getTrainLoss()` was not considered in the metric selection. This update introduces an explicit check for `"trainLoss"` in the `getMetric(...)` method, ensuring it is properly used for early stopping decisions.

### Changes Summary
- The `getMetric(...)` method now explicitly supports `"trainLoss"` in addition to `"validateLoss"`.

### Result
- When using `.optMonitoredMetric("trainLoss")`, training is now stopped early if the training loss fails to improve as specified.
- This improves flexibility for users who want to monitor training loss instead of validation loss.

Closes #3722 