### PR TITLE
fix(onnxruntime): allow sub-managers after NDManager.cap()

### DIFF
--- a/engines/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtNDManager.java
+++ b/engines/onnxruntime/onnxruntime-engine/src/main/java/ai/djl/onnxruntime/engine/OrtNDManager.java
@@ -150,7 +150,7 @@ public class OrtNDManager extends BaseNDManager {
     @Override
     public OrtNDManager newSubManager(Device device) {
         OrtNDManager manager = new OrtNDManager(this, device, env);
-        attachInternal(manager.uid, manager);
+        attachUncappedInternal(manager.uid, manager);
         return manager;
     }
 

--- a/engines/onnxruntime/onnxruntime-engine/src/test/java/ai/djl/onnxruntime/engine/OrtTest.java
+++ b/engines/onnxruntime/onnxruntime-engine/src/test/java/ai/djl/onnxruntime/engine/OrtTest.java
@@ -225,6 +225,22 @@ public class OrtTest {
         setAlternativeEngineDisabled(false);
     }
 
+    @Test
+    public void testCappedManagerAllowsSubManagers() {
+        // cap() blocks resource attachment but must still allow sub-managers (#3837)
+        try (NDManager manager = OrtNDManager.getSystemManager().newSubManager()) {
+            manager.cap();
+            Assert.expectThrows(IllegalStateException.class, () -> manager.ones(new Shape(1)));
+            try (NDManager subManager = manager.newSubManager()) {
+                Assert.assertTrue(subManager.isOpen());
+                Assert.assertEquals(subManager.getParentManager(), manager);
+                NDArray array = subManager.ones(new Shape(2));
+                Assert.assertEquals(array.getManager(), subManager);
+                Assert.assertEquals(array.toFloatArray(), new float[] {1f, 1f});
+            }
+        }
+    }
+
     private void setAlternativeEngineDisabled(boolean enable) {
         System.setProperty("ai.djl.onnx.disable_alternative", String.valueOf(enable));
         Engine engine = Engine.getEngine(OrtEngine.ENGINE_NAME);


### PR DESCRIPTION
## Description ##

`NDManager.cap()` is documented to still allow attaching **sub-managers** while blocking ordinary resource attachment (to catch memory leaks early).

Onnx Runtime's `OrtNDManager.newSubManager` incorrectly used `attachInternal`, which throws when the manager is capped. PyTorch, MXNet, and Rust engines already use `attachUncappedInternal` for sub-managers.

This change aligns Onnx Runtime with that contract:

- After `cap()`, creating arrays on the capped manager still fails (`IllegalStateException`)
- After `cap()`, `newSubManager()` succeeds and arrays can be created on the sub-manager

Fixes #3837

### Testing
- `./gradlew :engines:onnxruntime:onnxruntime-engine:test --tests "ai.djl.onnxruntime.engine.OrtTest"` (JDK 21, macOS aarch64) — all tests PASSED, including new `testCappedManagerAllowsSubManagers`