### PR TITLE
Correct topK documentation

### DIFF
--- a/api/src/main/java/ai/djl/modality/cv/MultiBoxDetection.java
+++ b/api/src/main/java/ai/djl/modality/cv/MultiBoxDetection.java
@@ -143,8 +143,8 @@ public class MultiBoxDetection {
         }
 
         /**
-         * Sets the maxmimum number of returned boxes. Defaults
-         * to -1 which implies that there is no limit.
+         * Sets the maxmimum number of returned boxes. Defaults to -1 which implies that there is no
+         * limit.
          *
          * @param nmsTopK the maximum number of boxes that will be returned
          * @return this {@code Builder}


### PR DESCRIPTION
## Description ##

The NMS top K documentation is mixed with the clip documentation. Change the docstring to correctly refer to topK.