### PR TITLE
Increase DJL version to 0.37.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The following pseudocode demonstrates running training:
 
 ## Release Notes
 
+* [0.37.0](https://github.com/deepjavalibrary/djl/releases/tag/v0.37.0) ([Code](https://github.com/deepjavalibrary/djl/tree/v0.37.0))
 * [0.36.0](https://github.com/deepjavalibrary/djl/releases/tag/v0.36.0) ([Code](https://github.com/deepjavalibrary/djl/tree/v0.36.0))
 * [0.35.1](https://github.com/deepjavalibrary/djl/releases/tag/v0.35.1) ([Code](https://github.com/deepjavalibrary/djl/tree/v0.35.1))
 * [0.33.0](https://github.com/deepjavalibrary/djl/releases/tag/v0.33.0) ([Code](https://github.com/deepjavalibrary/djl/tree/v0.33.0))

--- a/android/README.md
+++ b/android/README.md
@@ -16,7 +16,7 @@ In gradle, you can add the 5 modules in your dependencies:
 
 ```groovy
 dependencies {
-    implementation platform("ai.djl:bom:0.36.0")
+    implementation platform("ai.djl:bom:0.37.0")
 
     implementation "ai.djl:api"
     implementation "ai.djl.android:core"

--- a/android/pytorch-native/README.md
+++ b/android/pytorch-native/README.md
@@ -124,7 +124,7 @@ cd ..
 ./gradlew compileAndroidJNI -Ppt_version=${PYTORCH_VERSION}
 ```
 
-`jnilib/0.36.0/android` folder will be created after build, and shared library will be uploaded to S3 in CI build
+`jnilib/0.37.0/android` folder will be created after build, and shared library will be uploaded to S3 in CI build
 
 ## Build PyTorch android library (.aar) and publish to Sonatype snapshot repo
 
@@ -138,7 +138,7 @@ cd ../../../android
 
 # To avoid download jni from S3, manually copy them
 mkdir -p pytorch-native/jnilib
-cp -r ../engines/pytorch/pytorch-native/jnilib/0.36.0/android/* pytorch-native/jnilib
+cp -r ../engines/pytorch/pytorch-native/jnilib/0.37.0/android/* pytorch-native/jnilib
 
 ./gradlew :pytorch-native:assemble
 # publish to local maven repo (~/.m2 folder)

--- a/api/README.md
+++ b/api/README.md
@@ -35,7 +35,7 @@ You can pull the DJL API from the central Maven repository by including the foll
 <dependency>
     <groupId>ai.djl</groupId>
     <artifactId>api</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
 </dependency>
 ```
 

--- a/basicdataset/README.md
+++ b/basicdataset/README.md
@@ -29,7 +29,7 @@ You can pull the module from the central Maven repository by including the follo
 <dependency>
     <groupId>ai.djl</groupId>
     <artifactId>basicdataset</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
 </dependency>
 ```
 

--- a/bom/README.md
+++ b/bom/README.md
@@ -22,7 +22,7 @@ will need to mention the type as pom and the scope as import) as the following:
         <dependency>
             <groupId>ai.djl</groupId>
             <artifactId>bom</artifactId>
-            <version>0.36.0</version>
+            <version>0.37.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -38,7 +38,7 @@ will need to mention the type as pom and the scope as import) as the following:
         <dependency>
             <groupId>ai.djl</groupId>
             <artifactId>bom</artifactId>
-            <version>0.36.0</version>
+            <version>0.37.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -65,7 +65,7 @@ will need to mention the type as pom and the scope as import) as the following:
 - First you need add BOM into your build.gradle file as the following:
 
 ```
-    implementation platform("ai.djl:bom:0.36.0")
+    implementation platform("ai.djl:bom:0.37.0")
 ```
 
 - Then you import the desired DJL modules into to you pom.xml file (no version is needed):

--- a/djl-zero/README.md
+++ b/djl-zero/README.md
@@ -49,6 +49,6 @@ You can pull the module from the central Maven repository by including the follo
 <dependency>
     <groupId>ai.djl</groupId>
     <artifactId>djl-zero</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
 </dependency>
 ```

--- a/docs/development/example_dataset.md
+++ b/docs/development/example_dataset.md
@@ -24,8 +24,8 @@ api group: 'org.apache.commons', name: 'commons-csv', version: '1.7'
 In order to extend the dataset, the following dependencies are required:
 
 ```
-api "ai.djl:api:0.36.0"
-api "ai.djl:basicdataset:0.36.0"
+api "ai.djl:api:0.37.0"
+api "ai.djl:basicdataset:0.37.0"
 ```
 
 There are four parts we need to implement for CSVDataset.

--- a/docs/hybrid_engine.md
+++ b/docs/hybrid_engine.md
@@ -20,17 +20,17 @@ to run in a hybrid mode:
 To use it along with Apache MXNet for additional API support, add the following two dependencies:
 
 ```
-runtimeOnly "ai.djl.mxnet:mxnet-engine:0.36.0"
+runtimeOnly "ai.djl.mxnet:mxnet-engine:0.37.0"
 ```
 
 You can also use PyTorch or TensorFlow Engine as the supplemental engine by adding their corresponding dependencies.
 
 ```
-runtimeOnly "ai.djl.pytorch:pytorch-engine:0.36.0"
+runtimeOnly "ai.djl.pytorch:pytorch-engine:0.37.0"
 ```
 
 ```
-runtimeOnly "ai.djl.tensorflow:tensorflow-engine:0.36.0"
+runtimeOnly "ai.djl.tensorflow:tensorflow-engine:0.37.0"
 ```
 
 ## How Hybrid works

--- a/docs/load_model.md
+++ b/docs/load_model.md
@@ -185,7 +185,7 @@ Here is a few tips you can use to help you debug model loading issue:
 See [here](development/configure_logging.md#configure-logging-level) for how to enable debug log
 
 #### List models programmatically in your code
-You can use [ModelZoo.listModels()](https://javadoc.io/static/ai.djl/api/0.36.0/ai/djl/repository/zoo/ModelZoo.html#listModels--) API to query available models.
+You can use [ModelZoo.listModels()](https://javadoc.io/static/ai.djl/api/0.37.0/ai/djl/repository/zoo/ModelZoo.html#listModels--) API to query available models.
 
 #### List available models using DJL command line
 

--- a/engines/ml/lightgbm/README.md
+++ b/engines/ml/lightgbm/README.md
@@ -36,13 +36,13 @@ LightGBM can only run on top of the Linux/Mac/Windows machine using x86_64.
 ## Installation
 You can pull the LightGBM engine from the central Maven repository by including the following dependency:
 
-- ai.djl.ml.lightgbm:lightgbm:0.36.0
+- ai.djl.ml.lightgbm:lightgbm:0.37.0
 
 ```xml
 <dependency>
     <groupId>ai.djl.ml.lightgbm</groupId>
     <artifactId>lightgbm</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
     <scope>runtime</scope>
 </dependency>
 ```

--- a/engines/ml/xgboost/README.md
+++ b/engines/ml/xgboost/README.md
@@ -37,13 +37,13 @@ XGBoost can only run on top of the Linux/Mac machine. User can build from source
 ## Installation
 You can pull the XGBoost engine from the central Maven repository by including the following dependency:
 
-- ai.djl.ml.xgboost:xgboost:0.36.0
+- ai.djl.ml.xgboost:xgboost:0.37.0
 
 ```xml
 <dependency>
     <groupId>ai.djl.ml.xgboost</groupId>
     <artifactId>xgboost</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
     <scope>runtime</scope>
 </dependency>
 ```

--- a/engines/mxnet/mxnet-engine/README.md
+++ b/engines/mxnet/mxnet-engine/README.md
@@ -7,7 +7,7 @@ This module contains the Deep Java Library (DJL) EngineProvider for Apache MXNet
 We don't recommend that developers use classes in this module directly. Use of these classes
 will couple your code with Apache MXNet and make switching between engines difficult. Even so,
 developers are not restricted from using engine-specific features. For more information,
-see [NDManager#invoke()](https://javadoc.io/static/ai.djl/api/0.36.0/ai/djl/ndarray/NDManager.html#invoke-java.lang.String-ai.djl.ndarray.NDArray:A-ai.djl.ndarray.NDArray:A-ai.djl.util.PairList-).
+see [NDManager#invoke()](https://javadoc.io/static/ai.djl/api/0.37.0/ai/djl/ndarray/NDManager.html#invoke-java.lang.String-ai.djl.ndarray.NDArray:A-ai.djl.ndarray.NDArray:A-ai.djl.util.PairList-).
 
 ## Documentation
 
@@ -33,7 +33,7 @@ You can pull the MXNet engine from the central Maven repository by including the
 <dependency>
     <groupId>ai.djl.mxnet</groupId>
     <artifactId>mxnet-engine</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
     <scope>runtime</scope>
 </dependency>
 ```

--- a/engines/mxnet/mxnet-model-zoo/README.md
+++ b/engines/mxnet/mxnet-model-zoo/README.md
@@ -27,7 +27,7 @@ You can pull the MXNet engine from the central Maven repository by including the
 <dependency>
     <groupId>ai.djl.mxnet</groupId>
     <artifactId>mxnet-model-zoo</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
 </dependency>
 ```
 

--- a/engines/onnxruntime/onnxruntime-android/README.md
+++ b/engines/onnxruntime/onnxruntime-android/README.md
@@ -6,13 +6,13 @@ This module contains the DJL ONNX Runtime engine for Android.
 ## Installation
 You can pull the ONNX Runtime for Android from the central Maven repository by including the following dependency:
 
-- ai.djl.android:onnxruntime:0.36.0
+- ai.djl.android:onnxruntime:0.37.0
 
 ```xml
 <dependency>
     <groupId>ai.djl.android</groupId>
     <artifactId>onnxruntime</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
     <scope>runtime</scope>
 </dependency>
 ```

--- a/engines/onnxruntime/onnxruntime-engine/README.md
+++ b/engines/onnxruntime/onnxruntime-engine/README.md
@@ -47,13 +47,13 @@ for the official ONNX Runtime project.
 
 You can pull the ONNX Runtime engine from the central Maven repository by including the following dependency:
 
-- ai.djl.onnxruntime:onnxruntime-engine:0.36.0
+- ai.djl.onnxruntime:onnxruntime-engine:0.37.0
 
 ```xml
 <dependency>
     <groupId>ai.djl.onnxruntime</groupId>
     <artifactId>onnxruntime-engine</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
     <scope>runtime</scope>
 </dependency>
 ```
@@ -71,7 +71,7 @@ Maven:
 <dependency>
     <groupId>ai.djl.onnxruntime</groupId>
     <artifactId>onnxruntime-engine</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
     <scope>runtime</scope>
     <exclusions>
         <exclusion>
@@ -91,7 +91,7 @@ Maven:
 Gradle:
 
 ```groovy
-implementation("ai.djl.onnxruntime:onnxruntime-engine:0.36.0") {
+implementation("ai.djl.onnxruntime:onnxruntime-engine:0.37.0") {
     exclude group: "com.microsoft.onnxruntime", module: "onnxruntime"
 }
 implementation "com.microsoft.onnxruntime:onnxruntime_gpu:1.21.1"

--- a/engines/pytorch/pytorch-engine/README.md
+++ b/engines/pytorch/pytorch-engine/README.md
@@ -27,14 +27,14 @@ The javadocs output is built in the `build/doc/javadoc` folder.
 
 You can pull the PyTorch engine from the central Maven repository by including the following dependency:
 
-- ai.djl.pytorch:pytorch-engine:0.36.0
+- ai.djl.pytorch:pytorch-engine:0.37.0
 
 ```xml
 
 <dependency>
     <groupId>ai.djl.pytorch</groupId>
     <artifactId>pytorch-engine</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
     <scope>runtime</scope>
 </dependency>
 ```

--- a/engines/pytorch/pytorch-model-zoo/README.md
+++ b/engines/pytorch/pytorch-model-zoo/README.md
@@ -25,7 +25,7 @@ You can pull the PyTorch engine from the central Maven repository by including t
 <dependency>
     <groupId>ai.djl.pytorch</groupId>
     <artifactId>pytorch-model-zoo</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
 </dependency>
 ```
 

--- a/engines/tensorflow/tensorflow-api/README.md
+++ b/engines/tensorflow/tensorflow-api/README.md
@@ -16,6 +16,6 @@ You can pull the TensorFlow core java API from the central Maven repository by i
 <dependency>
     <groupId>ai.djl.tensorflow</groupId>
     <artifactId>tensorflow-api</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
 </dependency>
 ```

--- a/engines/tensorflow/tensorflow-engine/README.md
+++ b/engines/tensorflow/tensorflow-engine/README.md
@@ -28,13 +28,13 @@ The javadocs output is built in the `build/doc/javadoc` folder.
 
 You can pull the TensorFlow engine from the central Maven repository by including the following dependency:
 
-- ai.djl.tensorflow:tensorflow-engine:0.36.0
+- ai.djl.tensorflow:tensorflow-engine:0.37.0
 
 ```xml
 <dependency>
     <groupId>ai.djl.tensorflow</groupId>
     <artifactId>tensorflow-engine</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
     <scope>runtime</scope>
 </dependency>
 ```

--- a/engines/tensorflow/tensorflow-model-zoo/README.md
+++ b/engines/tensorflow/tensorflow-model-zoo/README.md
@@ -26,7 +26,7 @@ from the central Maven repository by including the following dependency:
 <dependency>
     <groupId>ai.djl.tensorflow</groupId>
     <artifactId>tensorflow-model-zoo</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
 </dependency>
 ```
 

--- a/extensions/audio/README.md
+++ b/extensions/audio/README.md
@@ -23,6 +23,6 @@ You can pull the module from the central Maven repository by including the follo
 <dependency>
     <groupId>ai.djl.audio</groupId>
     <artifactId>audio</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
 </dependency>
 ```

--- a/extensions/aws-ai/README.md
+++ b/extensions/aws-ai/README.md
@@ -58,6 +58,6 @@ You can pull the module from the central Maven repository by including the follo
 <dependency>
     <groupId>ai.djl.aws</groupId>
     <artifactId>aws-ai</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
 </dependency>
 ```

--- a/extensions/fasttext/README.md
+++ b/extensions/fasttext/README.md
@@ -34,7 +34,7 @@ You can pull the fastText engine from the central Maven repository by including 
 <dependency>
     <groupId>ai.djl.fasttext</groupId>
     <artifactId>fasttext-engine</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
 </dependency>
 ```
 

--- a/extensions/hadoop/README.md
+++ b/extensions/hadoop/README.md
@@ -52,6 +52,6 @@ You can pull the module from the central Maven repository by including the follo
 <dependency>
     <groupId>ai.djl.hadoop</groupId>
     <artifactId>hadoop</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
 </dependency>
 ```

--- a/extensions/opencv/README.md
+++ b/extensions/opencv/README.md
@@ -23,6 +23,6 @@ You can pull the module from the central Maven repository by including the follo
 <dependency>
     <groupId>ai.djl.opencv</groupId>
     <artifactId>opencv</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
 </dependency>
 ```

--- a/extensions/sentencepiece/README.md
+++ b/extensions/sentencepiece/README.md
@@ -23,6 +23,6 @@ You can pull the module from the central Maven repository by including the follo
 <dependency>
     <groupId>ai.djl.sentencepiece</groupId>
     <artifactId>sentencepiece</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
 </dependency>
 ```

--- a/extensions/spark/README.md
+++ b/extensions/spark/README.md
@@ -34,7 +34,7 @@ You can pull the module from the central Maven repository by including the follo
 <dependency>
     <groupId>ai.djl.spark</groupId>
     <artifactId>spark_2.12</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
 </dependency>
 ```
 

--- a/extensions/tablesaw/README.md
+++ b/extensions/tablesaw/README.md
@@ -25,6 +25,6 @@ You can pull the module from the central Maven repository by including the follo
 <dependency>
     <groupId>ai.djl.tablesaw</groupId>
     <artifactId>tablesaw</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
 </dependency>
 ```

--- a/extensions/timeseries/README.md
+++ b/extensions/timeseries/README.md
@@ -245,6 +245,6 @@ You can pull the module from the central Maven repository by including the follo
 <dependency>
     <groupId>ai.djl.timeseries</groupId>
     <artifactId>timeseries</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
 </dependency>
 ```

--- a/extensions/timeseries/docs/forecast_with_M5_data.md
+++ b/extensions/timeseries/docs/forecast_with_M5_data.md
@@ -56,7 +56,7 @@ repositories {
 }
 dependencies {
   implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.17.1"
-  implementation platform("ai.djl:bom:0.36.0")
+  implementation platform("ai.djl:bom:0.37.0")
   implementation "ai.djl:api"
   implementation "ai.djl.timeseries"
   runtimeOnly "ai.djl.mxnet:mxnet-engine"

--- a/extensions/tokenizers/README.md
+++ b/extensions/tokenizers/README.md
@@ -25,7 +25,7 @@ You can pull the module from the central Maven repository by including the follo
 <dependency>
     <groupId>ai.djl.huggingface</groupId>
     <artifactId>tokenizers</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
 </dependency>
 ```
 

--- a/model-zoo/README.md
+++ b/model-zoo/README.md
@@ -33,7 +33,7 @@ You can pull the model zoo from the central Maven repository by including the fo
 <dependency>
     <groupId>ai.djl</groupId>
     <artifactId>model-zoo</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Description ##

MCM preflight step for the 0.37.0 release (TM-50587): point documents, READMEs and examples at the version being released.

Generated with `./gradlew -PpreviousVersion=0.36.0 iFV`, plus the `0.37.0` entry added to the README Release Notes section.

32 files, `0.36.0` -> `0.37.0` in dependency snippets, BOM coordinates, Maven `<version>` blocks and the android `jnilib` paths.

## Note on CI ##

The notebooks/docs job is expected to fail on this PR: it resolves `ai.djl:*:0.37.0`, which is not on Maven Central yet. Per the release runbook this PR is raised now, re-run once the artifacts are published to Sonatype, and merged after the release completes.
