### PR TITLE
Issues related to the DownloadUtils vulnerability

### DIFF
--- a/api/src/main/java/ai/djl/training/util/DownloadUtils.java
+++ b/api/src/main/java/ai/djl/training/util/DownloadUtils.java
@@ -24,6 +24,9 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.zip.GZIPInputStream;
 
+import java.net.MalformedURLException;
+import java.nio.file.InvalidPathException;
+
 /** A utility class downloads the file from specified url. */
 public final class DownloadUtils {
 


### PR DESCRIPTION
## Description ##

Hello, I'm the person who reported the related vulnerability on huntr.com.

As you mentioned, due to the if (Files.exists(output)) line, existing files are indeed not overwritten. 
- https://github.com/deepjavalibrary/djl/pull/3753

I apologize for the incorrect information in my initial report.

However, since there is no validation for the url and output parameters, an attacker can still create arbitrary files in arbitrary locations. The overwrite prevention only limits part of the attack. This still allows for malicious files to be placed on the server or for large files to be downloaded, potentially leading to denial-of-service conditions. Additionally, depending on the server's configuration, an attacker could download a malicious file to execute a web shell.

I just finished updating and resubmitting the issue I previously reported on huntr.com.
I would appreciate it if you could review this issue once again.