### PR TITLE
fix(audio): use 32768.0f for 16-bit PCM normalization

### DIFF
--- a/api/src/main/java/ai/djl/modality/audio/SampledAudioFactory.java
+++ b/api/src/main/java/ai/djl/modality/audio/SampledAudioFactory.java
@@ -113,7 +113,7 @@ public class SampledAudioFactory extends AudioFactory {
         // Feed in float values between -1.0f and 1.0f.
         float[] floats = new float[shorts.length];
         for (int i = 0; i < shorts.length; i++) {
-            floats[i] = ((float) shorts[i]) / Short.MAX_VALUE;
+            floats[i] = ((float) shorts[i]) / 32768.0f;
         }
         return floats;
     }

--- a/api/src/main/java/ai/djl/modality/audio/SampledAudioFactory.java
+++ b/api/src/main/java/ai/djl/modality/audio/SampledAudioFactory.java
@@ -113,7 +113,7 @@ public class SampledAudioFactory extends AudioFactory {
         // Feed in float values between -1.0f and 1.0f.
         float[] floats = new float[shorts.length];
         for (int i = 0; i < shorts.length; i++) {
-            floats[i] = ((float) shorts[i]) / 32768.0f;
+            floats[i] = shorts[i] / 32768.0f;
         }
         return floats;
     }

--- a/api/src/test/java/ai/djl/modality/audio/AudioFactoryTest.java
+++ b/api/src/test/java/ai/djl/modality/audio/AudioFactoryTest.java
@@ -24,6 +24,7 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -82,8 +83,9 @@ public class AudioFactoryTest {
 
     @Test
     public void testPcm16Normalization() throws IOException {
-        Path path = Paths.get("build/test/pcm16_extremes.wav");
-        Files.createDirectories(path.getParent());
+        Path dir = Paths.get("build/test");
+        Files.createDirectories(dir);
+        Path path = dir.resolve("pcm16_extremes.wav");
         writeMonoPcm16Wav(path, new short[] {Short.MIN_VALUE, Short.MAX_VALUE, 0});
 
         Audio audio = new SampledAudioFactory().fromFile(path);
@@ -97,10 +99,10 @@ public class AudioFactoryTest {
     private static void writeMonoPcm16Wav(Path path, short[] samples) throws IOException {
         int dataSize = samples.length * 2;
         ByteBuffer buf = ByteBuffer.allocate(44 + dataSize).order(ByteOrder.LITTLE_ENDIAN);
-        buf.put("RIFF".getBytes());
+        buf.put("RIFF".getBytes(StandardCharsets.US_ASCII));
         buf.putInt(36 + dataSize);
-        buf.put("WAVE".getBytes());
-        buf.put("fmt ".getBytes());
+        buf.put("WAVE".getBytes(StandardCharsets.US_ASCII));
+        buf.put("fmt ".getBytes(StandardCharsets.US_ASCII));
         buf.putInt(16);
         buf.putShort((short) 1);
         buf.putShort((short) 1);
@@ -108,7 +110,7 @@ public class AudioFactoryTest {
         buf.putInt(32000);
         buf.putShort((short) 2);
         buf.putShort((short) 16);
-        buf.put("data".getBytes());
+        buf.put("data".getBytes(StandardCharsets.US_ASCII));
         buf.putInt(dataSize);
         for (short sample : samples) {
             buf.putShort(sample);

--- a/api/src/test/java/ai/djl/modality/audio/AudioFactoryTest.java
+++ b/api/src/test/java/ai/djl/modality/audio/AudioFactoryTest.java
@@ -22,6 +22,10 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class AudioFactoryTest {
@@ -74,5 +78,41 @@ public class AudioFactoryTest {
             NDArray array = manager.zeros(new Shape(1));
             AudioFactory.newInstance().fromNDArray(array);
         }
+    }
+
+    @Test
+    public void testPcm16Normalization() throws IOException {
+        Path path = Paths.get("build/test/pcm16_extremes.wav");
+        Files.createDirectories(path.getParent());
+        writeMonoPcm16Wav(path, new short[] {Short.MIN_VALUE, Short.MAX_VALUE, 0});
+
+        Audio audio = new SampledAudioFactory().fromFile(path);
+        float[] data = audio.getData();
+        Assert.assertEquals(data.length, 3);
+        Assert.assertEquals(data[0], -1.0f, 0.0f);
+        Assert.assertEquals(data[1], Short.MAX_VALUE / 32768.0f, 0.0f);
+        Assert.assertEquals(data[2], 0.0f, 0.0f);
+    }
+
+    private static void writeMonoPcm16Wav(Path path, short[] samples) throws IOException {
+        int dataSize = samples.length * 2;
+        ByteBuffer buf = ByteBuffer.allocate(44 + dataSize).order(ByteOrder.LITTLE_ENDIAN);
+        buf.put("RIFF".getBytes());
+        buf.putInt(36 + dataSize);
+        buf.put("WAVE".getBytes());
+        buf.put("fmt ".getBytes());
+        buf.putInt(16);
+        buf.putShort((short) 1);
+        buf.putShort((short) 1);
+        buf.putInt(16000);
+        buf.putInt(32000);
+        buf.putShort((short) 2);
+        buf.putShort((short) 16);
+        buf.put("data".getBytes());
+        buf.putInt(dataSize);
+        for (short sample : samples) {
+            buf.putShort(sample);
+        }
+        Files.write(path, buf.array());
     }
 }

--- a/extensions/audio/src/test/java/ai/djl/audio/FFmpegAudioFactoryTest.java
+++ b/extensions/audio/src/test/java/ai/djl/audio/FFmpegAudioFactoryTest.java
@@ -23,6 +23,10 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class FFmpegAudioFactoryTest {
@@ -65,5 +69,46 @@ public class FFmpegAudioFactoryTest {
                             .setSampleFormat(avutil.AV_SAMPLE_FMT_DBL)
                             .fromUrl(url);
                 });
+    }
+
+    @Test
+    public void testPcm16Normalization() throws IOException {
+        Path path = Paths.get("build/test/pcm16_extremes.wav");
+        Files.createDirectories(path.getParent());
+        writeMonoPcm16Wav(path, new short[] {Short.MIN_VALUE, Short.MAX_VALUE, 0});
+
+        Audio audio =
+                AudioFactory.newInstance()
+                        .setChannels(1)
+                        .setSampleRate(16000)
+                        .setSampleFormat(avutil.AV_SAMPLE_FMT_S16)
+                        .fromFile(path);
+        float[] data = audio.getData();
+        Assert.assertEquals(data.length, 3);
+        Assert.assertEquals(data[0], -1.0f, 0.0f);
+        Assert.assertEquals(data[1], Short.MAX_VALUE / 32768.0f, 0.0f);
+        Assert.assertEquals(data[2], 0.0f, 0.0f);
+    }
+
+    private static void writeMonoPcm16Wav(Path path, short[] samples) throws IOException {
+        int dataSize = samples.length * 2;
+        ByteBuffer buf = ByteBuffer.allocate(44 + dataSize).order(ByteOrder.LITTLE_ENDIAN);
+        buf.put("RIFF".getBytes());
+        buf.putInt(36 + dataSize);
+        buf.put("WAVE".getBytes());
+        buf.put("fmt ".getBytes());
+        buf.putInt(16);
+        buf.putShort((short) 1);
+        buf.putShort((short) 1);
+        buf.putInt(16000);
+        buf.putInt(32000);
+        buf.putShort((short) 2);
+        buf.putShort((short) 16);
+        buf.put("data".getBytes());
+        buf.putInt(dataSize);
+        for (short sample : samples) {
+            buf.putShort(sample);
+        }
+        Files.write(path, buf.array());
     }
 }

--- a/extensions/audio/src/test/java/ai/djl/audio/FFmpegAudioFactoryTest.java
+++ b/extensions/audio/src/test/java/ai/djl/audio/FFmpegAudioFactoryTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -73,8 +74,9 @@ public class FFmpegAudioFactoryTest {
 
     @Test
     public void testPcm16Normalization() throws IOException {
-        Path path = Paths.get("build/test/pcm16_extremes.wav");
-        Files.createDirectories(path.getParent());
+        Path dir = Paths.get("build/test");
+        Files.createDirectories(dir);
+        Path path = dir.resolve("pcm16_extremes.wav");
         writeMonoPcm16Wav(path, new short[] {Short.MIN_VALUE, Short.MAX_VALUE, 0});
 
         Audio audio =
@@ -93,10 +95,10 @@ public class FFmpegAudioFactoryTest {
     private static void writeMonoPcm16Wav(Path path, short[] samples) throws IOException {
         int dataSize = samples.length * 2;
         ByteBuffer buf = ByteBuffer.allocate(44 + dataSize).order(ByteOrder.LITTLE_ENDIAN);
-        buf.put("RIFF".getBytes());
+        buf.put("RIFF".getBytes(StandardCharsets.US_ASCII));
         buf.putInt(36 + dataSize);
-        buf.put("WAVE".getBytes());
-        buf.put("fmt ".getBytes());
+        buf.put("WAVE".getBytes(StandardCharsets.US_ASCII));
+        buf.put("fmt ".getBytes(StandardCharsets.US_ASCII));
         buf.putInt(16);
         buf.putShort((short) 1);
         buf.putShort((short) 1);
@@ -104,7 +106,7 @@ public class FFmpegAudioFactoryTest {
         buf.putInt(32000);
         buf.putShort((short) 2);
         buf.putShort((short) 16);
-        buf.put("data".getBytes());
+        buf.put("data".getBytes(StandardCharsets.US_ASCII));
         buf.putInt(dataSize);
         for (short sample : samples) {
             buf.putShort(sample);


### PR DESCRIPTION
## Summary

- Fix `SampledAudioFactory.bytesToFloats()` to divide 16-bit PCM samples by `32768.0f` instead of `Short.MAX_VALUE` (32767), so `-32768` maps to exactly `-1.0f` and all values stay in `[-1, 1]`.
- `FFmpegAudioFactory.grab()` was already corrected in #3646; this completes the same normalization for the Java Sound fallback path.
- Add regression tests in `AudioFactoryTest` and `FFmpegAudioFactoryTest` using a minimal WAV with `Short.MIN_VALUE`, `Short.MAX_VALUE`, and `0`.

Fixes #3643

## Test plan

- [x] `./gradlew :api:test --tests "ai.djl.modality.audio.AudioFactoryTest.testPcm16Normalization"`
- [x] `./gradlew :extensions:audio:test --tests "ai.djl.audio.FFmpegAudioFactoryTest.testPcm16Normalization"`

Both passed locally (JDK 17, macOS arm64).

## Licensing

Apache-2.0 contribution; no separate CLA signature required for this small bugfix per project CONTRIBUTING.md.


Made with [Cursor](https://cursor.com)