### PR TITLE
Added support for CSV inference input/output and corresponding tests

### DIFF
--- a/api/src/main/java/ai/djl/translate/NoopServingTranslatorFactory.java
+++ b/api/src/main/java/ai/djl/translate/NoopServingTranslatorFactory.java
@@ -222,7 +222,7 @@ public class NoopServingTranslatorFactory implements TranslatorFactory {
 
                 float[][] data = rows.toArray(new float[0][]);
                 return new NDList(manager.create(data));
-            } catch (Exception e) {
+            } catch (IOException | NumberFormatException e) {
                 throw new TranslateException("Failed to parse CSV data", e);
             }
         }

--- a/api/src/main/java/ai/djl/translate/NoopServingTranslatorFactory.java
+++ b/api/src/main/java/ai/djl/translate/NoopServingTranslatorFactory.java
@@ -240,7 +240,7 @@ public class NoopServingTranslatorFactory implements TranslatorFactory {
         }
 
         private String toCsv(NDList list) {
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = new StringBuilder(4096);
             for (NDArray array : list) {
                 Number[] data = array.toArray();
                 long[] shape = array.getShape().getShape();

--- a/api/src/test/java/ai/djl/translate/NoopServingTranslatorFactoryTest.java
+++ b/api/src/test/java/ai/djl/translate/NoopServingTranslatorFactoryTest.java
@@ -62,6 +62,23 @@ public class NoopServingTranslatorFactoryTest {
             Output out = predictor.predict(in);
             BytesSupplier outData = out.getData();
             Assert.assertEquals(outData.getAsString(), "{\"predictions\":[[1.0,0.1],[2.0,0.2]]}");
+
+            // Test CSV input with JSON output
+            Input csvJsonIn = new Input();
+            csvJsonIn.addProperty("Content-Type", "text/csv");
+            csvJsonIn.addProperty("Accept", "application/json");
+            csvJsonIn.add("1.0,0.1\n2.0,0.2\n");
+            Output csvJsonOut = predictor.predict(csvJsonIn);
+            Assert.assertEquals(
+                    csvJsonOut.getData().getAsString(), "{\"predictions\":[[1.0,0.1],[2.0,0.2]]}");
+
+            // Test CSV input with CSV output
+            Input csvCsvIn = new Input();
+            csvCsvIn.addProperty("Content-Type", "text/csv");
+            csvCsvIn.addProperty("Accept", "text/csv");
+            csvCsvIn.add("1.0,0.1\n2.0,0.2\n");
+            Output csvCsvOut = predictor.predict(csvCsvIn);
+            Assert.assertEquals(csvCsvOut.getData().getAsString(), "1.0,0.1\n2.0,0.2\n");
         }
     }
 }


### PR DESCRIPTION
## Description ##

**Summary**
Adds CSV input processing capability to NoopServingTranslatorFactory, enabling direct CSV data ingestion for model inference 

**Changes**
CSV Input Processing : Added parseCsv() method to parse CSV data into NDList format

CSV Output Support : Added toCsv() method for CSV output when Accept: text/csv is specified

Content-Type Handling : Extended to recognize text/csv input format

**Test Coverage : Added test cases**

- Tests CSV input with JSON output
- Tests CSV input with CSV output 