### PR TITLE
Fix `BaseNDManager.debugDump`

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
@@ -423,7 +423,7 @@ public abstract class BaseNDManager implements NDManager {
             sb.append("    ");
         }
         sb.append("\\--- NDManager(")
-                .append(uid.substring(24))
+                .append(uid)
                 .append(") resource count: ")
                 .append(resources.size());
 


### PR DESCRIPTION
Since https://github.com/deepjavalibrary/djl/pull/3719 calls to `uid.substring(24)` fail with `java.lang.StringIndexOutOfBoundsException`.

This means that `BaseNDManager.debugDump(int)` can't be used, and the [advice to use it in the docs is misleading](https://github.com/deepjavalibrary/djl/blob/90d5f38077ef7aced358820d9870cb7311c0a3da/docs/development/memory_management.md?plain=1#L68).

This PR simply avoids the substring.

Previous code to show the exception:
```java
public void testDebugDump() {
    try (BaseNDManager manager = (BaseNDManager)NDManager.newBaseManager()) {
        manager.debugDump(2);
    }
}
```
Results in:
```
java.lang.StringIndexOutOfBoundsException: Range [24, 20) out of bounds for length 20
        at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:55)
        at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:52)
        at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:213)
        at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:210)
        at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:98)
        at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckFromToIndex(Preconditions.java:112)
        at java.base/jdk.internal.util.Preconditions.checkFromToIndex(Preconditions.java:349)
        at java.base/java.lang.String.checkBoundsBeginEnd(String.java:4865)
        at java.base/java.lang.String.substring(String.java:2834)
        at java.base/java.lang.String.substring(String.java:2807)
        at ai.djl.ndarray.BaseNDManager.debugDump(BaseNDManager.java:426)
        at ai.djl.ndarray.NDScopeTest.testDebugDump(NDScopeTest.java:56)
```