### PR TITLE
Fix the broken first link in the 'Quick start' documentation

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -1,7 +1,7 @@
 # Quick start
 
 Deep Java Library (DJL) is designed to be easy to get started with and simple to use.
-The easiest way to learn DJL is to read the [beginner tutorial](https://docs.djl.ai/master/docs/demos/jupyter/tutorial/README.md) or
+The easiest way to learn DJL is to read the [beginner tutorial](https://docs.djl.ai/master/docs/demos/jupyter/tutorial/index.html) or
 our [examples](../examples/README.md).
 
 You can also view our 1.5 hour long (in 8 x ~10 minute segments) DJL 101 tutorial video series:


### PR DESCRIPTION
## Description ##

Hi - I was just getting started with DJL and working through the documentation.

I noticed that literally the first link users see when visiting the quick start documentation at https://docs.djl.ai/master/docs/quick_start.html  (to the "beginner tutorial" ) currently sends users to a nonexistent page / 404 due to pointing at README.md instead of the generated mkdocs html page.

I have just bumped the link to point to the same location as the other link to the same tutorial on line 23