### PR TITLE
fix: upgrade jQuery from 2.1.1 to 3.7.1 to address security vulnerabilities

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,7 +247,7 @@
 
     <!--  Scripts-->
     <!-- 生产环境版本，优化了尺寸和速度 -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
     <!-- <script src="website/js/init.js"></script> -->
     <!-- <script src='https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js'></script> -->

--- a/index1.0.html
+++ b/index1.0.html
@@ -241,7 +241,7 @@
 
 
     <!--  Scripts-->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
     <script src="website/js/init.js"></script>
     <script src='https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js'></script>

--- a/website/blog.html
+++ b/website/blog.html
@@ -198,7 +198,7 @@
 </footer>
 
 <!--  Scripts-->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 <script src="js/init.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.min.js"></script>

--- a/website/javadoc.html
+++ b/website/javadoc.html
@@ -126,7 +126,7 @@
 </footer>
 
 <!--  Scripts-->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 <script src="https://djl.ai/website/js/init.js"></script>
 <script src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>


### PR DESCRIPTION
- Updated jQuery version in index.html, index1.0.html, website/blog.html, and website/javadoc.html
- Addresses ACAT findings for Cross-Site Scripting and Prototype Pollution vulnerabilities
- jQuery versions below 3.5.0 are known to have security issues

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
