### PR TITLE
Implemented CSV translator that handles CSV input/output support for XGBoost

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
 
     testImplementation(project(":testing"))
     testImplementation(libs.testng)
-    runtimeOnly(project(":basicdataset"))
     testImplementation(project(":basicdataset"))
     testImplementation(libs.slf4j.simple)
     testRuntimeOnly(project(":engines:pytorch:pytorch-model-zoo"))

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
 
     testImplementation(project(":testing"))
     testImplementation(libs.testng)
+    runtimeOnly(project(":basicdataset"))
+    testImplementation(project(":basicdataset"))
     testImplementation(libs.slf4j.simple)
     testRuntimeOnly(project(":engines:pytorch:pytorch-model-zoo"))
     testRuntimeOnly(project(":engines:pytorch:pytorch-jni"))

--- a/api/src/main/java/ai/djl/translate/NoopServingTranslatorFactory.java
+++ b/api/src/main/java/ai/djl/translate/NoopServingTranslatorFactory.java
@@ -84,7 +84,7 @@ public class NoopServingTranslatorFactory implements TranslatorFactory {
                         if (csvTranslatorClass == null) {
                             csvTranslatorClass =
                                     Class.forName("ai.djl.basicdataset.tabular.CsvTranslator");
-                            csvConstructor = csvTranslatorClass.getConstructor(Map.class);
+                            csvConstructor = csvTranslatorClass.getConstructor();
                             csvProcessInputMethod =
                                     csvTranslatorClass.getMethod(
                                             "processInput", TranslatorContext.class, String.class);
@@ -94,7 +94,7 @@ public class NoopServingTranslatorFactory implements TranslatorFactory {
                         }
                     }
                 }
-                csvTranslator = csvConstructor.newInstance(Collections.emptyMap());
+                csvTranslator = csvConstructor.newInstance();
                 this.csvProcessInput = NoopServingTranslatorFactory.csvProcessInputMethod;
                 this.csvProcessOutput = NoopServingTranslatorFactory.csvProcessOutputMethod;
             } catch (ReflectiveOperationException e) {
@@ -201,8 +201,6 @@ public class NoopServingTranslatorFactory implements TranslatorFactory {
             }
             return output;
         }
-
-        // --- CSV helper methods ---
 
         private NDList processCsvInput(TranslatorContext ctx, String csvData)
                 throws TranslateException {

--- a/api/src/test/java/ai/djl/translate/NoopServingTranslatorFactoryTest.java
+++ b/api/src/test/java/ai/djl/translate/NoopServingTranslatorFactoryTest.java
@@ -113,14 +113,15 @@ public class NoopServingTranslatorFactoryTest {
                         msg.contains("Non-numeric"), "Unexpected exception message: " + msg);
             }
 
-            // Header row should be skipped
-            Input headerIn = new Input();
-            headerIn.addProperty("Content-Type", "text/csv");
-            headerIn.addProperty("Accept", "application/json");
-            headerIn.add("feature1,feature2\n1.0,0.1\n2.0,0.2\n");
-            Output headerOut = predictor.predict(headerIn);
+            // CSV with header should skip header and return predictions
+            Input csvWithHeaderIn = new Input();
+            csvWithHeaderIn.addProperty("Content-Type", "text/csv");
+            csvWithHeaderIn.addProperty("Accept", "application/json");
+            csvWithHeaderIn.add("feature1,feature2\n1.0,0.1\n2.0,0.2\n");
+            Output csvWithHeaderOut = predictor.predict(csvWithHeaderIn);
             Assert.assertEquals(
-                    headerOut.getData().getAsString(), "{\"predictions\":[[1.0,0.1],[2.0,0.2]]}");
+                    csvWithHeaderOut.getData().getAsString(),
+                    "{\"predictions\":[[1.0,0.1],[2.0,0.2]]}");
 
             // Empty CSV should fail
             Input emptyIn = new Input();

--- a/api/src/test/java/ai/djl/translate/NoopServingTranslatorFactoryTest.java
+++ b/api/src/test/java/ai/djl/translate/NoopServingTranslatorFactoryTest.java
@@ -51,6 +51,7 @@ public class NoopServingTranslatorFactoryTest {
 
         try (ZooModel<Input, Output> model = criteria.loadModel();
                 Predictor<Input, Output> predictor = model.newPredictor()) {
+
             Input in = new Input();
             in.addProperty("Content-Type", "application/json; charset=UTF-8");
             Map<String, List<List<Number>>> data = new ConcurrentHashMap<>();
@@ -62,6 +63,81 @@ public class NoopServingTranslatorFactoryTest {
             Output out = predictor.predict(in);
             BytesSupplier outData = out.getData();
             Assert.assertEquals(outData.getAsString(), "{\"predictions\":[[1.0,0.1],[2.0,0.2]]}");
+
+            // CSV input / JSON output
+            Input csvJsonIn = new Input();
+            csvJsonIn.addProperty("Content-Type", "text/csv");
+            csvJsonIn.addProperty("Accept", "application/json");
+            csvJsonIn.add("1.0,0.1\n2.0,0.2\n");
+            Output csvJsonOut = predictor.predict(csvJsonIn);
+            Assert.assertEquals(
+                    csvJsonOut.getData().getAsString(), "{\"predictions\":[[1.0,0.1],[2.0,0.2]]}");
+
+            // CSV input / CSV output
+            Input csvCsvIn = new Input();
+            csvCsvIn.addProperty("Content-Type", "text/csv");
+            csvCsvIn.addProperty("Accept", "text/csv");
+            csvCsvIn.add("1.0,0.1\n2.0,0.2\n");
+            Output csvCsvOut = predictor.predict(csvCsvIn);
+            Assert.assertEquals(csvCsvOut.getData().getAsString(), "1.0,0.1\n2.0,0.2\n");
+
+            // Uneven rows should fail
+            Input unevenRowsIn = new Input();
+            unevenRowsIn.addProperty("Content-Type", "text/csv");
+            unevenRowsIn.add("1.0,0.1\n2.0,0.2,0.3\n");
+            try {
+                predictor.predict(unevenRowsIn);
+                Assert.fail("Should have thrown exception for uneven rows");
+            } catch (Exception e) {
+                String msg = e.getMessage();
+                if (e.getCause() != null) {
+                    msg += " | cause: " + e.getCause().getMessage();
+                }
+                Assert.assertTrue(
+                        msg.contains("columns, expected"), "Unexpected exception message: " + msg);
+            }
+
+            // Non-numeric should fail
+            Input nonNumericIn = new Input();
+            nonNumericIn.addProperty("Content-Type", "text/csv");
+            nonNumericIn.add("1.0,hello\n2.0,0.2\n");
+            try {
+                predictor.predict(nonNumericIn);
+                Assert.fail("Should have thrown exception for non-numeric data");
+            } catch (Exception e) {
+                String msg = e.getMessage();
+                if (e.getCause() != null) {
+                    msg += " | cause: " + e.getCause().getMessage();
+                }
+                Assert.assertTrue(
+                        msg.contains("Non-numeric"), "Unexpected exception message: " + msg);
+            }
+
+            // Header row should be skipped
+            Input headerIn = new Input();
+            headerIn.addProperty("Content-Type", "text/csv");
+            headerIn.addProperty("Accept", "application/json");
+            headerIn.add("feature1,feature2\n1.0,0.1\n2.0,0.2\n");
+            Output headerOut = predictor.predict(headerIn);
+            Assert.assertEquals(
+                    headerOut.getData().getAsString(), "{\"predictions\":[[1.0,0.1],[2.0,0.2]]}");
+
+            // Empty CSV should fail
+            Input emptyIn = new Input();
+            emptyIn.addProperty("Content-Type", "text/csv");
+            emptyIn.add("");
+            try {
+                predictor.predict(emptyIn);
+                Assert.fail("Should have thrown exception for empty CSV");
+            } catch (Exception e) {
+                String msg = e.getMessage();
+                if (e.getCause() != null) {
+                    msg += " | cause: " + e.getCause().getMessage();
+                }
+                Assert.assertTrue(
+                        msg.toLowerCase().contains("csv") && msg.toLowerCase().contains("empty"),
+                        "Unexpected exception message: " + msg);
+            }
         }
     }
 }

--- a/basicdataset/build.gradle.kts
+++ b/basicdataset/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 dependencies {
     api(project(":api"))
     api(libs.apache.commons.csv)
+    compileOnly("com.github.spotbugs:spotbugs-annotations:4.7.3")
 
     // Add following dependency to your project for COCO dataset
     // runtimeOnly(libs.twelvemonkeys.imageio)

--- a/basicdataset/build.gradle.kts
+++ b/basicdataset/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 dependencies {
     api(project(":api"))
     api(libs.apache.commons.csv)
-    compileOnly("com.github.spotbugs:spotbugs-annotations:4.7.3")
+    compileOnly("com.github.spotbugs:spotbugs-annotations:4.8.3")
 
     // Add following dependency to your project for COCO dataset
     // runtimeOnly(libs.twelvemonkeys.imageio)

--- a/basicdataset/src/main/java/ai/djl/basicdataset/tabular/CsvTranslator.java
+++ b/basicdataset/src/main/java/ai/djl/basicdataset/tabular/CsvTranslator.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.basicdataset.tabular;
+
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDList;
+import ai.djl.translate.TranslateException;
+import ai.djl.translate.Translator;
+import ai.djl.translate.TranslatorContext;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.CSVRecord;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** A {@link Translator} that converts between CSV text and {@link NDList}. */
+public class CsvTranslator implements Translator<String, String> {
+
+    private final CSVFormat csvFormat;
+
+    /**
+     * Constructs a CsvTranslator.
+     *
+     * @param arguments the arguments (unused but required for reflection)
+     */
+    @SuppressWarnings({"PMD.UnusedFormalParameter", "deprecation"})
+    public CsvTranslator(Map<String, ?> arguments) {
+        this.csvFormat = CSVFormat.newFormat(',').withRecordSeparator("\n");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public NDList processInput(TranslatorContext ctx, String csvData) throws TranslateException {
+        try (CSVParser parser = csvFormat.parse(new StringReader(csvData))) {
+            List<float[]> rows = new ArrayList<>();
+            int expectedCols = -1;
+            boolean headerSkipped = false;
+
+            for (CSVRecord record : parser) {
+                if (!headerSkipped && isHeaderRow(record)) {
+                    headerSkipped = true;
+                    continue;
+                }
+
+                if (expectedCols == -1) {
+                    expectedCols = record.size();
+                } else if (record.size() != expectedCols) {
+                    throw new TranslateException(
+                            String.format(
+                                    "Row %d has %d columns, expected %d",
+                                    record.getRecordNumber(), record.size(), expectedCols));
+                }
+
+                float[] row = new float[expectedCols];
+                for (int j = 0; j < expectedCols; j++) {
+                    row[j] = parseFloat(record.get(j), record.getRecordNumber(), j);
+                }
+                rows.add(row);
+            }
+
+            if (rows.isEmpty()) {
+                throw new TranslateException("CSV data is empty");
+            }
+
+            float[][] data = rows.toArray(new float[0][]);
+            return new NDList(ctx.getNDManager().create(data));
+        } catch (IOException e) {
+            throw new TranslateException("Failed to process CSV input", e);
+        }
+    }
+
+    private boolean isHeaderRow(CSVRecord record) {
+        for (String cell : record) {
+            if (isNumeric(cell.trim())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isNumeric(String str) {
+        if (str == null || str.isEmpty()) {
+            return false;
+        }
+        try {
+            Float.parseFloat(str);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    private float parseFloat(String value, long row, int col) throws TranslateException {
+        try {
+            return Float.parseFloat(value.trim());
+        } catch (NumberFormatException e) {
+            throw new TranslateException(
+                    String.format("Non-numeric value '%s' at row %d, column %d", value, row, col),
+                    e);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String processOutput(TranslatorContext ctx, NDList list) throws TranslateException {
+        try (StringWriter writer = new StringWriter();
+                CSVPrinter printer = new CSVPrinter(writer, csvFormat)) {
+
+            for (NDArray array : list) {
+                float[] data =
+                        array.toType(ai.djl.ndarray.types.DataType.FLOAT32, false).toFloatArray();
+                long[] shape = array.getShape().getShape();
+
+                if (shape.length == 1) {
+                    // 1D array → single row
+                    printRow(printer, data, 0, data.length);
+                } else if (shape.length == 2) {
+                    int rows = (int) shape[0];
+                    int cols = (int) shape[1];
+                    for (int i = 0; i < rows; i++) {
+                        printRow(printer, data, i * cols, cols);
+                    }
+                } else {
+                    throw new TranslateException(
+                            "Only 1D or 2D arrays can be converted to CSV, found shape: "
+                                    + array.getShape());
+                }
+            }
+
+            return writer.toString();
+        } catch (IOException e) {
+            throw new TranslateException("Failed to generate CSV output", e);
+        }
+    }
+
+    private void printRow(CSVPrinter printer, float[] data, int offset, int length)
+            throws IOException {
+        for (int i = 0; i < length; i++) {
+            printer.print(data[offset + i]);
+        }
+        printer.println();
+    }
+}


### PR DESCRIPTION
## Description ##

**Prev PR: https://github.com/deepjavalibrary/djl/pull/3793**

**Summary**
Adds CSV translator support to DJL, enabling direct CSV input/output processing for tabular machine learning models

**Changes**
CSV Translator Implementation: Added CsvTranslator class in basicdataset module

NoopServingTranslatorFactory Integration: Used reflection as suggested instead to load CsvTranslator for CSV input/out processing

Input Processing: Implements CSV parsing with automatic header detection, numeric validation, and consistent column count enforcement

Output Processing: Supports both CSV and JSON output formats based on Accept header specification

Build Configuration: Added commons-csv dependency and runtime integration between API and basicdataset modules

**Test Coverage:**

CSV input with JSON output

CSV input with CSV output

Header row detection and skipping

Error handling for malformed data (uneven rows, non-numeric values, empty input)

Edge cases and validation scenarios
