### PR TITLE
Use 64-bit arithmetic for tensor buffer size calculations

### DIFF
--- a/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
@@ -177,7 +177,8 @@ public abstract class BaseNDManager implements NDManager {
     /** {@inheritDoc} */
     @Override
     public NDArray truncatedNormal(float loc, float scale, Shape shape, DataType dataType) {
-        int sampleSize = (int) shape.size();
+        // Fail closed rather than silently truncating an element count beyond int range.
+        int sampleSize = Math.toIntExact(shape.size());
         double[] dist = new double[sampleSize];
 
         for (int i = 0; i < sampleSize; i++) {
@@ -461,7 +462,10 @@ public abstract class BaseNDManager implements NDManager {
         }
 
         int remaining = buffer.remaining();
-        int expectedSize = isByteBuffer ? dataType.getNumOfBytes() * expected : expected;
+        // Compute the expected byte count in 64-bit arithmetic. getNumOfBytes() * expected is
+        // int*int, which overflows for large element counts and wraps to a small or negative
+        // value, causing the check below to compare against the wrong size.
+        long expectedSize = isByteBuffer ? (long) dataType.getNumOfBytes() * expected : expected;
         if (remaining < expectedSize) {
             throw new IllegalArgumentException(
                     "The NDArray size is: " + expected + ", but buffer size is: " + remaining);
@@ -470,7 +474,8 @@ public abstract class BaseNDManager implements NDManager {
             logger.warn(
                     "Input buffer size is greater than the NDArray size, please set limit"
                             + " explicitly.");
-            buffer.limit(expectedSize);
+            // Safe narrowing: in this branch expectedSize < remaining <= Integer.MAX_VALUE.
+            buffer.limit((int) expectedSize);
         }
     }
 

--- a/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/BaseNDManager.java
@@ -462,10 +462,8 @@ public abstract class BaseNDManager implements NDManager {
         }
 
         int remaining = buffer.remaining();
-        // Compute the expected byte count in 64-bit arithmetic. getNumOfBytes() * expected is
-        // int*int, which overflows for large element counts and wraps to a small or negative
-        // value, causing the check below to compare against the wrong size.
-        long expectedSize = isByteBuffer ? (long) dataType.getNumOfBytes() * expected : expected;
+        int expectedSize =
+                isByteBuffer ? Math.multiplyExact(dataType.getNumOfBytes(), expected) : expected;
         if (remaining < expectedSize) {
             throw new IllegalArgumentException(
                     "The NDArray size is: " + expected + ", but buffer size is: " + remaining);
@@ -474,8 +472,7 @@ public abstract class BaseNDManager implements NDManager {
             logger.warn(
                     "Input buffer size is greater than the NDArray size, please set limit"
                             + " explicitly.");
-            // Safe narrowing: in this branch expectedSize < remaining <= Integer.MAX_VALUE.
-            buffer.limit((int) expectedSize);
+            buffer.limit(expectedSize);
         }
     }
 

--- a/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
@@ -169,7 +169,9 @@ public abstract class NDArrayAdapter implements NDArray {
     }
 
     private ByteBuffer toTypeInternal(Number[] numbers, DataType dataType) {
-        int size = dataType.getNumOfBytes() * numbers.length;
+        // 64-bit arithmetic with a fail-closed narrowing: getNumOfBytes() * length can overflow
+        // int for large arrays, silently allocating an undersized direct buffer.
+        int size = Math.toIntExact((long) dataType.getNumOfBytes() * numbers.length);
         ByteBuffer bb = manager.allocateDirect(size);
         for (Number number : numbers) {
             switch (dataType) {

--- a/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
+++ b/api/src/main/java/ai/djl/ndarray/NDArrayAdapter.java
@@ -169,9 +169,7 @@ public abstract class NDArrayAdapter implements NDArray {
     }
 
     private ByteBuffer toTypeInternal(Number[] numbers, DataType dataType) {
-        // 64-bit arithmetic with a fail-closed narrowing: getNumOfBytes() * length can overflow
-        // int for large arrays, silently allocating an undersized direct buffer.
-        int size = Math.toIntExact((long) dataType.getNumOfBytes() * numbers.length);
+        int size = Math.multiplyExact(dataType.getNumOfBytes(), numbers.length);
         ByteBuffer bb = manager.allocateDirect(size);
         for (Number number : numbers) {
             switch (dataType) {

--- a/api/src/main/java/ai/djl/ndarray/NDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/NDManager.java
@@ -788,8 +788,11 @@ public interface NDManager extends AutoCloseable {
      * @see #zeros(Shape, DataType, Device)
      */
     default NDArray zeros(Shape shape, DataType dataType) {
-        int size = (int) shape.size();
-        ByteBuffer bb = allocateDirect(size * dataType.getNumOfBytes());
+        // Both narrowings fail closed: shape.size() is a long and the byte count is computed in
+        // 64-bit, so an element count or buffer size beyond int range throws instead of silently
+        // truncating or wrapping to an undersized allocation.
+        int size = Math.toIntExact(shape.size());
+        ByteBuffer bb = allocateDirect(Math.toIntExact((long) size * dataType.getNumOfBytes()));
         return create(bb, shape, dataType);
     }
 
@@ -817,8 +820,11 @@ public interface NDManager extends AutoCloseable {
      * @return a new instance of {@link NDArray}
      */
     default NDArray ones(Shape shape, DataType dataType) {
-        int size = (int) shape.size();
-        ByteBuffer bb = allocateDirect(size * dataType.getNumOfBytes());
+        // Both narrowings fail closed: shape.size() is a long and the byte count is computed in
+        // 64-bit, so an element count or buffer size beyond int range throws instead of silently
+        // truncating or wrapping to an undersized allocation.
+        int size = Math.toIntExact(shape.size());
+        ByteBuffer bb = allocateDirect(Math.toIntExact((long) size * dataType.getNumOfBytes()));
         for (int i = 0; i < size; ++i) {
             switch (dataType) {
                 case FLOAT16:

--- a/api/src/main/java/ai/djl/ndarray/NDManager.java
+++ b/api/src/main/java/ai/djl/ndarray/NDManager.java
@@ -792,7 +792,7 @@ public interface NDManager extends AutoCloseable {
         // 64-bit, so an element count or buffer size beyond int range throws instead of silently
         // truncating or wrapping to an undersized allocation.
         int size = Math.toIntExact(shape.size());
-        ByteBuffer bb = allocateDirect(Math.toIntExact((long) size * dataType.getNumOfBytes()));
+        ByteBuffer bb = allocateDirect(Math.multiplyExact(size, dataType.getNumOfBytes()));
         return create(bb, shape, dataType);
     }
 
@@ -824,7 +824,7 @@ public interface NDManager extends AutoCloseable {
         // 64-bit, so an element count or buffer size beyond int range throws instead of silently
         // truncating or wrapping to an undersized allocation.
         int size = Math.toIntExact(shape.size());
-        ByteBuffer bb = allocateDirect(Math.toIntExact((long) size * dataType.getNumOfBytes()));
+        ByteBuffer bb = allocateDirect(Math.multiplyExact(size, dataType.getNumOfBytes()));
         for (int i = 0; i < size; ++i) {
             switch (dataType) {
                 case FLOAT16:

--- a/api/src/main/java/ai/djl/ndarray/NDSerializer.java
+++ b/api/src/main/java/ai/djl/ndarray/NDSerializer.java
@@ -51,7 +51,12 @@ final class NDSerializer {
      * @return byte array
      */
     static byte[] encode(NDArray array) {
-        int total = Math.toIntExact(array.size()) * array.getDataType().getNumOfBytes() + 100;
+        // 64-bit arithmetic with a fail-closed narrowing: size() * getNumOfBytes() can overflow
+        // int for large arrays, sizing the output stream too small or negatively.
+        int total =
+                Math.toIntExact(
+                        (long) Math.toIntExact(array.size()) * array.getDataType().getNumOfBytes()
+                                + 100);
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream(total)) {
             encode(array, baos);
             return baos.toByteArray();

--- a/api/src/main/java/ai/djl/ndarray/NDSerializer.java
+++ b/api/src/main/java/ai/djl/ndarray/NDSerializer.java
@@ -52,9 +52,10 @@ final class NDSerializer {
      */
     static byte[] encode(NDArray array) {
         int total =
-                Math.multiplyExact(
-                                Math.toIntExact(array.size()), array.getDataType().getNumOfBytes())
-                        + 100;
+                Math.addExact(
+                        Math.multiplyExact(
+                                Math.toIntExact(array.size()), array.getDataType().getNumOfBytes()),
+                        100);
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream(total)) {
             encode(array, baos);
             return baos.toByteArray();

--- a/api/src/main/java/ai/djl/ndarray/NDSerializer.java
+++ b/api/src/main/java/ai/djl/ndarray/NDSerializer.java
@@ -51,12 +51,10 @@ final class NDSerializer {
      * @return byte array
      */
     static byte[] encode(NDArray array) {
-        // 64-bit arithmetic with a fail-closed narrowing: size() * getNumOfBytes() can overflow
-        // int for large arrays, sizing the output stream too small or negatively.
         int total =
-                Math.toIntExact(
-                        (long) Math.toIntExact(array.size()) * array.getDataType().getNumOfBytes()
-                                + 100);
+                Math.multiplyExact(
+                                Math.toIntExact(array.size()), array.getDataType().getNumOfBytes())
+                        + 100;
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream(total)) {
             encode(array, baos);
             return baos.toByteArray();

--- a/api/src/main/java/ai/djl/util/passthrough/PassthroughNDManager.java
+++ b/api/src/main/java/ai/djl/util/passthrough/PassthroughNDManager.java
@@ -97,7 +97,8 @@ public final class PassthroughNDManager implements NDManager {
         if (data instanceof ByteBuffer) {
             return new PassthroughNDArray(this, data, shape, dataType);
         }
-        ByteBuffer bb = ByteBuffer.allocate(size * dataType.getNumOfBytes());
+        ByteBuffer bb =
+                ByteBuffer.allocate(Math.toIntExact((long) size * dataType.getNumOfBytes()));
         bb.order(ByteOrder.nativeOrder());
         BaseNDManager.copyBuffer(data, bb);
         return new PassthroughNDArray(this, bb, shape, dataType);

--- a/api/src/main/java/ai/djl/util/passthrough/PassthroughNDManager.java
+++ b/api/src/main/java/ai/djl/util/passthrough/PassthroughNDManager.java
@@ -97,8 +97,7 @@ public final class PassthroughNDManager implements NDManager {
         if (data instanceof ByteBuffer) {
             return new PassthroughNDArray(this, data, shape, dataType);
         }
-        ByteBuffer bb =
-                ByteBuffer.allocate(Math.toIntExact((long) size * dataType.getNumOfBytes()));
+        ByteBuffer bb = ByteBuffer.allocate(Math.multiplyExact(size, dataType.getNumOfBytes()));
         bb.order(ByteOrder.nativeOrder());
         BaseNDManager.copyBuffer(data, bb);
         return new PassthroughNDArray(this, bb, shape, dataType);

--- a/api/src/test/java/ai/djl/ndarray/BaseNDManagerTest.java
+++ b/api/src/test/java/ai/djl/ndarray/BaseNDManagerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package ai.djl.ndarray;
+
+import ai.djl.ndarray.types.DataType;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.ByteBuffer;
+
+public class BaseNDManagerTest {
+
+    /**
+     * {@link BaseNDManager#validateBuffer} previously computed the expected byte count as {@code
+     * getNumOfBytes() * expected} in 32-bit {@code int}. For large element counts that product
+     * overflows and wraps to a small value, so the size check compared against the wrong number.
+     * The byte count is now computed in 64-bit, so these element counts are rejected.
+     */
+    @Test
+    public void testValidateBufferIntegerOverflow() {
+        ByteBuffer tiny = ByteBuffer.allocate(16);
+
+        // FLOAT32 (4 bytes) * 2^30 == 2^32, which wraps int32 to exactly 0.
+        assertOverflowRejected(tiny, DataType.FLOAT32, 1 << 30);
+
+        // FLOAT32 (4 bytes) * (2^30 + 4) == 4294967312, which wraps int32 to a small positive value
+        // rather than to zero.
+        assertOverflowRejected(tiny, DataType.FLOAT32, (1 << 30) + 4);
+
+        // FLOAT64 (8 bytes) * 2^29 == 2^32, which wraps int32 to exactly 0.
+        assertOverflowRejected(tiny, DataType.FLOAT64, 1 << 29);
+    }
+
+    /** A genuinely undersized buffer (no overflow) must still be rejected. */
+    @Test
+    public void testValidateBufferRejectsUndersized() {
+        ByteBuffer tiny = ByteBuffer.allocate(16);
+        Assert.assertThrows(
+                IllegalArgumentException.class,
+                () -> BaseNDManager.validateBuffer(tiny.duplicate(), DataType.FLOAT32, 1000));
+    }
+
+    /** A correctly sized buffer must pass validation unchanged. */
+    @Test
+    public void testValidateBufferAcceptsExactSize() {
+        // 4 FLOAT32 elements == 16 bytes.
+        ByteBuffer exact = ByteBuffer.allocate(16);
+        BaseNDManager.validateBuffer(exact, DataType.FLOAT32, 4);
+        Assert.assertEquals(exact.remaining(), 16);
+    }
+
+    private static void assertOverflowRejected(ByteBuffer buffer, DataType dataType, int expected) {
+        Assert.assertThrows(
+                "A "
+                        + buffer.remaining()
+                        + "-byte buffer must not pass validation for "
+                        + expected
+                        + " "
+                        + dataType
+                        + " elements",
+                IllegalArgumentException.class,
+                () -> BaseNDManager.validateBuffer(buffer.duplicate(), dataType, expected));
+    }
+}

--- a/api/src/test/java/ai/djl/ndarray/BaseNDManagerTest.java
+++ b/api/src/test/java/ai/djl/ndarray/BaseNDManagerTest.java
@@ -62,14 +62,7 @@ public class BaseNDManagerTest {
 
     private static void assertOverflowRejected(ByteBuffer buffer, DataType dataType, int expected) {
         Assert.assertThrows(
-                "A "
-                        + buffer.remaining()
-                        + "-byte buffer must not pass validation for "
-                        + expected
-                        + " "
-                        + dataType
-                        + " elements",
-                IllegalArgumentException.class,
+                ArithmeticException.class,
                 () -> BaseNDManager.validateBuffer(buffer.duplicate(), dataType, expected));
     }
 }

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
@@ -313,7 +313,7 @@ public class MxNDArray extends NativeResource<Pointer> implements LazyNDArray {
             return;
         }
 
-        ByteBuffer bb = manager.allocateDirect(size * type.getNumOfBytes());
+        ByteBuffer bb = manager.allocateDirect(Math.toIntExact((long) size * type.getNumOfBytes()));
         BaseNDManager.copyBuffer(buffer, bb);
         JnaUtils.syncCopyFromCPU(getHandle(), bb, size);
     }

--- a/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
+++ b/engines/mxnet/mxnet-engine/src/main/java/ai/djl/mxnet/engine/MxNDArray.java
@@ -313,7 +313,7 @@ public class MxNDArray extends NativeResource<Pointer> implements LazyNDArray {
             return;
         }
 
-        ByteBuffer bb = manager.allocateDirect(Math.toIntExact((long) size * type.getNumOfBytes()));
+        ByteBuffer bb = manager.allocateDirect(Math.multiplyExact(size, type.getNumOfBytes()));
         BaseNDManager.copyBuffer(buffer, bb);
         JnaUtils.syncCopyFromCPU(getHandle(), bb, size);
     }

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -257,7 +257,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
             return;
         }
         // int8, uint8, boolean use ByteBuffer, so need to explicitly input DataType
-        ByteBuffer buf = manager.allocateDirect(size * type.getNumOfBytes());
+        ByteBuffer buf = manager.allocateDirect(Math.toIntExact((long) size * type.getNumOfBytes()));
         BaseNDManager.copyBuffer(buffer, buf);
 
         // If NDArray is on the GPU, it is native code responsibility to control the data life cycle

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDArray.java
@@ -257,7 +257,7 @@ public class PtNDArray extends NativeResource<Long> implements NDArray {
             return;
         }
         // int8, uint8, boolean use ByteBuffer, so need to explicitly input DataType
-        ByteBuffer buf = manager.allocateDirect(Math.toIntExact((long) size * type.getNumOfBytes()));
+        ByteBuffer buf = manager.allocateDirect(Math.multiplyExact(size, type.getNumOfBytes()));
         BaseNDManager.copyBuffer(buffer, buf);
 
         // If NDArray is on the GPU, it is native code responsibility to control the data life cycle

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDManager.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDManager.java
@@ -72,7 +72,7 @@ public class PtNDManager extends BaseNDManager {
             return JniUtils.createNdFromByteBuffer(
                     this, (ByteBuffer) data, shape, dataType, SparseFormat.DENSE, device);
         }
-        ByteBuffer buf = allocateDirect(size * dataType.getNumOfBytes());
+        ByteBuffer buf = allocateDirect(Math.toIntExact((long) size * dataType.getNumOfBytes()));
         copyBuffer(data, buf);
         return JniUtils.createNdFromByteBuffer(
                 this, buf, shape, dataType, SparseFormat.DENSE, device);

--- a/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDManager.java
+++ b/engines/pytorch/pytorch-engine/src/main/java/ai/djl/pytorch/engine/PtNDManager.java
@@ -72,7 +72,7 @@ public class PtNDManager extends BaseNDManager {
             return JniUtils.createNdFromByteBuffer(
                     this, (ByteBuffer) data, shape, dataType, SparseFormat.DENSE, device);
         }
-        ByteBuffer buf = allocateDirect(Math.toIntExact((long) size * dataType.getNumOfBytes()));
+        ByteBuffer buf = allocateDirect(Math.multiplyExact(size, dataType.getNumOfBytes()));
         copyBuffer(data, buf);
         return JniUtils.createNdFromByteBuffer(
                 this, buf, shape, dataType, SparseFormat.DENSE, device);

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDArray.java
@@ -200,7 +200,8 @@ public class TfNDArray extends NativeResource<TFE_TensorHandle> implements NDArr
             JavacppUtils.setByteBuffer(getHandle(), (ByteBuffer) buffer);
             return;
         }
-        ByteBuffer bb = getManager().allocateDirect(size * type.getNumOfBytes());
+        ByteBuffer bb =
+                getManager().allocateDirect(Math.toIntExact((long) size * type.getNumOfBytes()));
         BaseNDManager.copyBuffer(buffer, bb);
         JavacppUtils.setByteBuffer(getHandle(), bb);
     }

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDManager.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDManager.java
@@ -93,7 +93,7 @@ public class TfNDManager extends BaseNDManager {
                             (ByteBuffer) data, shape, dataType, getEagerSession(), device);
             return new TfNDArray(this, handle);
         }
-        ByteBuffer buf = allocateDirect(size * dataType.getNumOfBytes());
+        ByteBuffer buf = allocateDirect(Math.toIntExact((long) size * dataType.getNumOfBytes()));
         copyBuffer(data, buf);
         TFE_TensorHandle handle =
                 JavacppUtils.createTFETensorFromByteBuffer(

--- a/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDManager.java
+++ b/engines/tensorflow/tensorflow-engine/src/main/java/ai/djl/tensorflow/engine/TfNDManager.java
@@ -93,7 +93,7 @@ public class TfNDManager extends BaseNDManager {
                             (ByteBuffer) data, shape, dataType, getEagerSession(), device);
             return new TfNDArray(this, handle);
         }
-        ByteBuffer buf = allocateDirect(Math.toIntExact((long) size * dataType.getNumOfBytes()));
+        ByteBuffer buf = allocateDirect(Math.multiplyExact(size, dataType.getNumOfBytes()));
         copyBuffer(data, buf);
         TFE_TensorHandle handle =
                 JavacppUtils.createTFETensorFromByteBuffer(

--- a/extensions/tokenizers/src/main/java/ai/djl/engine/rust/RsNDArray.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/engine/rust/RsNDArray.java
@@ -239,7 +239,7 @@ public class RsNDArray extends NativeResource<Long> implements NDArray {
             return;
         }
         // int8, uint8, boolean use ByteBuffer, so need to explicitly input DataType
-        ByteBuffer buf = manager.allocateDirect(size * type.getNumOfBytes());
+        ByteBuffer buf = manager.allocateDirect(Math.toIntExact((long) size * type.getNumOfBytes()));
         BaseNDManager.copyBuffer(buffer, buf);
 
         // If NDArray is on the GPU, it is native code responsibility to control the data life cycle

--- a/extensions/tokenizers/src/main/java/ai/djl/engine/rust/RsNDArray.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/engine/rust/RsNDArray.java
@@ -239,7 +239,7 @@ public class RsNDArray extends NativeResource<Long> implements NDArray {
             return;
         }
         // int8, uint8, boolean use ByteBuffer, so need to explicitly input DataType
-        ByteBuffer buf = manager.allocateDirect(Math.toIntExact((long) size * type.getNumOfBytes()));
+        ByteBuffer buf = manager.allocateDirect(Math.multiplyExact(size, type.getNumOfBytes()));
         BaseNDManager.copyBuffer(buffer, buf);
 
         // If NDArray is on the GPU, it is native code responsibility to control the data life cycle

--- a/extensions/tokenizers/src/main/java/ai/djl/engine/rust/RsNDManager.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/engine/rust/RsNDManager.java
@@ -74,7 +74,7 @@ public class RsNDManager extends BaseNDManager {
         if (data.isDirect() && data instanceof ByteBuffer) {
             buf = (ByteBuffer) data;
         } else {
-            buf = allocateDirect(size * dataType.getNumOfBytes());
+            buf = allocateDirect(Math.toIntExact((long) size * dataType.getNumOfBytes()));
             copyBuffer(data, buf);
         }
         String deviceType = device.getDeviceType();

--- a/extensions/tokenizers/src/main/java/ai/djl/engine/rust/RsNDManager.java
+++ b/extensions/tokenizers/src/main/java/ai/djl/engine/rust/RsNDManager.java
@@ -74,7 +74,7 @@ public class RsNDManager extends BaseNDManager {
         if (data.isDirect() && data instanceof ByteBuffer) {
             buf = (ByteBuffer) data;
         } else {
-            buf = allocateDirect(Math.toIntExact((long) size * dataType.getNumOfBytes()));
+            buf = allocateDirect(Math.multiplyExact(size, dataType.getNumOfBytes()));
             copyBuffer(data, buf);
         }
         String deviceType = device.getDeviceType();


### PR DESCRIPTION
Buffer size calculations of the form dataType.getNumOfBytes() * size were performed in 32-bit int. For large element counts these products overflow and wrap to a small or negative value, so BaseNDManager.validateBuffer compared the supplied buffer against the wrong expected size, and the corresponding allocateDirect calls allocated buffers smaller than the shape requires.

Compute these byte counts in 64-bit and narrow with Math.toIntExact so a request that does not fit in an int throws instead of silently wrapping. The same treatment is applied to the sibling allocation paths in the api module and in each engine, and to the (int) shape.size() narrowings in NDManager.zeros/ones and BaseNDManager.truncatedNormal, which could truncate rather than fail.

Behaviour is unchanged for any shape that fits in an int-sized buffer.

Adds regression coverage for the overflowing element counts.
