### PR TITLE
Scope RPC env API keys to known providers

### DIFF
--- a/api/src/main/java/ai/djl/engine/rpc/RpcClient.java
+++ b/api/src/main/java/ai/djl/engine/rpc/RpcClient.java
@@ -99,6 +99,9 @@ public final class RpcClient {
                 if (apiKey == null) {
                     apiKey = Utils.getenv("GOOGLE_API_KEY");
                 }
+                if (apiKey == null) {
+                    apiKey = Utils.getEnvOrSystemProperty("GENAI_API_KEY");
+                }
             }
             if (!url.endsWith("/openai/chat/completions")) {
                 authHeader = "x-goog-api-key";
@@ -106,11 +109,17 @@ public final class RpcClient {
         } else if (url.startsWith("https://api.anthropic.com/")) {
             if (apiKey == null) {
                 apiKey = Utils.getEnvOrSystemProperty("ANTHROPIC_API_KEY");
+                if (apiKey == null) {
+                    apiKey = Utils.getEnvOrSystemProperty("GENAI_API_KEY");
+                }
             }
             authHeader = "x-api-key";
         } else if (url.startsWith("https://api.openai.com/")) {
             if (apiKey == null) {
                 apiKey = Utils.getEnvOrSystemProperty("OPENAI_API_KEY");
+                if (apiKey == null) {
+                    apiKey = Utils.getEnvOrSystemProperty("GENAI_API_KEY");
+                }
             }
             httpHeaders.put(
                     new CaseInsensitiveKey("OpenAI-Organization"), "org-IS5aEokdvmbYXyWeJhhwe5Xn");
@@ -118,9 +127,6 @@ public final class RpcClient {
             if (project != null) {
                 httpHeaders.put(new CaseInsensitiveKey("OpenAI-Project"), project);
             }
-        }
-        if (apiKey == null) {
-            apiKey = Utils.getEnvOrSystemProperty("GENAI_API_KEY");
         }
         if (apiKey != null) {
             if ("Authorization".equals(authHeader)) {

--- a/api/src/test/java/ai/djl/engine/rpc/RpcTranslatorFactoryTest.java
+++ b/api/src/test/java/ai/djl/engine/rpc/RpcTranslatorFactoryTest.java
@@ -27,14 +27,18 @@ import ai.djl.util.Pair;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.sun.net.httpserver.HttpServer;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.reflect.Type;
+import java.net.InetSocketAddress;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class RpcTranslatorFactoryTest {
 
@@ -151,6 +155,43 @@ public class RpcTranslatorFactoryTest {
         }
     }
 
+    @Test
+    public void testGenericRpcUrlDoesNotReceiveProviderEnvKey() throws IOException {
+        String previous = System.getProperty("GENAI_API_KEY");
+        System.setProperty("GENAI_API_KEY", "provider-secret");
+        try (HeaderServer server = new HeaderServer()) {
+            RpcClient client =
+                    RpcClient.getClient(
+                            Map.of(
+                                    "djl_rpc_uri",
+                                    server.getUrl(),
+                                    "method",
+                                    "POST",
+                                    "content-type",
+                                    "text/plain"));
+            client.send(new Input());
+            Assert.assertNull(server.getAuthorization());
+
+            client =
+                    RpcClient.getClient(
+                            Map.of(
+                                    "djl_rpc_uri",
+                                    server.getUrl(),
+                                    "method",
+                                    "POST",
+                                    "api_key",
+                                    "explicit-secret"));
+            client.send(new Input());
+            Assert.assertEquals(server.getAuthorization(), "Bearer explicit-secret");
+        } finally {
+            if (previous == null) {
+                System.clearProperty("GENAI_API_KEY");
+            } else {
+                System.setProperty("GENAI_API_KEY", previous);
+            }
+        }
+    }
+
     private static final class TestData implements JsonSerializable {
 
         private static final long serialVersionUID = 1L;
@@ -181,6 +222,41 @@ public class RpcTranslatorFactoryTest {
         @Override
         public JsonElement serialize() {
             return JsonUtils.GSON.toJsonTree(data);
+        }
+    }
+
+    private static final class HeaderServer implements AutoCloseable {
+
+        private final HttpServer server;
+        private final AtomicReference<String> authorization = new AtomicReference<>();
+
+        HeaderServer() throws IOException {
+            server = HttpServer.create(new InetSocketAddress(0), 0);
+            server.createContext(
+                    "/invocations",
+                    exchange -> {
+                        authorization.set(exchange.getRequestHeaders().getFirst("Authorization"));
+                        byte[] body = "{}".getBytes();
+                        exchange.sendResponseHeaders(200, body.length);
+                        try (OutputStream os = exchange.getResponseBody()) {
+                            os.write(body);
+                        }
+                    });
+            server.start();
+        }
+
+        String getUrl() {
+            return "http://localhost:" + server.getAddress().getPort() + "/invocations";
+        }
+
+        String getAuthorization() {
+            return authorization.get();
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public void close() {
+            server.stop(0);
         }
     }
 }

--- a/api/src/test/java/ai/djl/engine/rpc/RpcTranslatorFactoryTest.java
+++ b/api/src/test/java/ai/djl/engine/rpc/RpcTranslatorFactoryTest.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Type;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -236,7 +237,7 @@ public class RpcTranslatorFactoryTest {
                     "/invocations",
                     exchange -> {
                         authorization.set(exchange.getRequestHeaders().getFirst("Authorization"));
-                        byte[] body = "{}".getBytes();
+                        byte[] body = "{}".getBytes(StandardCharsets.UTF_8);
                         exchange.sendResponseHeaders(200, body.length);
                         try (OutputStream os = exchange.getResponseBody()) {
                             os.write(body);


### PR DESCRIPTION
## Description

This changes RPC credential selection so `GENAI_API_KEY` is only used as a fallback for the built-in Google/Anthropic/OpenAI provider URLs. Generic `djl_rpc_uri` endpoints no longer receive that provider fallback key automatically.

Explicit `api_key`/`API_KEY` arguments are still honored for custom RPC endpoints, preserving the opt-in path for private model servers.

## Why

A model or configuration can select a custom RPC endpoint. With the previous fallback, a process-level provider key could be attached to requests for an unrelated endpoint even when the caller did not explicitly configure that endpoint with a key.

## Tests

- Added `testGenericRpcUrlDoesNotReceiveProviderEnvKey` to cover the generic-endpoint no-header case and the explicit-key case.
- `git diff --check`
- `python C:\Users\Noah\.codex\skills\autoreview\scripts\autoreview --mode local`

I could not run `./gradlew.bat :api:test --tests ai.djl.engine.rpc.RpcTranslatorFactoryTest` locally because this Windows environment has no `JAVA_HOME` and no `java` on `PATH`.