### PR TITLE
Update the Documentation (via DocString) to indicate the risks of using Utils.openUrl() with untrusted inputs

### DIFF
--- a/api/src/main/java/ai/djl/util/Utils.java
+++ b/api/src/main/java/ai/djl/util/Utils.java
@@ -501,8 +501,25 @@ public final class Utils {
     /**
      * Opens a connection to this URL and returns an InputStream for reading from that connection.
      *
-     * @param url the url to open
-     * @param headers the HTTP headers
+     * <p><b>Security Warning:</b> This method should NOT be used with untrusted URL inputs. Using
+     * untrusted URLs can lead to:
+     *
+     * <ul>
+     *   <li>Server-Side Request Forgery (SSRF) attacks - allowing access to internal resources
+     *   <li>Local file access via file:// protocol
+     *   <li>Arbitrary network requests to unintended destinations
+     * </ul>
+     *
+     * <p>Always validate and sanitize URL inputs before passing them to this method. Consider:
+     *
+     * <ul>
+     *   <li>Restricting allowed protocols (e.g., only https://)
+     *   <li>Validating against an allowlist of trusted domains
+     *   <li>Blocking access to private IP ranges and localhost
+     * </ul>
+     *
+     * @param url the URL to open
+     * @param headers HTTP headers
      * @return an input stream for reading from the URL connection.
      * @throws IOException if an I/O exception occurs
      */


### PR DESCRIPTION

## Description ##

Brief description of what this PR is about

- If this change is a backward incompatible change, why must this change be made?
- Interesting edge cases to note here
