### PR TITLE
[fix] Fixes load tokenizer gpu shared library issue

### DIFF
--- a/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/LibUtils.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/huggingface/tokenizers/jni/LibUtils.java
@@ -167,6 +167,7 @@ public final class LibUtils {
                         flavor,
                         cudaArch);
                 flavor = "cpu"; // Fallback to CPU
+                cudaArch = "";
             }
         }
 


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
