### PR TITLE
fix(spark): remove undefined `model_url` reference that makes TextGenerator unusable

### DIFF
--- a/extensions/spark/setup/djl_spark/task/text/text_generator.py
+++ b/extensions/spark/setup/djl_spark/task/text/text_generator.py
@@ -41,7 +41,6 @@ class TextGenerator:
         """
         self.input_col = input_col
         self.output_col = output_col
-        self.model_url = model_url
         self.hf_model_id = hf_model_id
         self.engine = engine
         self.batch_size = batch_size


### PR DESCRIPTION
## Problem

`djl_spark.task.text.text_generator.TextGenerator.__init__` assigns an undefined name:

https://github.com/deepjavalibrary/djl/blob/master/extensions/spark/setup/djl_spark/task/text/text_generator.py#L42-L47

```python
    def __init__(self,
                 input_col: str,
                 output_col: str,
                 hf_model_id: Optional[str] = None,
                 engine: Optional[str] = "PyTorch",
                 batch_size: Optional[str] = 100):
        ...
        self.input_col = input_col
        self.output_col = output_col
        self.model_url = model_url      # <-- `model_url` is not a parameter
        self.hf_model_id = hf_model_id
```

`model_url` is neither a parameter of `__init__`, nor a module-level global, nor an
attribute — so **every** instantiation of `TextGenerator` raises `NameError`, making the
class completely unusable. `pyflakes` flags it as `undefined name 'model_url'`.

## Why removing the line is the right fix

`TextGenerator` is a copy of `Text2TextGenerator`. Diffing the two files shows the stray
assignment is the only structural difference:

```diff
--- text2text_generator.py
+++ text_generator.py
-class Text2TextGenerator:
+class TextGenerator:
         self.input_col = input_col
         self.output_col = output_col
+        self.model_url = model_url
         self.hf_model_id = hf_model_id
```

The `model_url` attribute is a leftover from the tasks that genuinely take one
(`TextClassifier`, `TextEmbedder`, `QuestionAnswerer`, `ImageClassifier`, …). Those all
follow the same shape — `model_url: str` parameter, `:param model_url:` docstring entry,
and a `.setModelUrl(self.model_url)` call in the body. `TextGenerator` has none of those:
it is a `transformers.pipeline`-based task keyed on `hf_model_id`, and `self.model_url`
is never read anywhere. `Text2TextGenerator`, `TextDecoder` and `TextEncoder` — the other
`hf_model_id`-based tasks — don't mention `model_url` at all.

So the assignment is dead as well as broken, and removing it restores parity with the
sibling classes.

## Reproduction

```python
from djl_spark.task.text.text_generator import TextGenerator

TextGenerator(input_col="text", output_col="out", hf_model_id="gpt2")
```

Before:

```
NameError: name 'model_url' is not defined
```

After:

```
{'input_col': 'text', 'output_col': 'out', 'hf_model_id': 'gpt2',
 'engine': 'PyTorch', 'batch_size': 100}
```

which matches what the unmodified `Text2TextGenerator` produces for the same arguments.

(Verified by extracting the real `__init__` from this file with `ast` and executing it,
so the check doesn't require a Spark/transformers runtime.)

## Change

One line removed; no behaviour change for any working code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
