### PR TITLE
[ci] Add post-publish task

### DIFF
--- a/android/pytorch-native/build.gradle
+++ b/android/pytorch-native/build.gradle
@@ -1,3 +1,7 @@
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.Base64
+
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
@@ -105,6 +109,30 @@ afterEvaluate {
     }
 }
 
+// Post-publish task to make deployment visible in Central Publisher Portal.
+// See https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#ensuring-deployment-visibility-in-the-central-publisher-portal
+if (project.hasProperty("staging")) {
+    def url = "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/${project.group}"
+    def username = findProperty("sonatypeUsername").toString()
+    def password = findProperty("sonatypePassword").toString()
+    def token = Base64.encoder.encodeToString("${username}:${password}".bytes)
+
+    tasks.register("postPublish") {
+        doLast {
+            HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection()
+            conn.requestMethod = "POST"
+            conn.setRequestProperty("Authorization", "Bearer ${token}")
+            int status = conn.responseCode
+            if (status != HttpURLConnection.HTTP_OK) {
+                throw new GradleException("Failed to POST '${url}'. Received status code ${status}: ${conn.responseMessage}")
+            }
+        }
+    }
+
+    tasks.named("publish") {
+        finalizedBy("postPublish")
+    }
+}
 
 tasks.register('processResources') {
     doLast {

--- a/android/tokenizer-native/build.gradle
+++ b/android/tokenizer-native/build.gradle
@@ -1,3 +1,7 @@
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.Base64
+
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
@@ -105,6 +109,30 @@ afterEvaluate {
     }
 }
 
+// Post-publish task to make deployment visible in Central Publisher Portal.
+// See https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#ensuring-deployment-visibility-in-the-central-publisher-portal
+if (project.hasProperty("staging")) {
+    def url = "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/${project.group}"
+    def username = findProperty("sonatypeUsername").toString()
+    def password = findProperty("sonatypePassword").toString()
+    def token = Base64.encoder.encodeToString("${username}:${password}".bytes)
+
+    tasks.register("postPublish") {
+        doLast {
+            HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection()
+            conn.requestMethod = "POST"
+            conn.setRequestProperty("Authorization", "Bearer ${token}")
+            int status = conn.responseCode
+            if (status != HttpURLConnection.HTTP_OK) {
+                throw new GradleException("Failed to POST '${url}'. Received status code ${status}: ${conn.responseMessage}")
+            }
+        }
+    }
+
+    tasks.named("publish") {
+        finalizedBy("postPublish")
+    }
+}
 
 tasks.register('processResources') {
     doLast {

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.Base64
 import org.w3c.dom.Element
 
 plugins {
@@ -183,5 +186,30 @@ signing {
         val signingPassword = findProperty("signingPassword").toString()
         useInMemoryPgpKeys(signingKey, signingPassword)
         sign(publishing.publications["bom"])
+    }
+}
+
+// Post-publish task to make deployment visible in Central Publisher Portal.
+// See https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#ensuring-deployment-visibility-in-the-central-publisher-portal
+if (project.hasProperty("staging")) {
+    val url = "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/${project.group}"
+    val username = findProperty("sonatypeUsername").toString()
+    val password = findProperty("sonatypePassword").toString()
+    val token = Base64.getEncoder().encodeToString("${username}:${password}".toByteArray())
+
+    tasks.register("postPublish") {
+        doLast {
+            val conn = URL(url).openConnection() as HttpURLConnection
+            conn.requestMethod = "POST"
+            conn.setRequestProperty("Authorization", "Bearer ${token}")
+            val status = conn.responseCode
+            if (status != HttpURLConnection.HTTP_OK) {
+                throw GradleException("Failed to POST '${url}'. Received status code ${status}: ${conn.responseMessage}")
+            }
+        }
+    }
+
+    tasks.named("publish") {
+        finalizedBy(tasks.named("postPublish"))
     }
 }

--- a/buildSrc/src/main/kotlin/ai/djl/publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/ai/djl/publish.gradle.kts
@@ -1,5 +1,8 @@
 package ai.djl
 
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.Base64
 import org.gradle.kotlin.dsl.*
 
 plugins {
@@ -95,6 +98,31 @@ tasks {
         val signingPassword = findProperty("signingPassword") as String?
         useInMemoryPgpKeys(signingKey, signingPassword)
         sign(publishing.publications["maven"])
+    }
+}
+
+// Post-publish task to make deployment visible in Central Publisher Portal.
+// See https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#ensuring-deployment-visibility-in-the-central-publisher-portal
+if (project.hasProperty("staging")) {
+    val url = "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/${project.group}"
+    val username = findProperty("sonatypeUsername").toString()
+    val password = findProperty("sonatypePassword").toString()
+    val token = Base64.getEncoder().encodeToString("${username}:${password}".toByteArray())
+
+    tasks.register("postPublish") {
+        doLast {
+            val conn = URL(url).openConnection() as HttpURLConnection
+            conn.requestMethod = "POST"
+            conn.setRequestProperty("Authorization", "Bearer ${token}")
+            val status = conn.responseCode
+            if (status != HttpURLConnection.HTTP_OK) {
+                throw GradleException("Failed to POST '${url}'. Received status code ${status}: ${conn.responseMessage}")
+            }
+        }
+    }
+
+    tasks.named("publish") {
+        finalizedBy(tasks.named("postPublish"))
     }
 }
 

--- a/engines/mxnet/native/build.gradle.kts
+++ b/engines/mxnet/native/build.gradle.kts
@@ -1,3 +1,8 @@
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.Base64
+import kotlin.collections.ArrayList
+
 plugins {
     ai.djl.javaProject
     `maven-publish`
@@ -225,5 +230,30 @@ tasks {
                 into(binaryRoot / "cu112mkl/linux/native/lib")
             }
         }
+    }
+}
+
+// Post-publish task to make deployment visible in Central Publisher Portal.
+// See https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#ensuring-deployment-visibility-in-the-central-publisher-portal
+if (project.hasProperty("staging")) {
+    val url = "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/${project.group}"
+    val username = findProperty("sonatypeUsername").toString()
+    val password = findProperty("sonatypePassword").toString()
+    val token = Base64.getEncoder().encodeToString("${username}:${password}".toByteArray())
+
+    tasks.register("postPublish") {
+        doLast {
+            val conn = URL(url).openConnection() as HttpURLConnection
+            conn.requestMethod = "POST"
+            conn.setRequestProperty("Authorization", "Bearer ${token}")
+            val status = conn.responseCode
+            if (status != HttpURLConnection.HTTP_OK) {
+                project.logger.error("Failed to POST '${url}'. Received status code ${status}: ${conn.responseMessage}")
+            }
+        }
+    }
+
+    tasks.named("publish") {
+        finalizedBy(tasks.named("postPublish"))
     }
 }

--- a/engines/tensorflow/tensorflow-native/build.gradle.kts
+++ b/engines/tensorflow/tensorflow-native/build.gradle.kts
@@ -1,6 +1,9 @@
+import java.net.HttpURLConnection
 import java.net.URL
+import java.util.Base64
 import java.util.zip.GZIPOutputStream
 import java.util.zip.ZipInputStream
+import kotlin.collections.ArrayList
 
 plugins {
     ai.djl.javaProject
@@ -250,5 +253,30 @@ tasks {
                 "$url/$f".url gzipInto file
             }
         }
+    }
+}
+
+// Post-publish task to make deployment visible in Central Publisher Portal.
+// See https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#ensuring-deployment-visibility-in-the-central-publisher-portal
+if (project.hasProperty("staging")) {
+    val url = "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/${project.group}"
+    val username = findProperty("sonatypeUsername").toString()
+    val password = findProperty("sonatypePassword").toString()
+    val token = Base64.getEncoder().encodeToString("${username}:${password}".toByteArray())
+
+    tasks.register("postPublish") {
+        doLast {
+            val conn = URL(url).openConnection() as HttpURLConnection
+            conn.requestMethod = "POST"
+            conn.setRequestProperty("Authorization", "Bearer ${token}")
+            val status = conn.responseCode
+            if (status != HttpURLConnection.HTTP_OK) {
+                project.logger.error("Failed to POST '${url}'. Received status code ${status}: ${conn.responseMessage}")
+            }
+        }
+    }
+
+    tasks.named("publish") {
+        finalizedBy(tasks.named("postPublish"))
     }
 }


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

Post-publish task to make deployment visible in Central Publisher Portal.

See https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#getting-started-for-maven-api-like-plugins