### PR TITLE
[api] Use FileUtils.copyURLToFile() in DownloadUtils

### DIFF
--- a/api/src/main/java/ai/djl/training/util/DownloadUtils.java
+++ b/api/src/main/java/ai/djl/training/util/DownloadUtils.java
@@ -12,17 +12,13 @@
  */
 package ai.djl.training.util;
 
-import ai.djl.util.Progress;
+import org.apache.commons.io.FileUtils;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
-import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.util.zip.GZIPInputStream;
 
 /** A utility class downloads the file from specified url. */
 public final class DownloadUtils {
@@ -37,7 +33,7 @@ public final class DownloadUtils {
      * @throws IOException when IO operation fails in downloading
      */
     public static void download(String url, String output) throws IOException {
-        download(url, output, null);
+        download(new URL(url.trim()), Paths.get(output.trim()));
     }
 
     /**
@@ -45,85 +41,12 @@ public final class DownloadUtils {
      *
      * @param url the url to download
      * @param output the output location
-     * @param progress the progress tracker to show download progress
      * @throws IOException when IO operation fails in downloading
      */
-    public static void download(String url, String output, Progress progress) throws IOException {
-        download(new URL(url.trim()), Paths.get(output.trim()), progress);
-    }
-
-    /**
-     * Downloads a file from specified url.
-     *
-     * @param url the url to download
-     * @param output the output location
-     * @param progress the progress tracker to show download progress
-     * @throws IOException when IO operation fails in downloading
-     */
-    public static void download(URL url, Path output, Progress progress) throws IOException {
+    public static void download(URL url, Path output) throws IOException {
         if (Files.exists(output)) {
             return;
         }
-        Path dir = output.toAbsolutePath().getParent();
-        if (dir != null) {
-            Files.createDirectories(dir);
-        }
-        URLConnection conn = url.openConnection();
-        if (progress != null) {
-            long contentLength = conn.getContentLengthLong();
-            if (contentLength > 0) {
-                progress.reset("Downloading", contentLength, output.toFile().getName());
-            }
-        }
-        try (InputStream is = conn.getInputStream()) {
-            ProgressInputStream pis = new ProgressInputStream(is, progress);
-            String fileName = url.getFile();
-            if (fileName.endsWith(".gz")) {
-                Files.copy(new GZIPInputStream(pis), output, StandardCopyOption.REPLACE_EXISTING);
-            } else {
-                Files.copy(pis, output, StandardCopyOption.REPLACE_EXISTING);
-            }
-        }
-    }
-
-    private static final class ProgressInputStream extends InputStream {
-
-        private InputStream is;
-        private Progress progress;
-
-        public ProgressInputStream(InputStream is, Progress progress) {
-            this.is = is;
-            this.progress = progress;
-        }
-
-        /** {@inheritDoc} */
-        @Override
-        public int read() throws IOException {
-            int ret = is.read();
-            if (progress != null) {
-                if (ret >= 0) {
-                    progress.increment(1);
-                } else {
-                    progress.end();
-                }
-            }
-            return ret;
-        }
-
-        /** {@inheritDoc} */
-        @Override
-        public int read(byte[] b, int off, int len) throws IOException {
-            int size = is.read(b, off, len);
-            if (progress != null) {
-                progress.increment(size);
-            }
-            return size;
-        }
-
-        /** {@inheritDoc} */
-        @Override
-        public void close() throws IOException {
-            is.close();
-        }
+        FileUtils.copyURLToFile(url, output.toFile());
     }
 }

--- a/examples/src/main/java/ai/djl/examples/inference/whisper/WhisperJet.java
+++ b/examples/src/main/java/ai/djl/examples/inference/whisper/WhisperJet.java
@@ -24,7 +24,6 @@ import ai.djl.ndarray.types.Shape;
 import ai.djl.repository.zoo.Criteria;
 import ai.djl.repository.zoo.ZooModel;
 import ai.djl.training.util.DownloadUtils;
-import ai.djl.training.util.ProgressBar;
 import ai.djl.translate.NoBatchifyTranslator;
 import ai.djl.translate.NoopTranslator;
 import ai.djl.translate.TranslateException;
@@ -73,7 +72,7 @@ public final class WhisperJet {
 
         String url = "https://resources.djl.ai/audios/testEN.wav";
         Path file = Paths.get("build/tmp/testEn.wav");
-        DownloadUtils.download(new URL(url), file, new ProgressBar());
+        DownloadUtils.download(new URL(url), file);
         Audio audio = AudioFactory.newInstance().fromFile(file);
         AudioInput input = new AudioInput(audio, "en");
         try (ZooModel<AudioInput, String> model = criteria.loadModel();

--- a/extensions/tokenizers/src/test/java/ai/djl/huggingface/tokenizers/BpeTokenizerBuilderTest.java
+++ b/extensions/tokenizers/src/test/java/ai/djl/huggingface/tokenizers/BpeTokenizerBuilderTest.java
@@ -31,9 +31,9 @@ public class BpeTokenizerBuilderTest {
         Path merges = bpe.resolve("merges.txt");
 
         DownloadUtils.download(
-                new URL("https://resources.djl.ai/test-models/tokenizer/vocab.json"), vocab, null);
+                new URL("https://resources.djl.ai/test-models/tokenizer/vocab.json"), vocab);
         DownloadUtils.download(
-                new URL("https://resources.djl.ai/test-models/tokenizer/merges.txt"), merges, null);
+                new URL("https://resources.djl.ai/test-models/tokenizer/merges.txt"), merges);
 
         try (HuggingFaceTokenizer tokenizer =
                 HuggingFaceTokenizer.builder().optTokenizerPath(bpe).build()) {


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Remove DownloadUtils and replace it with apache commons `FileUtils.copyURLToFile()` to resolve the security incident saying that DJL `DownloadUtils.download()` lack validation so it might download from a malicious url, or overwrite content in `/etc/passwd`, `/root/.ssh/authorized_keys`, etc.