### PR TITLE
[pytorch] Link XNNPACK microkernels for Android JNI

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -17,6 +17,6 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
-djl_version=0.38.0
+djl_version=0.39.0
 pytorch_version=2.7.1
 tokenizers_version=0.21.0

--- a/engines/pytorch/pytorch-native/CMakeLists.txt
+++ b/engines/pytorch/pytorch-native/CMakeLists.txt
@@ -93,7 +93,7 @@ else()
             PROPERTY IMPORTED_LOCATION
             ${CMAKE_CURRENT_SOURCE_DIR}/libtorch_android/${ANDROID_ABI}/lib/${name}.a)
     endfunction(import_static_lib)
-    list(APPEND LIBS libtorch libtorch_cpu libc10 libnnpack libXNNPACK libpytorch_qnnpack libpthreadpool libeigen_blas libcpuinfo libclog libVulkanWrapper)
+    list(APPEND LIBS libtorch libtorch_cpu libc10 libnnpack libXNNPACK libmicrokernels-prod libpytorch_qnnpack libpthreadpool libeigen_blas libcpuinfo libclog libVulkanWrapper)
     foreach(lib IN LISTS LIBS)
         import_static_lib(${lib})
     endforeach()
@@ -105,15 +105,18 @@ else()
         libtorch
         libtorch_cpu
         -Wl,--no-whole-archive
+        -Wl,--start-group
         libc10
         libnnpack
         libXNNPACK
+        libmicrokernels-prod
         libpytorch_qnnpack
         libpthreadpool
         libeigen_blas
         libcpuinfo
         libclog
         libVulkanWrapper
+        -Wl,--end-group
         ${log-lib}
     )
 endif()


### PR DESCRIPTION
## Description ##

Brief description of what this PR is about

PyTorch 2.7.1 splits XNNPACK microkernels into a separate static library (libmicrokernels-prod.a). Linking libXNNPACK.a alone left the xnn_*_ukernel__* symbols undefined, failing the arm64-v8a/x86/x86_64 Android JNI link. Link libmicrokernels-prod and wrap the static archives in a link group so cross-references resolve.