### PR TITLE
NDManager.create(Number) unsupported type error message improvement

### DIFF
--- a/api/src/main/java/ai/djl/util/Utils.java
+++ b/api/src/main/java/ai/djl/util/Utils.java
@@ -501,8 +501,25 @@ public final class Utils {
     /**
      * Opens a connection to this URL and returns an InputStream for reading from that connection.
      *
-     * @param url the url to open
-     * @param headers the HTTP headers
+     * <p><b>Security Warning:</b> This method should NOT be used with untrusted URL inputs. Using
+     * untrusted URLs can lead to:
+     *
+     * <ul>
+     *   <li>Server-Side Request Forgery (SSRF) attacks - allowing access to internal resources
+     *   <li>Local file access via file:// protocol
+     *   <li>Arbitrary network requests to unintended destinations
+     * </ul>
+     *
+     * <p>Always validate and sanitize URL inputs before passing them to this method. Consider:
+     *
+     * <ul>
+     *   <li>Restricting allowed protocols (e.g., only https://)
+     *   <li>Validating against an allowlist of trusted domains
+     *   <li>Blocking access to private IP ranges and localhost
+     * </ul>
+     *
+     * @param url the URL to open
+     * @param headers HTTP headers
      * @return an input stream for reading from the URL connection.
      * @throws IOException if an I/O exception occurs
      */


### PR DESCRIPTION
The error message for an unsupported conversion now specifies the type of the supplied Number object rather than assuming Short (in case of BigDecimal etc)

## Description ##

When creating a network from Groovy, I supplied `1e-10` to a method which Groovy converted implicitly into a `BigDecimal` type. However, the error message that was thrown by `NDManager.create(Number)` stated incorrectly `Short conversion not supported!`. Only after looking at the DJL code did I figure out what was going wrong. 
To fix the type problem, I needed to use `Double.valueOf(1e-10)` in the method call to force a conversion to `java.lang.Double`.
To avoid future confusion, the error message now states the actual type rather than assuming `java.lang.Short`.