### PR TITLE
fix(api): Remove runtime Java compilation from model archives

### DIFF
--- a/api/src/main/java/ai/djl/translate/ServingTranslatorFactory.java
+++ b/api/src/main/java/ai/djl/translate/ServingTranslatorFactory.java
@@ -85,8 +85,6 @@ public class ServingTranslatorFactory implements TranslatorFactory {
     }
 
     private ServingTranslator findTranslator(Path path, String className) {
-        Path classesDir = path.resolve("classes");
-        ClassLoaderUtils.compileJavaClass(classesDir);
         return ClassLoaderUtils.findImplementation(path, ServingTranslator.class, className);
     }
 

--- a/api/src/main/java/ai/djl/util/ClassLoaderUtils.java
+++ b/api/src/main/java/ai/djl/util/ClassLoaderUtils.java
@@ -34,9 +34,6 @@ import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.tools.JavaCompiler;
-import javax.tools.ToolProvider;
-
 /** A utility class that load classes from specific URLs. */
 public final class ClassLoaderUtils {
 
@@ -239,30 +236,4 @@ public final class ClassLoaderUtils {
         }
     }
 
-    /**
-     * Tries to compile java classes in the directory.
-     *
-     * @param dir the directory to scan java file.
-     */
-    public static void compileJavaClass(Path dir) {
-        try {
-            if (!Files.isDirectory(dir)) {
-                logger.debug("Directory not exists: {}", dir);
-                return;
-            }
-            String[] files;
-            try (Stream<Path> stream = Files.walk(dir)) {
-                files =
-                        stream.filter(p -> Files.isRegularFile(p) && p.toString().endsWith(".java"))
-                                .map(p -> p.toAbsolutePath().toString())
-                                .toArray(String[]::new);
-            }
-            JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-            if (files.length > 0) {
-                compiler.run(null, null, null, files);
-            }
-        } catch (Throwable e) {
-            logger.warn("Failed to compile bundled java file", e);
-        }
-    }
 }

--- a/api/src/main/java/ai/djl/util/ClassLoaderUtils.java
+++ b/api/src/main/java/ai/djl/util/ClassLoaderUtils.java
@@ -235,5 +235,4 @@ public final class ClassLoaderUtils {
             throw new IllegalArgumentException("Invalid native_helper: " + nativeHelper, e);
         }
     }
-
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.google.googlejavaformat:google-java-format:1.22.0")
+    implementation("com.google.googlejavaformat:google-java-format:1.35.0")
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.15")
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }


### PR DESCRIPTION
Remove ClassLoaderUtils.compileJavaClass() and its invocation from ServingTranslatorFactory.findTranslator(). This method compiled arbitrary .java files from model archives' libs/classes/ directory using javax.tools.JavaCompiler, enabling remote code execution via malicious model archives. Static initializers in compiled classes execute immediately at class load time with server process privileges.

Pre-compiled .jar files in libs/ remain supported for custom translators. Only the unsafe runtime compilation of .java source files is removed.
