### PR TITLE
[build] Bump log4j to 2.26.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ sentencepiece = "0.2.0"
 tokenizers = "0.21.0"
 
 slf4j = "2.0.17"
-log4j_slf4j = "2.24.3"
+log4j_slf4j = "2.26.0"
 gson = "2.13.1"
 jna = "5.17.0"
 commonCli = "1.9.0"


### PR DESCRIPTION
## Description ##

Bumps `log4j_slf4j` from `2.24.3` to `2.26.0`.

`log4j-slf4j2-impl` is the only log4j coordinate declared in `gradle/libs.versions.toml`, and at `2.24.3` it resolves `log4j-api` and `log4j-core` to `2.24.3` as well. That is below the fixed version for five advisories that apply to the resolved artifacts:

| Artifact | Advisory | Fixed in |
|---|---|---|
| `log4j-core` | CVE-2025-68161 | 2.25.3 |
| `log4j-core` | CVE-2026-34477 | 2.25.4 |
| `log4j-core` | CVE-2026-34478 | 2.25.4 |
| `log4j-core` | CVE-2026-34480 | 2.25.4 |
| `log4j-api` | CVE-2026-49844 | 2.25.5 |

`2.26.0` is the current release and is above all five.

## Verification ##

Checked against the **resolved runtime classpath**, not just the declaration, since `log4j-api` and `log4j-core` arrive transitively through the slf4j binding:

```
$ ./gradlew :examples:dependencies --configuration runtimeClasspath
# before
log4j-api:2.24.3   log4j-core:2.24.3   log4j-slf4j2-impl:2.24.3
# after
log4j-api:2.26.0   log4j-core:2.26.0   log4j-slf4j2-impl:2.26.0
```

`:api:compileJava`, `:examples:compileJava` and `:api:verifyJava` pass.

## Two related advisories that do not apply ##

Recorded so they are not re-triaged later:

- **`log4j:log4j` 1.x (CVE-2023-26464)** — absent from the runtime classpath of `:api`, `:examples` and `:extensions:hadoop`. `extensions/hadoop/build.gradle.kts` already excludes the reload4j bindings that would pull it in.
- **`log4j-1.2-api` (CVE-2026-34479)** — not resolved on any runtime classpath.

Both are reported against the declared dependency graph rather than a resolved configuration.
