### PR TITLE
Fix regression in object detection models

### DIFF
--- a/api/src/main/java/ai/djl/modality/cv/translator/SingleShotDetectionTranslator.java
+++ b/api/src/main/java/ai/djl/modality/cv/translator/SingleShotDetectionTranslator.java
@@ -20,6 +20,7 @@ import ai.djl.ndarray.NDList;
 import ai.djl.translate.TranslatorContext;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -60,10 +61,10 @@ public class SingleShotDetectionTranslator extends ObjectDetectionTranslator {
                 String className = classes.get(classId);
                 float[] box = boundingBoxes.get(i).toFloatArray();
                 // rescale box coordinates by width and height
-                double x = width > 0 ? box[0] / width : box[0];
-                double y = height > 0 ? box[1] / height : box[1];
-                double w = width > 0 ? box[2] / width - x : box[2] - x;
-                double h = height > 0 ? box[3] / height - y : box[3] - y;
+                double x = box[0];
+                double y = box[1];
+                double w = box[2] - x;
+                double h = box[3] - y;
                 Rectangle rect = new Rectangle(x, y, w, h);
                 retNames.add(className);
                 retProbs.add(probability);

--- a/api/src/main/java/ai/djl/modality/cv/translator/SingleShotDetectionTranslator.java
+++ b/api/src/main/java/ai/djl/modality/cv/translator/SingleShotDetectionTranslator.java
@@ -64,6 +64,7 @@ public class SingleShotDetectionTranslator extends ObjectDetectionTranslator {
                 double y = box[1];
                 double w = box[2] - x;
                 double h = box[3] - y;
+                Rectangle rect;
                 if (applyRatio) {
                     rect = new Rectangle(x / width, y / height, w / width, h / height);
                 } else {

--- a/api/src/main/java/ai/djl/modality/cv/translator/SingleShotDetectionTranslator.java
+++ b/api/src/main/java/ai/djl/modality/cv/translator/SingleShotDetectionTranslator.java
@@ -64,12 +64,7 @@ public class SingleShotDetectionTranslator extends ObjectDetectionTranslator {
                 double y = height > 0 ? box[1] / height : box[1];
                 double w = width > 0 ? box[2] / width - x : box[2] - x;
                 double h = height > 0 ? box[3] / height - y : box[3] - y;
-                Rectangle rect;
-                if (applyRatio) {
-                    rect = new Rectangle(x / width, y / height, w / width, h / height);
-                } else {
-                    rect = new Rectangle(x, y, w, h);
-                }
+                Rectangle rect = new Rectangle(x, y, w, h);
                 retNames.add(className);
                 retProbs.add(probability);
                 retBB.add(rect);

--- a/api/src/main/java/ai/djl/modality/cv/translator/SingleShotDetectionTranslator.java
+++ b/api/src/main/java/ai/djl/modality/cv/translator/SingleShotDetectionTranslator.java
@@ -20,7 +20,6 @@ import ai.djl.ndarray.NDList;
 import ai.djl.translate.TranslatorContext;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 

--- a/api/src/main/java/ai/djl/modality/cv/translator/SingleShotDetectionTranslator.java
+++ b/api/src/main/java/ai/djl/modality/cv/translator/SingleShotDetectionTranslator.java
@@ -65,7 +65,11 @@ public class SingleShotDetectionTranslator extends ObjectDetectionTranslator {
                 double y = box[1];
                 double w = box[2] - x;
                 double h = box[3] - y;
-                Rectangle rect = new Rectangle(x, y, w, h);
+                if (applyRatio) {
+                    rect = new Rectangle(x / width, y / height, w / width, h / height);
+                } else {
+                    rect = new Rectangle(x, y, w, h);
+                }
                 retNames.add(className);
                 retProbs.add(probability);
                 retBB.add(rect);

--- a/api/src/main/java/ai/djl/modality/cv/translator/SingleShotDetectionTranslator.java
+++ b/api/src/main/java/ai/djl/modality/cv/translator/SingleShotDetectionTranslator.java
@@ -59,7 +59,6 @@ public class SingleShotDetectionTranslator extends ObjectDetectionTranslator {
                 }
                 String className = classes.get(classId);
                 float[] box = boundingBoxes.get(i).toFloatArray();
-                // rescale box coordinates by width and height
                 double x = box[0];
                 double y = box[1];
                 double w = box[2] - x;


### PR DESCRIPTION
## Description ##

Resolve #3840 

Previously imageWidth/height was used from ObjectDetectionTranslator:

https://github.com/deepjavalibrary/djl/blob/3cc328d511bf7e0a480296dc68fc8f03c9593a45/api/src/main/java/ai/djl/modality/cv/translator/SingleShotDetectionTranslator.java#L63-L66

These were usually ignored/set to zero unless the rescaleRatio was set:

https://github.com/deepjavalibrary/djl/blob/3cc328d511bf7e0a480296dc68fc8f03c9593a45/api/src/main/java/ai/djl/modality/cv/translator/ObjectDetectionTranslator.java#L81-L92

now, width/height are used from BaseImageTranslator, and these always default to 224x224: https://github.com/deepjavalibrary/djl/blob/3edd20adb4142e883f79a3fc962a09a9d0d43e73/api/src/main/java/ai/djl/modality/cv/translator/BaseImageTranslator.java#L111-L112

Currently it is possible (and indeed common) to double-normalize the coordinates in this method (if width/height are nonzero and applyRatio is true), and the default is to normalize coordinates even though they are by default normalized in the SSD models anyway; meaning the default was double normalization and triple normalization is possible. This change means that coordinates are only normalized if the applyRatio flag is set, which seems appropriate based on the documentation.