### PR TITLE
fix(basicdataset): undefined `makedirs` breaks extract_imagenet.py --with-rec

### DIFF
--- a/basicdataset/src/main/resources/imagenet/extract_imagenet.py
+++ b/basicdataset/src/main/resources/imagenet/extract_imagenet.py
@@ -139,7 +139,7 @@ def check_file(filename, checksum, sha1):
 
 def build_rec_process(img_dir, train=False, num_thread=1):
     rec_dir = os.path.abspath(os.path.join(img_dir, '../rec'))
-    makedirs(rec_dir)
+    os.makedirs(rec_dir, exist_ok=True)
     prefix = 'train' if train else 'val'
     print('Building ImageRecord file for ' + prefix + ' ...')
     to_path = rec_dir


### PR DESCRIPTION
## Problem

`basicdataset/src/main/resources/imagenet/extract_imagenet.py` calls an undefined
`makedirs`:

https://github.com/deepjavalibrary/djl/blob/master/basicdataset/src/main/resources/imagenet/extract_imagenet.py#L140-L142

```python
def build_rec_process(img_dir, train=False, num_thread=1):
    rec_dir = os.path.abspath(os.path.join(img_dir, '../rec'))
    makedirs(rec_dir)        # <-- bare `makedirs`, never imported or defined
```

The script imports `os` and every other directory-creating call in the file is qualified
(`os.makedirs` at lines 50, 185, 210, 224, 246) — line 142 is the only bare one. It is a
leftover from the GluonCV script this was adapted from, which imported
`gluoncv.utils.makedirs`.

`pyflakes` confirms it is the only undefined name in the file:

```
extract_imagenet.py:142:5: undefined name 'makedirs'
```

## Impact

`build_rec_process` is on the `--with-rec` path, reached from both `extract_train` and
`extract_val`:

```python
    if with_rec:
        build_rec_process(target_dir, True, num_thread)   # extract_train
    ...
    if with_rec:
        build_rec_process(target_dir, False, num_thread)  # extract_val
```

So `python extract_imagenet.py --download-dir ... --with-rec` aborts with
`NameError: name 'makedirs' is not defined` right after the (very long) train tarball
extraction finishes.

## Why `exist_ok=True`

The `rec` directory is created up-front by `main()`:

```python
    build_rec = args.with_rec
    if build_rec:
        os.makedirs(os.path.join(target_dir, 'rec'))
```

and `build_rec_process` resolves `rec_dir` to that same path
(`os.path.abspath(os.path.join(img_dir, '../rec'))`, with `img_dir` being
`<target>/train` or `<target>/val`). It is then called twice for it. A plain
`os.makedirs(rec_dir)` would therefore raise `FileExistsError` on the very first call, so
the original `gluoncv.utils.makedirs` semantics — create-if-missing — have to be
preserved. `os.makedirs(rec_dir, exist_ok=True)` is the stdlib equivalent.

## Change

One line:

```diff
-    makedirs(rec_dir)
+    os.makedirs(rec_dir, exist_ok=True)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
