### PR TITLE
add minimal permissions for CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql-analysis-java.yml
+++ b/.github/workflows/codeql-analysis-java.yml
@@ -23,6 +23,10 @@ jobs:
     if: github.repository == 'deepjavalibrary/djl'
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      pull-requests: read
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

- Use min. permissions necessary for CodeQL workflow.
