### PR TITLE
[djl-converter] Update license in pyproject.toml

### DIFF
--- a/extensions/tokenizers/src/main/python/pyproject.toml
+++ b/extensions/tokenizers/src/main/python/pyproject.toml
@@ -8,7 +8,7 @@ description = "Model converter utility package"
 authors = [
     { name = "Deep Java Library team", email = "djl-dev@amazon.com" }
 ]
-license = "Apache-2.0"
+license = { text = "Apache-2.0" }
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Update license in pyproject.toml to fix the build error.

https://github.com/deepjavalibrary/djl/actions/runs/16677328359/job/47207085546#step:6:85

```
ValueError: invalid pyproject.toml config: `project.license`.
configuration error: `project.license` must be valid exactly by one definition (2 matches found):

    - keys:
        'file': {type: string}
      required: ['file']
    - keys:
        'text': {type: string}
      required: ['text']
```